### PR TITLE
Cleanup branding implementation

### DIFF
--- a/src/main/java/net/fabricmc/loader/mixin/client/MixinClientBrandRetriever.java
+++ b/src/main/java/net/fabricmc/loader/mixin/client/MixinClientBrandRetriever.java
@@ -27,6 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinClientBrandRetriever {
 	@Inject(at = @At("RETURN"), method = "getClientModName", cancellable = true)
 	private static void getClientModName(final CallbackInfoReturnable<String> cir) {
-		cir.setReturnValue(FabricBranding.apply(cir.getReturnValue()));
+		cir.setReturnValue(FabricBranding.apply(cir.getReturnValue(), ClientBrandRetriever.class));
 	}
 }

--- a/src/main/java/net/fabricmc/loader/mixin/client/MixinClientBrandRetriever.java
+++ b/src/main/java/net/fabricmc/loader/mixin/client/MixinClientBrandRetriever.java
@@ -16,7 +16,7 @@
 
 package net.fabricmc.loader.mixin.client;
 
-import net.fabricmc.loader.util.BrandingUtil;
+import net.fabricmc.loader.util.FabricBranding;
 import net.minecraft.client.ClientBrandRetriever;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,6 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinClientBrandRetriever {
 	@Inject(at = @At("RETURN"), method = "getClientModName", cancellable = true)
 	private static void getClientModName(final CallbackInfoReturnable<String> cir) {
-		cir.setReturnValue(BrandingUtil.brand(cir.getReturnValue()));
+		cir.setReturnValue(FabricBranding.apply(cir.getReturnValue()));
 	}
 }

--- a/src/main/java/net/fabricmc/loader/mixin/client/MixinClientBrandRetriever.java
+++ b/src/main/java/net/fabricmc/loader/mixin/client/MixinClientBrandRetriever.java
@@ -27,6 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinClientBrandRetriever {
 	@Inject(at = @At("RETURN"), method = "getClientModName", cancellable = true)
 	private static void getClientModName(final CallbackInfoReturnable<String> cir) {
-		BrandingUtil.brand(cir);
+		cir.setReturnValue(BrandingUtil.brand(cir.getReturnValue()));
 	}
 }

--- a/src/main/java/net/fabricmc/loader/mixin/common/server/MixinMinecraftServerBrand.java
+++ b/src/main/java/net/fabricmc/loader/mixin/common/server/MixinMinecraftServerBrand.java
@@ -16,7 +16,7 @@
 
 package net.fabricmc.loader.mixin.common.server;
 
-import net.fabricmc.loader.util.BrandingUtil;
+import net.fabricmc.loader.util.FabricBranding;
 import net.minecraft.server.MinecraftServer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,6 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinMinecraftServerBrand {
 	@Inject(at = @At("RETURN"), method = "getServerModName", cancellable = true)
 	private void getServerModName(final CallbackInfoReturnable<String> cir) {
-		cir.setReturnValue(BrandingUtil.brand(cir.getReturnValue()));
+		cir.setReturnValue(FabricBranding.apply(cir.getReturnValue()));
 	}
 }

--- a/src/main/java/net/fabricmc/loader/mixin/common/server/MixinMinecraftServerBrand.java
+++ b/src/main/java/net/fabricmc/loader/mixin/common/server/MixinMinecraftServerBrand.java
@@ -27,6 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinMinecraftServerBrand {
 	@Inject(at = @At("RETURN"), method = "getServerModName", cancellable = true)
 	private void getServerModName(final CallbackInfoReturnable<String> cir) {
-		cir.setReturnValue(FabricBranding.apply(cir.getReturnValue()));
+		cir.setReturnValue(FabricBranding.apply(cir.getReturnValue(), this));
 	}
 }

--- a/src/main/java/net/fabricmc/loader/mixin/common/server/MixinMinecraftServerBrand.java
+++ b/src/main/java/net/fabricmc/loader/mixin/common/server/MixinMinecraftServerBrand.java
@@ -27,6 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinMinecraftServerBrand {
 	@Inject(at = @At("RETURN"), method = "getServerModName", cancellable = true)
 	private void getServerModName(final CallbackInfoReturnable<String> cir) {
-		BrandingUtil.brand(cir);
+		cir.setReturnValue(BrandingUtil.brand(cir.getReturnValue()));
 	}
 }

--- a/src/main/java/net/fabricmc/loader/util/BrandingUtil.java
+++ b/src/main/java/net/fabricmc/loader/util/BrandingUtil.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.loader.util;
 
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 public final class BrandingUtil {
 	public static final String FABRIC = "fabric";
 	public static final String VANILLA = "vanilla";
@@ -25,11 +23,11 @@ public final class BrandingUtil {
 	private BrandingUtil() {
 	}
 
-	public static void brand(final CallbackInfoReturnable<String> cir) {
-		if (cir.getReturnValue().equals(VANILLA)) {
-			cir.setReturnValue(FABRIC);
+	public static String brand(final String branding) {
+		if (branding.equals(VANILLA)) {
+			return FABRIC;
 		} else {
-			cir.setReturnValue(cir.getReturnValue() + "," + FABRIC);
+			return branding + "," + FABRIC;
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loader/util/FabricBranding.java
+++ b/src/main/java/net/fabricmc/loader/util/FabricBranding.java
@@ -16,18 +16,24 @@
 
 package net.fabricmc.loader.util;
 
+import com.google.common.base.Strings;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public final class FabricBranding {
 	public static final String FABRIC = "fabric";
 	public static final String VANILLA = "vanilla";
+	
+	private static final Logger LOGGER = LogManager.getLogger("FabricBranding");
 
 	private FabricBranding() {
 	}
 
 	public static String apply(final String branding) {
-		if (branding.equals(VANILLA)) {
+		if (Strings.isNullOrEmpty(branding)) {
+			LOGGER.warn("Null or empty branding");
 			return FABRIC;
-		} else {
-			return branding + "," + FABRIC;
 		}
+		return VANILLA.equals(branding) ? FABRIC : branding + "," + FABRIC;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/util/FabricBranding.java
+++ b/src/main/java/net/fabricmc/loader/util/FabricBranding.java
@@ -29,9 +29,9 @@ public final class FabricBranding {
 	private FabricBranding() {
 	}
 
-	public static String apply(final String branding) {
+	public static String apply(final String branding, final Object environment) {
 		if (Strings.isNullOrEmpty(branding)) {
-			LOGGER.warn("Null or empty branding");
+			LOGGER.warn("Null or empty branding given for {}", environment);
 			return FABRIC;
 		}
 		return VANILLA.equals(branding) ? FABRIC : branding + "," + FABRIC;

--- a/src/main/java/net/fabricmc/loader/util/FabricBranding.java
+++ b/src/main/java/net/fabricmc/loader/util/FabricBranding.java
@@ -16,14 +16,14 @@
 
 package net.fabricmc.loader.util;
 
-public final class BrandingUtil {
+public final class FabricBranding {
 	public static final String FABRIC = "fabric";
 	public static final String VANILLA = "vanilla";
 
-	private BrandingUtil() {
+	private FabricBranding() {
 	}
 
-	public static String brand(final String branding) {
+	public static String apply(final String branding) {
 		if (branding.equals(VANILLA)) {
 			return FABRIC;
 		} else {


### PR DESCRIPTION
- Avoids referencing Mixin's callback API classes outside of the mixin package.
- Changed utility class name to `FabricBranding`, with the method named `apply`.
- Logs warnings for potential "error" states wherein the original brand is null or empty.