### PR TITLE
Fix injection point detection on 19w34a

### DIFF
--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
@@ -149,9 +149,10 @@ public class EntrypointPatchHook extends EntrypointPatch {
 							Object cst = ((LdcInsnNode) insn).cst;
 							if (cst instanceof String) {
 								String s = (String) cst;
-								if (s.startsWith("LWJGL Version: ")) {
+								//This log output was renamed to Backend library in 19w34a
+								if (s.startsWith("LWJGL Version: ") || s.startsWith("Backend library: ")) {
 									hasLwjglLog = true;
-									if ("LWJGL Version: ".equals(s) || "LWJGL Version: {}".equals(s)) {
+									if ("LWJGL Version: ".equals(s) || "LWJGL Version: {}".equals(s) || "Backend library: {}".equals(s)) {
 										qual = 3;
 									}
 									break;


### PR DESCRIPTION
In 1.14.4 fabric-loader was looking for the log output `LWJGL Version: {}` to find the correct method to inject into.

In 19w34a this was changed to `Backend library: {}`, this is a quick and easy fix to ensure mods get loaded at the correct time.

Ideally something less fragile would be used here, but for now this should be fine.

Fix tested in 1.14.4 and 19w34a