### PR TITLE
Print a bit more information if the mod ID is invalid or a dependent mod has a version mismatch

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -320,22 +320,27 @@ public class ModResolver {
         prefix.append(" ").append(errorType).append(" mod ").append(depModId);
 
         List<String> errorList = new ArrayList<>();
+
         if (!isModIdValid(depModId, errorList)) {
             if (errorList.size() == 1) {
                 errors.append(prefix).append(" which has an invalid mod id because it ").append(errorList.get(0));
             } else {
                 errors.append(prefix).append(" which has an invalid mod because:");
+
                 for (String error : errorList) {
                     errors.append("\n   - It ").append(error);
                 }
             }
+
             return;
         }
 
         ModCandidate depCandidate = result.get(depModId);
         boolean isPresent = depCandidate == null ? false : dependency.matches(depCandidate.getInfo().getVersion());
+
         if (isPresent != cond) {
             errors.append("\n - Mod ").append(candidate.getInfo().getId()).append(" ").append(errorType).append(" mod ").append(dependency).append(", ");
+
             if (depCandidate == null) {
                 errors.append("which is missing");
             } else if (cond) {
@@ -346,6 +351,7 @@ public class ModResolver {
             } else {
                 errors.append("but the breaking version is present: ").append(depCandidate.getInfo().getVersion());
             }
+
             errors.append("!");
         }
     }
@@ -357,35 +363,47 @@ public class ModResolver {
             errorList.add("is empty!");
             return false;
         }
+
         if (modId.length() == 1) {
             errorList.add("is only a single character! (It must be at least 2 characters long)!");
         } else if (modId.length() > 64) {
             errorList.add("has more than 64 characters!");
         }
+
         char first = modId.charAt(0);
+
         if (first < 'a' || first > 'z') {
             errorList.add("starts with an invalid character '" + first + "' (it must be a lowercase a-z - upper case isn't allowed anywhere in the ID)");
         }
+
         Set<Character> invalidChars = null;
+
         for (int i = 1; i < modId.length(); i++) {
             char c = modId.charAt(i);
+
             if (c == '-' || c == '_' || ('0' <= c && c <= '9') || ('a' <= c && c <= 'z')) {
                 continue;
             }
+
             if (invalidChars == null) {
                 invalidChars = new HashSet<>();
             }
+
             invalidChars.add(c);
         }
+
         if (invalidChars != null) {
             StringBuilder error = new StringBuilder("contains invalid characters: '");
             Character[] chars = invalidChars.toArray(new Character[0]);
             Arrays.sort(chars);
+
             for (Character c : chars) {
                 error.append(c.charValue());
             }
+
             errorList.add(error.append("'!").toString());
         }
+
         assert errorList.isEmpty() == MOD_ID_PATTERN.matcher(modId).matches() : "Errors list " + errorList + " didn't match the mod ID pattern!";
         return errorList.isEmpty();
     }

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -101,7 +101,7 @@ public class ModResolver {
 		}
 		char first = modId.charAt(0);
 		if (first < 'a' || first > 'z') {
-			errorList.add("starts with an invalid characters '" + first + "' (it must be a lowercase a-z)");
+			errorList.add("starts with invalid characters '" + first + "' (it must be a lowercase a-z)");
 		}
 		Set<Character> invalidChars = null;
 		for (int i = 1; i < modId.length(); i++) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -87,17 +87,80 @@ public class ModResolver {
 		return new VecInt(stream.toArray());
 	}
 
