### PR TITLE
Add support for development entrypoints (take 2)

### DIFF
--- a/src/main/java/net/fabricmc/loader/metadata/EntrypointMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/EntrypointMetadata.java
@@ -19,4 +19,5 @@ package net.fabricmc.loader.metadata;
 public interface EntrypointMetadata {
 	String getAdapter();
 	String getValue();
+	boolean isDevelopment();
 }


### PR DESCRIPTION
As stated in #129, a `"development": true` key on object-form entrypoints is a better solution to development environment-only entrypoints than a `dev-` prefix on the entrypoint type key. This PR adds support for that key, which should be used as follows in `fabric.mod.json`:

```json
"entrypoints": {
  "main": [{
    "value": "net.fabricmc.example.test.ArtificeTest",
    "development": true
  }]
}
```

The main use case for such an entrypoint would be for test entrypoints that shouldn't be loaded / packaged with the mod in production; for example, by using this one could place their test entrypoints in `src/test/` instead of `src/main/` and easily exclude their test sources from the rest of the mod code, simply by then loading the game with the classpath of the `test` module instead of `main` during development.