### PR TITLE
[0.4.2] cleanup classpath-related activities

### DIFF
--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -104,7 +104,7 @@ class EntrypointStorage {
 
 	private final Map<String, List<Entry>> entryMap = new HashMap<>();
 
-	private final List<Entry> getOrCreateEntries(String key) {
+	private List<Entry> getOrCreateEntries(String key) {
 		return entryMap.computeIfAbsent(key, (z) -> new ArrayList<>());
 	}
 

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -308,7 +308,7 @@ public class ModResolver {
 		private final URL url;
 		private final int depth;
 
-		public UrlProcessAction(FabricLoader loader, Map<String, ModCandidateSet> candidatesById, URL url, int depth) {
+		UrlProcessAction(FabricLoader loader, Map<String, ModCandidateSet> candidatesById, URL url, int depth) {
 			this.loader = loader;
 			this.candidatesById = candidatesById;
 			this.url = url;

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -127,7 +127,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 	}
 
 	@Override
-	public Collection<URL> getClasspathURLs() {
+	public Collection<URL> getLoadTimeDependencies() {
 		return launchClassLoader.getSources();
 	}
 

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncher.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncher.java
@@ -29,8 +29,6 @@ public interface FabricLauncher {
 
 	void propose(URL url);
 
-	Collection<URL> getClasspathURLs();
-
 	EnvType getEnvironmentType();
 
 	boolean isClassLoaded(String name);
@@ -46,4 +44,6 @@ public interface FabricLauncher {
 	String getEntrypoint();
 
 	String getTargetNamespace();
+
+	Collection<URL> getLoadTimeDependencies();
 }

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
@@ -16,14 +16,12 @@
 
 package net.fabricmc.loader.launch.common;
 
-import com.google.common.collect.ImmutableSet;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.util.mappings.TinyRemapperMappingsHelper;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
 import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.mappings.Mappings;
-import net.fabricmc.mappings.MappingsProvider;
 import net.fabricmc.tinyremapper.OutputConsumerPath;
 import net.fabricmc.tinyremapper.TinyRemapper;
 import org.apache.logging.log4j.LogManager;
@@ -109,7 +107,7 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 
 						Set<Path> depPaths = new HashSet<>();
 
-						for (URL url : launcher.getClasspathURLs()) {
+						for (URL url : launcher.getLoadTimeDependencies()) {
 							try {
 								Path path = UrlUtil.asPath(url);
 								if (!Files.exists(path)) {

--- a/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
@@ -152,30 +152,6 @@ public final class Knot extends FabricLauncherBase {
 		}).filter(Objects::nonNull).collect(Collectors.toSet());
 	}
 
-	private int findEntrypoint(List<String> entrypointClasses, List<String> entrypointFilenames, File file) {
-		for (int i = 0; i < entrypointClasses.size(); i++) {
-			String entryPointFilename = entrypointFilenames.get(i);
-
-			if (file.isDirectory()) {
-				if (new File(file, entryPointFilename).exists()) {
-					return i;
-				}
-			} else if (file.isFile()) {
-				try {
-					JarFile jf = new JarFile(file);
-					ZipEntry entry = jf.getEntry(entryPointFilename);
-					if (entry != null) {
-						return i;
-					}
-				} catch (IOException e) {
-					// pass
-				}
-			}
-		}
-
-		return -1;
-	}
-
 	private void prepareGameJar(Arguments argMap, List<String> entrypointClasses, List<String> filenamesToDetectGameEnvJars) {
 		List<String> entrypointFilenames = entrypointClasses.stream()
 			.map((ep) -> ep.replace('.', '/') + ".class")

--- a/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
@@ -65,7 +65,9 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 
 	@Override
 	public URL[] getClassPath() {
-		return FabricLauncherBase.getLauncher().getClasspathURLs().toArray(new URL[0]);
+		// Mixin 0.7.x only uses getClassPath() to find itself; we implement CodeSource correctly,
+		// so this is unnecessary.
+		return new URL[0];
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/util/mappings/MixinIntermediaryDevRemapper.java
+++ b/src/main/java/net/fabricmc/loader/util/mappings/MixinIntermediaryDevRemapper.java
@@ -122,7 +122,7 @@ public class MixinIntermediaryDevRemapper extends MixinMappingsRemapper {
 			}
 		}
 
-		LinkedList<ClassInfo> classInfos = new LinkedList<ClassInfo>();
+		LinkedList<ClassInfo> classInfos = new LinkedList<>();
 		classInfos.add(ClassInfo.forName(owner));
 
 		while (!classInfos.isEmpty()) {


### PR DESCRIPTION
Benefits:

* boots to the game a tiny bit faster
* far less reliance on hacks like parsing "java.class.path"; instead using ClassLoader API methods such as getResources() where possible