### PR TITLE
Fix only one a single mod initializer getting loaded

### DIFF
--- a/src/main/java/net/fabricmc/loader/InstanceStorage.java
+++ b/src/main/java/net/fabricmc/loader/InstanceStorage.java
@@ -28,11 +28,11 @@ class InstanceStorage {
 		.missingSuperclassBehaviour(LanguageAdapter.MissingSuperclassBehavior.RETURN_NULL)
 		.build();
 
-	private final Multimap<Class, Object> instances = HashMultimap.create();
+	private final Multimap<String, Object> instances = HashMultimap.create();
 
 	@SuppressWarnings("unchecked")
 	public <T> Collection<T> getInitializers(Class<T> type) {
-		return (Collection<T>) instances.get(type);
+		return (Collection<T>) instances.get(type.getName());
 	}
 
 	protected void instantiate(String name, LanguageAdapter adapter) {
@@ -55,7 +55,7 @@ class InstanceStorage {
 			return;
 		}
 
-		instances.put(c, o);
+		instances.put(c.getName(), o);
 		add(o, c.getSuperclass());
 		for (Class ci : c.getInterfaces()) {
 			add(o, ci);


### PR DESCRIPTION
Fix #80 by using a the class's fully qualified name instead of a Class instance as the key to the map of initializers, since there can be multiple Class instances in an environment with multiple class loaders.