### PR TITLE
Actually fix bug causing ClientModInitializer/DedicatedServerModInitializers being loaded when they should not be

### DIFF
--- a/src/main/java/net/fabricmc/loader/language/JavaLanguageAdapter.java
+++ b/src/main/java/net/fabricmc/loader/language/JavaLanguageAdapter.java
@@ -28,16 +28,16 @@ import java.lang.reflect.InvocationTargetException;
 
 public class JavaLanguageAdapter implements LanguageAdapter {
 	private static boolean canApplyInterface(String itfString) throws IOException {
-		String className = itfString.replace('.', '/') + ".class";
+		String className = itfString + ".class";
 
 		// TODO: Be a bit more involved
 		switch (itfString) {
-			case "net.fabricmc.api.ClientModInitializer":
+			case "net/fabricmc/api/ClientModInitializer":
 				if (FabricLoader.INSTANCE.getEnvironmentHandler().getEnvironmentType() == EnvType.SERVER) {
 					return false;
 				}
 				break;
-			case "net.fabricmc.api.DedicatedServerModInitializer":
+			case "net/fabricmc/api/DedicatedServerModInitializer":
 				if (FabricLoader.INSTANCE.getEnvironmentHandler().getEnvironmentType() == EnvType.CLIENT) {
 					return false;
 				}


### PR DESCRIPTION
I assumed canApplyInterface is called with `.` as a separator because of the replacement, but it actually does not.

This actually resolves the issue.