-	private boolean matches(ModDependency dependency, Map<String, ModCandidate> result) {
-		if (!result.containsKey(dependency.getModId())) {
+	/** @param errorList The list of errors. The returned list of errors all need to be prefixed with "it " in order to make sense. */
+	private static boolean isModIdValid(String modId, List<String> errorList) {
+		// A more useful error list for MOD_ID_PATTERN
+		if (modId.isEmpty()) {
+			errorList.add("is empty!");
 			return false;
 		}
-
-		return dependency.matches(result.get(dependency.getModId()).getInfo().getVersion());
+		if (modId.length() == 1) {
+			errorList.add("is only a single character! (It must be at least 2 characters long)!");
+		} else if (modId.length() > 64) {
+			errorList.add("has more than 64 characters!");
+		}
+		char first = modId.charAt(0);
+		if (first < 'a' || first > 'z') {
+			errorList.add("starts with an invalid characters '" + first + "' (it must be a lowercase a-z)");
+		}
+		Set<Character> invalidChars = null;
+		for (int i = 1; i < modId.length(); i++) {
+			char c = modId.charAt(i);
+			if (c == '-' || c == '_' || ('0' <= c && c <= '9') || ('a' <= c && c <= 'z')) {
+				continue;
+			}
+			if (invalidChars == null) {
+				invalidChars = new HashSet<>();
+			}
+			invalidChars.add(c);
+		}
+		if (invalidChars != null) {
+			StringBuilder error = new StringBuilder("contains invalid characters: '");
+			Character[] chars = invalidChars.toArray(new Character[0]);
+			Arrays.sort(chars);
+			for (Character c : chars) {
+				error.append(c.charValue());
+			}
+			errorList.add(error.append("'!").toString());
+		}
+		assert errorList.isEmpty() == MOD_ID_PATTERN.matcher(modId).matches() : "Errors list " + errorList + " didn't match the mod ID pattern!";
+		return errorList.isEmpty();
 	}
 
 	private void addErrorToList(ModCandidate candidate, ModDependency dependency, Map<String, ModCandidate> result, StringBuilder errors, String errorType, boolean cond) {
-		if (matches(dependency, result) != cond) {
-			errors.append("\n - Mod ").append(candidate.getInfo().getId()).append(" ").append(errorType).append(" mod ").append(dependency).append(", which is missing!");
+		String depModId = dependency.getModId();
+
+		StringBuilder prefix = new StringBuilder("\n - Mod ").append(candidate.getInfo().getId());
+		prefix.append(" ").append(errorType).append(" mod ").append(depModId);
+
+		List<String> errorList = new ArrayList<>();
+		if (!isModIdValid(depModId, errorList)) {
+			if (errorList.size() == 1) {
+				errors.append(prefix).append(" which has an invalid mod id because it ").append(errorList.get(0));
+			} else {
+				errors.append(prefix).append(" which has an invalid mod because:");
+				for (String error : errorList) {
+					errors.append("\n	- It ").append(error);
+				}
+			}
+			return;
+		}
+
+		ModCandidate depCandidate = result.get(depModId);
+		boolean isPresent = depCandidate == null ? false : dependency.matches(depCandidate.getInfo().getVersion());
+		if (isPresent != cond) {
+			errors.append("\n - Mod ").append(candidate.getInfo().getId()).append(" ").append(errorType).append(" mod ").append(dependency).append(", ");
+			if (depCandidate == null) {
+				errors.append("which is missing");
+			} else if (cond) {
+				errors.append("but a different version is present: ").append(depCandidate.getInfo().getVersion());
+			} else if (errorType.contains("conf")) {
+				// CONFLICTS WITH
+				errors.append("but the conflicting version is present: ").append(depCandidate.getInfo().getVersion());
+			} else {
+				errors.append("but the breaking version is present: ").append(depCandidate.getInfo().getVersion());
+			}
+			errors.append("!");
 		}
 	}
 
@@ -399,7 +462,19 @@ public class ModResolver {
 				}
 
 				if (!MOD_ID_PATTERN.matcher(candidate.getInfo().getId()).matches()) {
-					throw new RuntimeException(String.format("Mod id `%s` does not match the requirements", candidate.getInfo().getId()));
+					List<String> errorList = new ArrayList<>();
+					isModIdValid(candidate.getInfo().getId(), errorList);
+					StringBuilder fullError = new StringBuilder("Mod id `");
+					fullError.append(candidate.getInfo().getId()).append("` does not match the requirements because");
+					if (errorList.size() == 1) {
+						fullError.append(" it ").append(errorList.get(0));
+					} else {
+						fullError.append(":");
+						for (String error : errorList) {
+							fullError.append("\n  - It ").append(error);
+						}
+					}
+					throw new RuntimeException(fullError.toString());
 				}
 
 				added = candidatesById.computeIfAbsent(candidate.getInfo().getId(), ModCandidateSet::new).add(candidate);

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -484,6 +484,7 @@ public class ModResolver {
 					isModIdValid(candidate.getInfo().getId(), errorList);
 					StringBuilder fullError = new StringBuilder("Mod id `");
 					fullError.append(candidate.getInfo().getId()).append("` does not match the requirements because");
+
 					if (errorList.size() == 1) {
 						fullError.append(" it ").append(errorList.get(0));
 					} else {
@@ -492,6 +493,7 @@ public class ModResolver {
 							fullError.append("\n  - It ").append(error);
 						}
 					}
+
 					throw new RuntimeException(fullError.toString());
 				}
 

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -101,7 +101,7 @@ public class ModResolver {
 		}
 		char first = modId.charAt(0);
 		if (first < 'a' || first > 'z') {
-			errorList.add("starts with invalid characters '" + first + "' (it must be a lowercase a-z)");
+			errorList.add("starts with an invalid character '" + first + "' (it must be a lowercase a-z)");
 		}
 		Set<Character> invalidChars = null;
 		for (int i = 1; i < modId.length(); i++) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -101,7 +101,7 @@ public class ModResolver {
 		}
 		char first = modId.charAt(0);
 		if (first < 'a' || first > 'z') {
-			errorList.add("starts with an invalid character '" + first + "' (it must be a lowercase a-z)");
+			errorList.add("starts with an invalid character '" + first + "' (it must be a lowercase a-z - upper case isn't allowed anywhere in the ID)");
 		}
 		Set<Character> invalidChars = null;
 		for (int i = 1; i < modId.length(); i++) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -313,100 +313,100 @@ public class ModResolver {
 		return result;
 	}
 
-    private void addErrorToList(ModCandidate candidate, ModDependency dependency, Map<String, ModCandidate> result, StringBuilder errors, String errorType, boolean cond) {
-        String depModId = dependency.getModId();
+	private void addErrorToList(ModCandidate candidate, ModDependency dependency, Map<String, ModCandidate> result, StringBuilder errors, String errorType, boolean cond) {
+		String depModId = dependency.getModId();
 
-        StringBuilder prefix = new StringBuilder("\n - Mod ").append(candidate.getInfo().getId());
-        prefix.append(" ").append(errorType).append(" mod ").append(depModId);
+		StringBuilder prefix = new StringBuilder("\n - Mod ").append(candidate.getInfo().getId());
+		prefix.append(" ").append(errorType).append(" mod ").append(depModId);
 
-        List<String> errorList = new ArrayList<>();
+		List<String> errorList = new ArrayList<>();
 
-        if (!isModIdValid(depModId, errorList)) {
-            if (errorList.size() == 1) {
-                errors.append(prefix).append(" which has an invalid mod id because it ").append(errorList.get(0));
-            } else {
-                errors.append(prefix).append(" which has an invalid mod because:");
+		if (!isModIdValid(depModId, errorList)) {
+			if (errorList.size() == 1) {
+				errors.append(prefix).append(" which has an invalid mod id because it ").append(errorList.get(0));
+			} else {
+				errors.append(prefix).append(" which has an invalid mod because:");
 
-                for (String error : errorList) {
-                    errors.append("\n   - It ").append(error);
-                }
-            }
+				for (String error : errorList) {
+					errors.append("\n   - It ").append(error);
+				}
+			}
 
-            return;
-        }
+			return;
+		}
 
-        ModCandidate depCandidate = result.get(depModId);
-        boolean isPresent = depCandidate == null ? false : dependency.matches(depCandidate.getInfo().getVersion());
+		ModCandidate depCandidate = result.get(depModId);
+		boolean isPresent = depCandidate == null ? false : dependency.matches(depCandidate.getInfo().getVersion());
 
-        if (isPresent != cond) {
-            errors.append("\n - Mod ").append(candidate.getInfo().getId()).append(" ").append(errorType).append(" mod ").append(dependency).append(", ");
+		if (isPresent != cond) {
+			errors.append("\n - Mod ").append(candidate.getInfo().getId()).append(" ").append(errorType).append(" mod ").append(dependency).append(", ");
 
-            if (depCandidate == null) {
-                errors.append("which is missing");
-            } else if (cond) {
-                errors.append("but a different version is present: ").append(depCandidate.getInfo().getVersion());
-            } else if (errorType.contains("conf")) {
-                // CONFLICTS WITH
-                errors.append("but the conflicting version is present: ").append(depCandidate.getInfo().getVersion());
-            } else {
-                errors.append("but the breaking version is present: ").append(depCandidate.getInfo().getVersion());
-            }
+			if (depCandidate == null) {
+				errors.append("which is missing");
+			} else if (cond) {
+				errors.append("but a different version is present: ").append(depCandidate.getInfo().getVersion());
+			} else if (errorType.contains("conf")) {
+				// CONFLICTS WITH
+				errors.append("but the conflicting version is present: ").append(depCandidate.getInfo().getVersion());
+			} else {
+				errors.append("but the breaking version is present: ").append(depCandidate.getInfo().getVersion());
+			}
 
-            errors.append("!");
-        }
-    }
+			errors.append("!");
+		}
+	}
 
-    /** @param errorList The list of errors. The returned list of errors all need to be prefixed with "it " in order to make sense. */
-    private static boolean isModIdValid(String modId, List<String> errorList) {
-        // A more useful error list for MOD_ID_PATTERN
-        if (modId.isEmpty()) {
-            errorList.add("is empty!");
-            return false;
-        }
+	/** @param errorList The list of errors. The returned list of errors all need to be prefixed with "it " in order to make sense. */
+	private static boolean isModIdValid(String modId, List<String> errorList) {
+		// A more useful error list for MOD_ID_PATTERN
+		if (modId.isEmpty()) {
+			errorList.add("is empty!");
+			return false;
+		}
 
-        if (modId.length() == 1) {
-            errorList.add("is only a single character! (It must be at least 2 characters long)!");
-        } else if (modId.length() > 64) {
-            errorList.add("has more than 64 characters!");
-        }
+		if (modId.length() == 1) {
+			errorList.add("is only a single character! (It must be at least 2 characters long)!");
+		} else if (modId.length() > 64) {
+			errorList.add("has more than 64 characters!");
+		}
 
-        char first = modId.charAt(0);
+		char first = modId.charAt(0);
 
-        if (first < 'a' || first > 'z') {
-            errorList.add("starts with an invalid character '" + first + "' (it must be a lowercase a-z - upper case isn't allowed anywhere in the ID)");
-        }
+		if (first < 'a' || first > 'z') {
+			errorList.add("starts with an invalid character '" + first + "' (it must be a lowercase a-z - upper case isn't allowed anywhere in the ID)");
+		}
 
-        Set<Character> invalidChars = null;
+		Set<Character> invalidChars = null;
 
-        for (int i = 1; i < modId.length(); i++) {
-            char c = modId.charAt(i);
+		for (int i = 1; i < modId.length(); i++) {
+			char c = modId.charAt(i);
 
-            if (c == '-' || c == '_' || ('0' <= c && c <= '9') || ('a' <= c && c <= 'z')) {
-                continue;
-            }
+			if (c == '-' || c == '_' || ('0' <= c && c <= '9') || ('a' <= c && c <= 'z')) {
+				continue;
+			}
 
-            if (invalidChars == null) {
-                invalidChars = new HashSet<>();
-            }
+			if (invalidChars == null) {
+				invalidChars = new HashSet<>();
+			}
 
-            invalidChars.add(c);
-        }
+			invalidChars.add(c);
+		}
 
-        if (invalidChars != null) {
-            StringBuilder error = new StringBuilder("contains invalid characters: '");
-            Character[] chars = invalidChars.toArray(new Character[0]);
-            Arrays.sort(chars);
+		if (invalidChars != null) {
+			StringBuilder error = new StringBuilder("contains invalid characters: '");
+			Character[] chars = invalidChars.toArray(new Character[0]);
+			Arrays.sort(chars);
 
-            for (Character c : chars) {
-                error.append(c.charValue());
-            }
+			for (Character c : chars) {
+				error.append(c.charValue());
+			}
 
-            errorList.add(error.append("'!").toString());
-        }
+			errorList.add(error.append("'!").toString());
+		}
 
-        assert errorList.isEmpty() == MOD_ID_PATTERN.matcher(modId).matches() : "Errors list " + errorList + " didn't match the mod ID pattern!";
-        return errorList.isEmpty();
-    }
+		assert errorList.isEmpty() == MOD_ID_PATTERN.matcher(modId).matches() : "Errors list " + errorList + " didn't match the mod ID pattern!";
+		return errorList.isEmpty();
+	}
 
 	static class UrlProcessAction extends RecursiveAction {
 		private final FabricLoader loader;


### PR DESCRIPTION
This makes 3 changes:

 - When validating a mod ID against the regex this will print out a detailed list of the errors, rather than just `Mod '%s' does not match the requirements`. For example a mod id like: `buildCraftIA :)`it will print: `Mod id 'buildCraftIA :)' does not match the requirements because it contains invalid characters: ' ):ACI'!`. If there are multiple errors then they will appear like this:
```
Mod id `BuildCraftIA :)--------------------------------------------------------------` does not match the requirements because:
  - It has more than 64 characters!
  - It starts with an invalid character 'B' (it must be a lowercase a-z)
  - It contains invalid characters: ' ):ACI'!
```

- When validating a required/recommended/breaks/conficting mod ID it will print the same information as above.

 - If a required/recommended/breaks/conficting mod ID is present but doesn't match the version requirements it will now print `but a different version is present: {loaded version}` instead of `which is missing`. (If a conflicting or breaking mod is is present then it will print `but the conflicting version is...` or `but the breaking version is..` instead).