### PR TITLE
[WIP] Remove hard log4j dependency

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -24,11 +24,11 @@ import net.fabricmc.loader.discovery.*;
 import net.fabricmc.loader.launch.common.FabricLauncher;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.launch.knot.Knot;
+import net.fabricmc.loader.logging.FabricLogger;
+import net.fabricmc.loader.logging.FabricLoggerFactory;
 import net.fabricmc.loader.metadata.EntrypointMetadata;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.util.DefaultLanguageAdapter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.net.URL;
@@ -48,7 +48,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	@Deprecated
 	public static final FabricLoader INSTANCE = new FabricLoader();
 
-	protected static Logger LOGGER = LogManager.getFormatterLogger("Fabric|Loader");
+	protected static FabricLogger LOGGER = FabricLoggerFactory.create("Fabric Loader");
 
 	protected final Map<String, ModContainer> modMap = new HashMap<>();
 	protected List<ModContainer> mods = new ArrayList<>();
@@ -378,7 +378,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		}
 	}
 
-	public Logger getLogger() {
+	public FabricLogger getLogger() {
 		return LOGGER;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ClasspathModCandidateFinder.java
@@ -40,10 +40,11 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 				Enumeration<URL> mods = FabricLauncherBase.getLauncher().getTargetClassLoader().getResources("fabric.mod.json");
 				List<URL> modsList = new ArrayList<>();
 				while (mods.hasMoreElements()) {
+					URL modJsonUrl =mods.nextElement();
 					try {
-						modsList.add(UrlUtil.getSource("fabric.mod.json", mods.nextElement()));
+						modsList.add(UrlUtil.getSource("fabric.mod.json", modJsonUrl));
 					} catch (UrlConversionException e) {
-						loader.getLogger().debug(e);
+						loader.getLogger().debug("Could not find mod source for classpath mod " + modJsonUrl, e);
 					}
 				}
 

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -25,6 +25,7 @@ import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
+import net.fabricmc.loader.logging.FabricLogger;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.metadata.ModMetadataParser;
 import net.fabricmc.loader.metadata.ModMetadataV0;
@@ -39,12 +40,9 @@ import net.fabricmc.loader.util.sat4j.specs.IProblem;
 import net.fabricmc.loader.util.sat4j.specs.ISolver;
 import net.fabricmc.loader.util.sat4j.specs.IVecInt;
 import net.fabricmc.loader.util.sat4j.specs.TimeoutException;
-import net.fabricmc.loader.util.version.VersionDeserializer;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -102,7 +100,7 @@ public class ModResolver {
 	}
 
 	// TODO: Find a way to sort versions of mods by suggestions and conflicts (not crucial, though)
-	public Map<String, ModCandidate> findCompatibleSet(Logger logger, Map<String, ModCandidateSet> modCandidateSetMap) throws ModResolutionException {
+	public Map<String, ModCandidate> findCompatibleSet(FabricLogger logger, Map<String, ModCandidateSet> modCandidateSetMap) throws ModResolutionException {
 		// First, map all ModCandidateSets to Set<ModCandidate>s.
 		boolean isAdvanced = false;
 		Map<String, Collection<ModCandidate>> modCandidateMap = new HashMap<>();

--- a/src/main/java/net/fabricmc/loader/entrypoint/EntrypointTransformer.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/EntrypointTransformer.java
@@ -21,8 +21,8 @@ import net.fabricmc.loader.entrypoint.patches.EntrypointPatchBranding;
 import net.fabricmc.loader.entrypoint.patches.EntrypointPatchFML125;
 import net.fabricmc.loader.entrypoint.patches.EntrypointPatchHook;
 import net.fabricmc.loader.launch.common.FabricLauncher;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import net.fabricmc.loader.logging.FabricLogger;
+import net.fabricmc.loader.logging.FabricLoggerFactory;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.*;
@@ -34,7 +34,7 @@ public class EntrypointTransformer {
 	public static final EntrypointTransformer INSTANCE = new EntrypointTransformer();
 	public static String appletMainClass;
 
-	public final Logger logger = LogManager.getFormatterLogger("FabricLoader|EntrypointTransformer");
+	public final FabricLogger logger = FabricLoggerFactory.create("Fabric Loader");
 	private final List<EntrypointPatch> patches;
 	private Map<String, byte[]> patchedClasses;
 	private boolean entrypointsLocated = false;

--- a/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointBranding.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointBranding.java
@@ -16,14 +16,14 @@
 
 package net.fabricmc.loader.entrypoint.hooks;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import net.fabricmc.loader.logging.FabricLogger;
+import net.fabricmc.loader.logging.FabricLoggerFactory;
 
 public final class EntrypointBranding {
 	public static final String FABRIC = "fabric";
 	public static final String VANILLA = "vanilla";
 
-	private static final Logger LOGGER = LogManager.getLogger("Fabric|Branding");
+	private static final FabricLogger LOGGER = FabricLoggerFactory.create("Fabric Loader");
 
 	private EntrypointBranding() {
 	}

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
@@ -17,6 +17,8 @@
 package net.fabricmc.loader.launch.common;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.logging.FabricLogger;
+import net.fabricmc.loader.logging.FabricLoggerFactory;
 import net.fabricmc.loader.util.mappings.TinyRemapperMappingsHelper;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
@@ -24,8 +26,6 @@ import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.mappings.Mappings;
 import net.fabricmc.tinyremapper.OutputConsumerPath;
 import net.fabricmc.tinyremapper.TinyRemapper;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 
 import java.io.*;
@@ -41,7 +41,7 @@ import java.util.jar.JarFile;
 public abstract class FabricLauncherBase implements FabricLauncher {
 	public static Path minecraftJar;
 
-	protected static Logger LOGGER = LogManager.getFormatterLogger("FabricLoader");
+	protected static final FabricLogger LOGGER = FabricLoggerFactory.create("Fabric Loader");
 	private static Map<String, Object> properties;
 	private static FabricLauncher launcher;
 	private static MappingConfiguration mappingConfiguration = new MappingConfiguration();

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
@@ -19,11 +19,11 @@ package net.fabricmc.loader.launch.common;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.logging.FabricLogger;
+import net.fabricmc.loader.logging.FabricLoggerFactory;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.util.mappings.MixinIntermediaryDevRemapper;
 import net.fabricmc.mappings.Mappings;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.Mixins;
@@ -36,7 +36,7 @@ public final class FabricMixinBootstrap {
 
 	}
 
-	protected static Logger LOGGER = LogManager.getFormatterLogger("Fabric|MixinBootstrap");
+	private static final FabricLogger LOGGER = FabricLoggerFactory.create("Fabric Loader");
 	private static boolean initialized = false;
 
 	static void addConfiguration(String configuration) {

--- a/src/main/java/net/fabricmc/loader/launch/common/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/MappingConfiguration.java
@@ -16,16 +16,16 @@
 
 package net.fabricmc.loader.launch.common;
 
+import net.fabricmc.loader.logging.FabricLogger;
+import net.fabricmc.loader.logging.FabricLoggerFactory;
 import net.fabricmc.mappings.Mappings;
 import net.fabricmc.mappings.MappingsProvider;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 public class MappingConfiguration {
-	protected static Logger LOGGER = LogManager.getFormatterLogger("FabricLoader");
+	protected static FabricLogger LOGGER = FabricLoggerFactory.create("Fabric Loader");
 
 	private static Mappings mappings;
 	private static boolean checkedMappings;

--- a/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
@@ -150,7 +150,7 @@ public final class Knot extends FabricLauncherBase {
 				try {
 					return (UrlUtil.asUrl(file));
 				} catch (UrlConversionException e) {
-					LOGGER.debug(e);
+					LOGGER.debug("Could not convert " + file + " to URL!", e);
 					return null;
 				}
 			} else {

--- a/src/main/java/net/fabricmc/loader/logging/FabricLogger.java
+++ b/src/main/java/net/fabricmc/loader/logging/FabricLogger.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.logging;
+
+public abstract class FabricLogger {
+	protected final String prefix;
+
+	FabricLogger(String prefix) {
+		this.prefix = prefix;
+	}
+
+	protected abstract boolean shouldPrint(Severity severity);
+	protected abstract void internalPrint(Severity severity, String message);
+	protected abstract void internalPrint(Severity severity, String message, Throwable e);
+
+	public final void print(Severity severity, String message) {
+		if (shouldPrint(severity)) {
+			internalPrint(severity, message);
+		}
+	}
+
+	public final void print(Severity severity, String message, Object... args) {
+		if (shouldPrint(severity)) {
+			internalPrint(severity, String.format(message, args));
+		}
+	}
+
+	public final void info(String message, Object... args) {
+		print(Severity.INFO, message, args);
+	}
+
+	public final void warn(String message, Object... args) {
+		print(Severity.WARN, message, args);
+	}
+
+	public final void error(String message, Object... args) {
+		print(Severity.ERROR, message, args);
+	}
+
+	public final void debug(String message, Object... args) {
+		print(Severity.DEBUG, message, args);
+	}
+
+	public final void trace(String message, Object... args) {
+		print(Severity.TRACE, message, args);
+	}
+
+	public final void info(String message, Throwable e) {
+		if (shouldPrint(Severity.INFO)) {
+			internalPrint(Severity.INFO, message, e);
+		}
+	}
+
+	public final void warn(String message, Throwable e) {
+		if (shouldPrint(Severity.WARN)) {
+			internalPrint(Severity.WARN, message, e);
+		}
+	}
+
+	public final void error(String message, Throwable e) {
+		if (shouldPrint(Severity.ERROR)) {
+			internalPrint(Severity.ERROR, message, e);
+		}
+	}
+
+	public final void debug(String message, Throwable e) {
+		if (shouldPrint(Severity.DEBUG)) {
+			internalPrint(Severity.DEBUG, message, e);
+		}
+	}
+
+	public final void trace(String message, Throwable e) {
+		if (shouldPrint(Severity.TRACE)) {
+			internalPrint(Severity.TRACE, message, e);
+		}
+	}
+
+	public enum Severity {
+		TRACE,
+		DEBUG,
+		INFO,
+		WARN,
+		ERROR
+	}
+}

--- a/src/main/java/net/fabricmc/loader/logging/FabricLoggerFactory.java
+++ b/src/main/java/net/fabricmc/loader/logging/FabricLoggerFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.logging;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+public final class FabricLoggerFactory {
+	private static MethodHandle loggerFactory;
+
+	private FabricLoggerFactory() {
+
+	}
+
+	public static FabricLogger create(String prefix) {
+		if (loggerFactory == null) {
+			String className = "FabricLoggerStdout";
+
+			try {
+				if (Class.forName("org.apache.logging.log4j.LogManager") != null) {
+					className = "FabricLoggerLog4j";
+				}
+			} catch (ClassNotFoundException e) {
+				// pass
+			}
+
+			try {
+				Class loggerClass = Class.forName("net.fabricmc.loader.logging." + className);
+				loggerFactory = MethodHandles.publicLookup().unreflectConstructor(loggerClass.getConstructor(String.class));
+			} catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		try {
+			return (FabricLogger) loggerFactory.invoke(prefix);
+		} catch (Throwable t) {
+			throw new RuntimeException(t);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loader/logging/FabricLoggerLog4j.java
+++ b/src/main/java/net/fabricmc/loader/logging/FabricLoggerLog4j.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.logging;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FabricLoggerLog4j extends FabricLogger {
+	private final Logger logger;
+
+	public FabricLoggerLog4j(String prefix) {
+		super(prefix);
+		this.logger = LogManager.getFormatterLogger(prefix);
+	}
+
+	@Override
+	protected boolean shouldPrint(Severity severity) {
+		switch (severity) {
+			case INFO:
+				return logger.isInfoEnabled();
+			case WARN:
+				return logger.isWarnEnabled();
+			case ERROR:
+				return logger.isErrorEnabled();
+			case DEBUG:
+				return logger.isDebugEnabled();
+			case TRACE:
+				return logger.isTraceEnabled();
+			default:
+				return true;
+		}
+	}
+
+	@Override
+	protected void internalPrint(Severity severity, String message) {
+		switch (severity) {
+			case INFO:
+				logger.info(message);
+				break;
+			case WARN:
+				logger.warn(message);
+				break;
+			case ERROR:
+				logger.error(message);
+				break;
+			case DEBUG:
+				logger.debug(message);
+				break;
+			case TRACE:
+				logger.trace(message);
+				break;
+			default:
+				logger.warn("(Unsupported level " + severity.name() + ") " + message);
+				break;
+		}
+	}
+
+	@Override
+	protected void internalPrint(Severity severity, String message, Throwable e) {
+		switch (severity) {
+			case INFO:
+				logger.info(message, e);
+				break;
+			case WARN:
+				logger.warn(message, e);
+				break;
+			case ERROR:
+				logger.error(message, e);
+				break;
+			case DEBUG:
+				logger.debug(message, e);
+				break;
+			case TRACE:
+				logger.trace(message, e);
+				break;
+			default:
+				logger.warn("(Unsupported level " + severity.name() + ") " + message, e);
+				break;
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loader/logging/FabricLoggerStdout.java
+++ b/src/main/java/net/fabricmc/loader/logging/FabricLoggerStdout.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.logging;
+
+public class FabricLoggerStdout extends FabricLogger {
+	public FabricLoggerStdout(String prefix) {
+		super(prefix);
+	}
+
+	@Override
+	protected boolean shouldPrint(Severity severity) {
+		return severity != Severity.TRACE; // TODO
+	}
+
+	@Override
+	protected void internalPrint(Severity severity, String message) {
+		String msg = "[" + severity.name() + ":" + prefix + "] " + message;
+
+		if (severity == Severity.WARN || severity == Severity.ERROR) {
+			System.err.println(msg);
+		} else {
+			System.out.println(msg);
+		}
+	}
+
+	@Override
+	protected void internalPrint(Severity severity, String message, Throwable e) {
+		internalPrint(severity, message);
+		e.printStackTrace((severity == Severity.WARN || severity == Severity.ERROR) ? System.err : System.out);
+	}
+}


### PR DESCRIPTION
TODO:

- [ ] Move the hacky meta-logging framework to a separate, small dependency
- [ ] Remove hard Log4j dependency in our Mixin fork (which will then pull in said small dependency in place of Log4j)