### PR TITLE
[dev/0.4] Do not apply Minecraft specific patch to non Minecraft games

### DIFF
--- a/src/main/java/net/fabricmc/loader/entrypoint/patches/EntrypointPatchHook.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/patches/EntrypointPatchHook.java
@@ -44,6 +44,10 @@ public class EntrypointPatchHook extends EntrypointPatch {
 		EnvType type = launcher.getEnvironmentType();
 		String entrypoint = launcher.getEntrypoint();
 
+		if (!entrypoint.startsWith("net.minecraft.") && !entrypoint.startsWith("com.mojang.")) {
+			return;
+		}
+
 		try {
 			String gameEntrypoint = null;
 			boolean serverHasFile = true;


### PR DESCRIPTION
Check to see if the entry point is for Minecraft before attempting to apply a patch.