### PR TITLE
Display the mod list on multiple lines

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -191,7 +191,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 				break;
 		}
 
-		LOGGER.info("[" + getClass().getSimpleName() + "] " + modText, candidateMap.values().size());
+		LOGGER.info("[%s] " + modText, getClass().getSimpleName(), candidateMap.values().size());
 
 		List<ModCandidate> candidates = new ArrayList<>(candidateMap.values());
 		candidates.sort(Comparator.comparing(candidate -> candidate.getInfo().getId()));

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,6 +179,11 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		resolver.addCandidateFinder(new DirectoryModCandidateFinder(getModsDirectory().toPath()));
 		Map<String, ModCandidate> candidateMap = resolver.resolve(this);
 
+		String modListText = candidateMap.values().stream()
+				.sorted(Comparator.comparing(candidate -> candidate.getInfo().getId()))
+				.map(candidate -> String.format("- %s@%s", candidate.getInfo().getId(), candidate.getInfo().getVersion().getFriendlyString()))
+				.collect(Collectors.joining("\n"));
+
 		String modText;
 		switch (candidateMap.values().size()) {
 			case 0:
@@ -191,14 +197,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 				break;
 		}
 
-		LOGGER.info("[%s] " + modText, getClass().getSimpleName(), candidateMap.values().size());
-
-		List<ModCandidate> candidates = new ArrayList<>(candidateMap.values());
-		candidates.sort(Comparator.comparing(candidate -> candidate.getInfo().getId()));
-
-		for (ModCandidate candidate : candidates) {
-			LOGGER.info("- %s@%s", candidate.getInfo().getId(), candidate.getInfo().getVersion().getFriendlyString());
-		}
+		LOGGER.info("[%s] " + modText + "%n%s", getClass().getSimpleName(), candidateMap.values().size(), modListText);
 
 		for (ModCandidate candidate : candidateMap.values()) {
 			addMod(candidate);

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -193,7 +193,10 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 
 		LOGGER.info("[" + getClass().getSimpleName() + "] " + modText, candidateMap.values().size());
 
-		for (ModCandidate candidate : candidateMap.values()) {
+		List<ModCandidate> candidates = new ArrayList<>(candidateMap.values());
+		candidates.sort(Comparator.comparing(candidate -> candidate.getInfo().getId()));
+
+		for (ModCandidate candidate : candidates) {
 			LOGGER.info("- %s@%s", candidate.getInfo().getId(), candidate.getInfo().getVersion().getFriendlyString());
 		}
 

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -184,16 +184,18 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 				modText = "Loading %d mods";
 				break;
 			case 1:
-				modText = "Loading %d mod:\n%s";
+				modText = "Loading %d mod:";
 				break;
 			default:
-				modText = "Loading %d mods:\n%s";
+				modText = "Loading %d mods:";
 				break;
 		}
 
-		LOGGER.info("[" + getClass().getSimpleName() + "] " + modText, candidateMap.values().size(), candidateMap.values().stream()
-			.map(info -> String.format("- %s@%s", info.getInfo().getId(), info.getInfo().getVersion().getFriendlyString()))
-			.collect(Collectors.joining("\n")));
+		LOGGER.info("[" + getClass().getSimpleName() + "] " + modText, candidateMap.values().size());
+
+		for (ModCandidate candidate : candidateMap.values()) {
+			LOGGER.info("- %s@%s", candidate.getInfo().getId(), candidate.getInfo().getVersion().getFriendlyString());
+		}
 
 		for (ModCandidate candidate : candidateMap.values()) {
 			addMod(candidate);

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -181,7 +181,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 
 		String modListText = candidateMap.values().stream()
 				.sorted(Comparator.comparing(candidate -> candidate.getInfo().getId()))
-				.map(candidate -> String.format("- %s@%s", candidate.getInfo().getId(), candidate.getInfo().getVersion().getFriendlyString()))
+				.map(candidate -> String.format("\t- %s@%s", candidate.getInfo().getId(), candidate.getInfo().getVersion().getFriendlyString()))
 				.collect(Collectors.joining("\n"));
 
 		String modText;

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -184,16 +184,16 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 				modText = "Loading %d mods";
 				break;
 			case 1:
-				modText = "Loading %d mod: %s";
+				modText = "Loading %d mod:\n%s";
 				break;
 			default:
-				modText = "Loading %d mods: %s";
+				modText = "Loading %d mods:\n%s";
 				break;
 		}
 
 		LOGGER.info("[" + getClass().getSimpleName() + "] " + modText, candidateMap.values().size(), candidateMap.values().stream()
-			.map(info -> String.format("%s@%s", info.getInfo().getId(), info.getInfo().getVersion().getFriendlyString()))
-			.collect(Collectors.joining(", ")));
+			.map(info -> String.format("- %s@%s", info.getInfo().getId(), info.getInfo().getVersion().getFriendlyString()))
+			.collect(Collectors.joining("\n")));
 
 		for (ModCandidate candidate : candidateMap.values()) {
 			addMod(candidate);


### PR DESCRIPTION
Changes the mod list printed in the log on launch to be on multiple lines to increase readability, instead of printing it on a single line.

Example:
```
[15:16:52] [main/INFO] (Fabric|Loader) [FabricLoader] Loading 47 mods:
	- fabric@0.13.1+build.370-1.16
	- fabric-api-base@0.1.3+12a8474c7c
	- fabric-biomes-v1@0.2.7+059ea8667c
	- fabric-blockrenderlayer-v1@1.1.4+c6a8ea897c
	- fabric-command-api-v1@1.0.8+5ce533987c
	- fabric-commands-v0@0.2.0+52d308367c
	- fabric-containers-v0@0.1.8+045df74f7c
	- fabric-content-registries-v0@0.1.9+059ea8667c
	- fabric-crash-report-info-v1@0.1.2+b7f9825d7c
	- fabric-dimensions-v1@1.0.0+a71b30537c
[rest of the list]
```