### PR TITLE
Add support for dev- entrypoints

### DIFF
--- a/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointClient.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointClient.java
@@ -33,5 +33,10 @@ public final class EntrypointClient {
 		FabricLoader.INSTANCE.instantiateMods(runDir, gameInstance);
 		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypoints("main", ModInitializer.class), ModInitializer::onInitialize);
 		EntrypointUtils.logErrors("client", FabricLoader.INSTANCE.getEntrypoints("client", ClientModInitializer.class), ClientModInitializer::onInitializeClient);
+
+		if(FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+			EntrypointUtils.logErrors("dev-main", FabricLoader.INSTANCE.getEntrypoints("dev-main", ModInitializer.class), ModInitializer::onInitialize);
+			EntrypointUtils.logErrors("dev-client", FabricLoader.INSTANCE.getEntrypoints("dev-client", ClientModInitializer.class), ClientModInitializer::onInitializeClient);
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointServer.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/hooks/EntrypointServer.java
@@ -32,5 +32,10 @@ public final class EntrypointServer {
 		FabricLoader.INSTANCE.instantiateMods(runDir, gameInstance);
 		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypoints("main", ModInitializer.class), ModInitializer::onInitialize);
 		EntrypointUtils.logErrors("server", FabricLoader.INSTANCE.getEntrypoints("server", DedicatedServerModInitializer.class), DedicatedServerModInitializer::onInitializeServer);
+
+		if(FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+			EntrypointUtils.logErrors("dev-main", FabricLoader.INSTANCE.getEntrypoints("dev-main", ModInitializer.class), ModInitializer::onInitialize);
+			EntrypointUtils.logErrors("dev-server", FabricLoader.INSTANCE.getEntrypoints("dev-server", DedicatedServerModInitializer.class), DedicatedServerModInitializer::onInitializeServer);
+		}
 	}
 }


### PR DESCRIPTION
Added `dev-` prefixed versions of the three existing builtin entrypoints, which are only called when the loader is run with `-Dfabric.development=true`. This allows for more easily adding test code to mods that will only be used in a test environment (such as for API mods that shouldn't add any content when used normally, but need to be tested by adding content).

Example `entrypoints` object in `fabric.mod.json`: 
```json
"entrypoints": {
  "dev-main": [ "com.swordglowsblue.artifice.test.ArtificeTest" ],
  "dev-client": [ "com.swordglowsblue.artifice.test.ArtificeTestClient" ],
  "dev-server": [ "com.swordglowsblue.artifice.test.ArtificeTestDedicatedServer" ]
}
```