### PR TITLE
[dev/0.4] Load classpaths from original gameJar if remapped

### DIFF
--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -121,6 +121,11 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 	}
 
 	@Override
+	public void proposeJarClasspaths(File jarFile) {
+		// TODO: read manifest and propose classpaths from jarFile.
+	}
+
+	@Override
 	public Collection<URL> getClasspathURLs() {
 		return launchClassLoader.getSources();
 	}

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncher.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncher.java
@@ -19,6 +19,7 @@ package net.fabricmc.loader.launch.common;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.mappings.Mappings;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -28,6 +29,8 @@ public interface FabricLauncher {
 	Mappings getMappings();
 
 	void propose(URL url);
+
+	void proposeJarClasspaths(File jarFile);
 
 	Collection<URL> getClasspathURLs();
 

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
@@ -180,6 +180,7 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 				}
 
 				launcher.propose(UrlUtil.asUrl(deobfJarFile));
+				launcher.proposeJarClasspaths(minecraftJar);
 				minecraftJar = deobfJarFile;
 			} catch (IOException | UrlConversionException e) {
 				throw new RuntimeException(e);


### PR DESCRIPTION
The remapped game jar does not have a manifest and we manually need to add the class paths from the original game jar.