### PR TITLE
use maven-publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,16 +2,27 @@ pipeline {
    agent any
    stages {
 
+      stage('Init') {
+         steps {
+            sh "rm -rf build/libs/"
+            sh "chmod +x gradlew"
+         }
+      }
+
       stage ('Build') {
+         steps {
+            sh "./gradlew build --refresh-dependencies --stacktrace"
+
+            archiveArtifacts artifacts: '**/build/libs/*.jar', fingerprint: true
+         }
+      }
+
+      stage('Publish') {
          when {
             branch 'master'
          }
          steps {
-            sh "rm -rf build/libs/"
-            sh "chmod +x gradlew"
-            sh "./gradlew build uploadArchives --refresh-dependencies --stacktrace"
-
-            archiveArtifacts artifacts: '**/build/libs/*.jar', fingerprint: true
+            sh "./gradlew publish --refresh-dependencies --stacktrace"
          }
       }
    }

--- a/build.gradle
+++ b/build.gradle
@@ -3,24 +3,6 @@ plugins {
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
-import net.fabricmc.loom.LoomGradlePlugin
-
-//buildscript {
-//	repositories {
-//		mavenCentral()
-//		maven {
-//			name = 'Fabric'
-//			url = 'https://maven.fabricmc.net/'
-//		}
-//		maven {
-//			name = 'mojang'
-//			url = 'https://libraries.minecraft.net/'
-//		}
-//	}
-//	dependencies {
-//		classpath 'net.fabricmc:fabric-loom:0.2.0-SNAPSHOT'
-//	}
-//}
 
 plugins {
 	id 'java'
@@ -30,7 +12,6 @@ plugins {
 	id 'eclipse'
 	id("fabric-loom") version "0.2.0-SNAPSHOT"
 }
-//apply plugin: LoomGradlePlugin
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -160,11 +141,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 	from sourceSets.main.allSource
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-	classifier = 'javadoc'
-	from javadoc.destinationDir
-}
-
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
@@ -175,9 +151,6 @@ publishing {
 			artifact(sourcesJar) {
 				builtBy remapSourcesJar
 			}
-			// TODO: commented out because generating javadoc errors 
-			//   due to incorrect or missing documentation in the project
-//			artifact(javadocJar)
 		}
 	}
 
@@ -192,10 +165,7 @@ publishing {
 				}
 			}
 		}
-		// uncomment to publish to the local maven always
-		// mavenLocal()
 	}
 }
-//apply from: 'https://github.com/FabricMC/fabric-docs/raw/master/gradle/maven.gradle'
 apply from: 'https://github.com/FabricMC/fabric-docs/raw/master/gradle/license.gradle'
 apply from: 'https://github.com/FabricMC/fabric-docs/raw/master/gradle/ideconfig.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -127,10 +127,6 @@ String getClasspathEntries(){
 	return classPath;
 }
 
-artifacts {
-	archives file("src/main/resources/fabric-installer.json")
-}
-
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 // if it is present.
 // If you remove this task, sources will not be generated.
@@ -148,6 +144,9 @@ publishing {
 			}
 			artifact(sourcesJar) {
 				builtBy remapSourcesJar
+			}
+			artifact(file("$buildDir/libs/${archivesBaseName}-${version}.json")) {
+				builtBy copyJson
 			}
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-plugins {
-}
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject

--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,10 @@ publishing {
 			artifact(file('src/main/resources/fabric-installer.json')) {
 				builtBy remapJar
 			}
+			artifact(file('src/main/resources/fabric-installer.launchwrapper.json')) {
+				builtBy remapJar
+				classifier = "launchwrapper"
+			}
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -145,8 +145,8 @@ publishing {
 			artifact(sourcesJar) {
 				builtBy remapSourcesJar
 			}
-			artifact(file("$buildDir/libs/${archivesBaseName}-${version}.json")) {
-				builtBy copyJson
+			artifact(file('src/main/resources/fabric-installer.json')) {
+				builtBy remapJar
 			}
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,36 @@
+plugins {
+}
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import net.fabricmc.loom.LoomGradlePlugin
 
-buildscript {
-	repositories {
-		mavenCentral()
-		maven {
-			name = 'Fabric'
-			url = 'https://maven.fabricmc.net/'
-		}
-		maven {
-			name = 'mojang'
-			url = 'https://libraries.minecraft.net/'
-		}
-	}
-	dependencies {
-		classpath 'net.fabricmc:fabric-loom:0.2.0-SNAPSHOT'
-	}
-}
+//buildscript {
+//	repositories {
+//		mavenCentral()
+//		maven {
+//			name = 'Fabric'
+//			url = 'https://maven.fabricmc.net/'
+//		}
+//		maven {
+//			name = 'mojang'
+//			url = 'https://libraries.minecraft.net/'
+//		}
+//	}
+//	dependencies {
+//		classpath 'net.fabricmc:fabric-loom:0.2.0-SNAPSHOT'
+//	}
+//}
 
 plugins {
 	id 'java'
-	id 'maven'
+	id 'maven-publish'
 
 	id 'idea'
 	id 'eclipse'
+	id("fabric-loom") version "0.2.0-SNAPSHOT"
 }
-apply plugin: LoomGradlePlugin
+//apply plugin: LoomGradlePlugin
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -149,11 +152,50 @@ artifacts {
 	archives file("src/main/resources/fabric-installer.json")
 }
 
+// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+// if it is present.
+// If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
 	classifier = 'sources'
 	from sourceSets.main.allSource
 }
 
-apply from: 'https://github.com/FabricMC/fabric-docs/raw/master/gradle/maven.gradle'
+task javadocJar(type: Jar, dependsOn: javadoc) {
+	classifier = 'javadoc'
+	from javadoc.destinationDir
+}
+
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			// add all the jars that should be included when publishing to maven
+			artifact(jar) {
+				builtBy remapJar
+			}
+			artifact(sourcesJar) {
+				builtBy remapSourcesJar
+			}
+			// TODO: commented out because generating javadoc errors 
+			//   due to incorrect or missing documentation in the project
+//			artifact(javadocJar)
+		}
+	}
+
+	// select the repositories you want to publish to
+	repositories {
+		if (project.hasProperty('mavenPass')) {
+			maven {
+				url = "http://mavenupload.modmuss50.me/"
+				credentials {
+					username = "buildslave"
+					password = project.getProperty('mavenPass')
+				}
+			}
+		}
+		// uncomment to publish to the local maven always
+		// mavenLocal()
+	}
+}
+//apply from: 'https://github.com/FabricMC/fabric-docs/raw/master/gradle/maven.gradle'
 apply from: 'https://github.com/FabricMC/fabric-docs/raw/master/gradle/license.gradle'
 apply from: 'https://github.com/FabricMC/fabric-docs/raw/master/gradle/ideconfig.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,10 @@
+pluginManagement {
+	repositories {
+		maven {
+			url = "http://maven.fabricmc.net"
+			name = "FabricMC"
+		}
+		gradlePluginPortal()
+	}
+}
 rootProject.name='fabric-loader'


### PR DESCRIPTION
also gets rid of the buildscript block, since its not needed anymore

as commented in the TODO: javadoc errors on some code, so i left it commented out
should probably be moved into a gradle snippet for reuse anyways