### PR TITLE
Improve crash logs so it reports the mod name + jar name that failed …

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -454,8 +454,12 @@ public class FabricLoader implements Loader {
 
 	private void initializeMods() {
 		for (ModContainer mod : mods) {
-			for (String in : mod.getInfo().getInitializers()) {
-				instanceStorage.instantiate(in, mod.getAdapter());
+			try {
+				for (String in : mod.getInfo().getInitializers()) {
+					instanceStorage.instantiate(in, mod.getAdapter());
+				}
+			} catch (Exception e){
+				throw new RuntimeException(String.format("Failed to load mod %s (%s)", mod.getInfo().getName(), mod.getOriginFile().getName()), e);
 			}
 		}
 	}


### PR DESCRIPTION
…to load.

There may be a better way to do this?