### PR TITLE
Fix a crash caused by attempting to load the mixin subsystem to load …

### DIFF
--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotClassDelegate.java
@@ -62,7 +62,7 @@ class KnotClassDelegate {
 	private final boolean isDevelopment;
 	private final EnvType envType;
 	private MixinTransformer mixinTransformer;
-	private volatile boolean isLoadingMixinTransformer;
+	private boolean isLoadingMixinTransformer;
 
 	KnotClassDelegate(boolean isDevelopment, EnvType envType, KnotClassLoaderInterface itf) {
 		this.isDevelopment = isDevelopment;


### PR DESCRIPTION
…a class requested by the mixin system loading.

I'm not entirely sure if this is actually a bug in fabric-loader, or in the way that I'm running it from eclipse as I haven't seen any other bug reports for this recently. If it helps here's the [log that is generated](https://gist.github.com/AlexIIL/4a4bf1ccafcd0543e4c43bbefb3ee391).