### PR TITLE
[0.4.9] add entrypoint containers

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -17,6 +17,7 @@
 package net.fabricmc.loader;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.EntrypointContainer;
 import net.fabricmc.loader.api.LanguageAdapter;
 import net.fabricmc.loader.api.MappingResolver;
 import net.fabricmc.loader.api.SemanticVersion;
@@ -183,6 +184,11 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 
 	@Override
 	public <T> List<T> getEntrypoints(String key, Class<T> type) {
+		return entrypointStorage.getEntrypoints(key, type).stream().map(EntrypointContainer::get).collect(Collectors.toList());
+	}
+
+	@Override
+	public <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
 		return entrypointStorage.getEntrypoints(key, type);
 	}
 

--- a/src/main/java/net/fabricmc/loader/ModEntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/ModEntrypointContainer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader;
+
+import net.fabricmc.loader.api.EntrypointContainer;
+import net.fabricmc.loader.api.ModContainer;
+
+import java.util.Optional;
+
+final class ModEntrypointContainer<T> implements EntrypointContainer<T> {
+	private final T object;
+	private final Optional<ModContainer> provider;
+	private final String name;
+
+	ModEntrypointContainer(T object, ModContainer provider, String name) {
+		this.object = object;
+		this.provider = Optional.of(provider);
+		this.name = name;
+	}
+
+	@Override
+	public T get() {
+		return object;
+	}
+
+	@Override
+	public Optional<ModContainer> getProvidingMod() {
+		return provider;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+}

--- a/src/main/java/net/fabricmc/loader/api/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/EntrypointContainer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.api;
+
+import java.util.Optional;
+
+public interface EntrypointContainer<T> {
+	T get();
+	Optional<ModContainer> getProvidingMod();
+	String getName();
+}

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -37,7 +37,10 @@ public interface FabricLoader {
 		return net.fabricmc.loader.FabricLoader.INSTANCE;
 	}
 
+	@Deprecated
 	<T> List<T> getEntrypoints(String key, Class<T> type);
+
+	<T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type);
 
 	/**
 	 * Get the current mapping resolver.

--- a/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointClient.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointClient.java
@@ -31,7 +31,7 @@ public final class EntrypointClient {
 		}
 
 		FabricLoader.INSTANCE.instantiateMods(runDir, gameInstance);
-		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypoints("main", ModInitializer.class), ModInitializer::onInitialize);
-		EntrypointUtils.logErrors("client", FabricLoader.INSTANCE.getEntrypoints("client", ClientModInitializer.class), ClientModInitializer::onInitializeClient);
+		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypointContainers("main", ModInitializer.class), ModInitializer::onInitialize);
+		EntrypointUtils.logErrors("client", FabricLoader.INSTANCE.getEntrypointContainers("client", ClientModInitializer.class), ClientModInitializer::onInitializeClient);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointServer.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointServer.java
@@ -30,7 +30,7 @@ public final class EntrypointServer {
 		}
 
 		FabricLoader.INSTANCE.instantiateMods(runDir, gameInstance);
-		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypoints("main", ModInitializer.class), ModInitializer::onInitialize);
-		EntrypointUtils.logErrors("server", FabricLoader.INSTANCE.getEntrypoints("server", DedicatedServerModInitializer.class), DedicatedServerModInitializer::onInitializeServer);
+		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypointContainers("main", ModInitializer.class), ModInitializer::onInitialize);
+		EntrypointUtils.logErrors("server", FabricLoader.INSTANCE.getEntrypointContainers("server", DedicatedServerModInitializer.class), DedicatedServerModInitializer::onInitializeServer);
 	}
 }


### PR DESCRIPTION
The primary benefit is passing extra debugging information alongside the object reference itself; this allows for easier-to-debug error logging.