### PR TITLE
Implement builtin mod feature, add builtin mod for Minecraft

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 		exclude module: 'guava'
 	}
 	compile 'net.fabricmc:tiny-mappings-parser:0.1.1.8'
-	compile 'net.fabricmc:tiny-remapper:0.1.0.33'
+	compile 'net.fabricmc:tiny-remapper:0.1.0.40'
 
 	compile 'com.google.jimfs:jimfs:1.1'
 	compile 'net.fabricmc:fabric-loader-sat4j:2.3.5.4'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-version = 0.4.9
+version = 0.5.0

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -21,7 +21,7 @@ import net.fabricmc.loader.api.LanguageAdapter;
 import net.fabricmc.loader.api.MappingResolver;
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.discovery.*;
-import net.fabricmc.loader.launch.common.FabricLauncher;
+import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.launch.knot.Knot;
 import net.fabricmc.loader.metadata.EntrypointMetadata;
@@ -61,6 +61,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	private Object gameInstance;
 
 	private MappingResolver mappingResolver;
+	private GameProvider provider;
 	private File gameDir;
 	private File configDir;
 
@@ -79,7 +80,19 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		finishModLoading();
 	}
 
-	public void setGameDir(File gameDir) {
+	public GameProvider getGameProvider() {
+		if (provider == null) throw new IllegalStateException("game provider not set (yet)");
+
+		return provider;
+	}
+
+	public void setGameProvider(GameProvider provider) {
+		this.provider = provider;
+
+		setGameDir(provider.getLaunchDirectory().toFile());
+	}
+
+	private void setGameDir(File gameDir) {
 		this.gameDir = gameDir;
 		this.configDir = new File(gameDir, "config");
 	}
@@ -133,9 +146,8 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	}
 
 	public void load() {
-		if (frozen) {
-			throw new RuntimeException("Frozen - cannot load additional mods!");
-		}
+		if (provider == null) throw new IllegalStateException("game provider not set");
+		if (frozen) throw new IllegalStateException("Frozen - cannot load additional mods!");
 
 		ModResolver resolver = new ModResolver();
 		resolver.addCandidateFinder(new ClasspathModCandidateFinder());

--- a/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.discovery;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.JsonElement;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.metadata.EntrypointMetadata;
+import net.fabricmc.loader.metadata.LoaderModMetadata;
+import net.fabricmc.loader.metadata.NestedJarEntry;
+
+class BuiltinMetadataWrapper implements LoaderModMetadata {
+	private final ModMetadata parent;
+
+	public BuiltinMetadataWrapper(ModMetadata parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public String getType() { return parent.getType(); }
+	@Override
+	public String getId() { return parent.getId(); }
+	@Override
+	public Version getVersion() { return parent.getVersion(); }
+	@Override
+	public Collection<ModDependency> getDepends() { return parent.getDepends(); }
+	@Override
+	public Collection<ModDependency> getRecommends() { return parent.getRecommends(); }
+	@Override
+	public Collection<ModDependency> getSuggests() { return parent.getSuggests(); }
+	@Override
+	public Collection<ModDependency> getConflicts() { return parent.getConflicts(); }
+	@Override
+	public Collection<ModDependency> getBreaks() { return parent.getBreaks(); }
+	@Override
+	public String getName() { return parent.getName(); }
+	@Override
+	public String getDescription() { return parent.getDescription(); }
+	@Override
+	public Collection<Person> getAuthors() { return parent.getAuthors(); }
+	@Override
+	public Collection<Person> getContributors() { return parent.getContributors(); }
+	@Override
+	public ContactInformation getContact() { return parent.getContact(); }
+	@Override
+	public Collection<String> getLicense() { return parent.getLicense(); }
+	@Override
+	public Optional<String> getIconPath(int size) { return parent.getIconPath(size); }
+	@Override
+	public boolean containsCustomElement(String key) { return parent.containsCustomElement(key); }
+	@Override
+	public JsonElement getCustomElement(String key) { return parent.getCustomElement(key); }
+	@Override
+	public int getSchemaVersion() { return Integer.MAX_VALUE; }
+	@Override
+	public Map<String, String> getLanguageAdapterDefinitions() { return Collections.emptyMap(); }
+	@Override
+	public Collection<NestedJarEntry> getJars() { return Collections.emptyList(); }
+	@Override
+	public Collection<String> getMixinConfigs(EnvType type) { return Collections.emptyList(); }
+	@Override
+	public boolean loadsInEnvironment(EnvType type) { return true; }
+	@Override
+	public Collection<String> getOldInitializers() { return Collections.emptyList(); }
+	@Override
+	public List<EntrypointMetadata> getEntrypoints(String type) { return Collections.emptyList(); }
+	@Override
+	public Collection<String> getEntrypointKeys() { return Collections.emptyList(); }
+	@Override
+	public void emitFormatWarnings(Logger logger) { }
+}

--- a/src/main/java/net/fabricmc/loader/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/GameProvider.java
@@ -17,21 +17,39 @@
 package net.fabricmc.loader.game;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.entrypoint.EntrypointTransformer;
 
+import java.net.URL;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 
 public interface GameProvider {
 	String getGameId();
 	String getGameName();
+	String getRawGameVersion();
+	String getNormalizedGameVersion();
+	Collection<BuiltinMod> getBuiltinMods();
+
 	String getEntrypoint();
 	Path getLaunchDirectory();
 	boolean isObfuscated();
 	boolean requiresUrlClassLoader();
 	List<Path> getGameContextJars();
+
 	boolean locateGame(EnvType envType, ClassLoader loader);
 	void acceptArguments(String... arguments);
 	EntrypointTransformer getEntrypointTransformer();
 	void launch(ClassLoader loader);
+
+	public static class BuiltinMod {
+		public BuiltinMod(URL url, ModMetadata metadata) {
+			this.url = url;
+			this.metadata = metadata;
+		}
+
+		public final URL url;
+		public final ModMetadata metadata;
+	}
 }

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -24,39 +24,29 @@ import net.fabricmc.loader.entrypoint.minecraft.EntrypointPatchBranding;
 import net.fabricmc.loader.entrypoint.minecraft.EntrypointPatchFML125;
 import net.fabricmc.loader.entrypoint.minecraft.EntrypointPatchHook;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
+import net.fabricmc.loader.metadata.BuiltinModMetadata;
+import net.fabricmc.loader.minecraft.McVersionLookup;
+import net.fabricmc.loader.minecraft.McVersionLookup.McVersion;
 import net.fabricmc.loader.util.Arguments;
-import net.fabricmc.loader.util.FileSystemUtil;
-
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public class MinecraftGameProvider implements GameProvider {
-	static class VersionData {
-		public String id;
-		public String name;
-		public String release_target;
-		public int world_version;
-		public int protocol_version;
-		public int pack_version;
-		public String build_time;
-		public boolean stable;
-	}
-
 	private static final Gson GSON = new Gson();
 
 	private EnvType envType;
 	private String entrypoint;
 	private Arguments arguments;
 	private Path gameJar, realmsJar;
-	private VersionData versionData;
+	private McVersion versionData;
 	private boolean hasModLoader = false;
 
 	public static final EntrypointTransformer TRANSFORMER = new EntrypointTransformer(it -> Arrays.asList(
@@ -65,36 +55,41 @@ public class MinecraftGameProvider implements GameProvider {
 		new EntrypointPatchFML125(it)
 	));
 
-	MinecraftGameProvider() {}
-
 	@Override
 	public String getGameId() {
-		if (versionData != null) {
-			String id = versionData.id;
-			if (id == null) {
-				id = versionData.name;
-			}
-
-			if (id != null) {
-				return "minecraft-" + id.replaceAll("[^a-zA-Z0-9.]+", "-");
-			}
-		}
-
-		String filename = gameJar.getFileName().toString();
-		if (filename.lastIndexOf('.') >= 0) {
-			filename = filename.substring(0, filename.lastIndexOf('.'));
-		}
-
-		return "minecraft-" + filename;
+		return "minecraft";
 	}
 
 	@Override
 	public String getGameName() {
-		if (versionData != null && versionData.name != null) {
-			return "Minecraft " + versionData.name;
-		}
-		
 		return "Minecraft";
+	}
+
+	@Override
+	public String getRawGameVersion() {
+		return versionData.raw;
+	}
+
+	@Override
+	public String getNormalizedGameVersion() {
+		return versionData.normalized;
+	}
+
+	@Override
+	public Collection<BuiltinMod> getBuiltinMods() {
+		URL url;
+
+		try {
+			url = gameJar.toUri().toURL();
+		} catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+
+		return Arrays.asList(
+			new BuiltinMod(url, new BuiltinModMetadata.Builder(getGameId(), getNormalizedGameVersion())
+				.setName(getGameName())
+				.build())
+		);
 	}
 
 	@Override
@@ -134,9 +129,13 @@ public class MinecraftGameProvider implements GameProvider {
 	@Override
 	public boolean locateGame(EnvType envType, ClassLoader loader) {
 		this.envType = envType;
-		List<String> entrypointClasses = (envType == EnvType.CLIENT
-			   ? Lists.newArrayList("net.minecraft.client.main.Main", "net.minecraft.client.MinecraftApplet", "com.mojang.minecraft.MinecraftApplet")
-			   : Lists.newArrayList("net.minecraft.server.MinecraftServer", "com.mojang.minecraft.server.MinecraftServer"));
+		List<String> entrypointClasses;
+
+		if (envType == EnvType.CLIENT) {
+			entrypointClasses = Lists.newArrayList("net.minecraft.client.main.Main", "net.minecraft.client.MinecraftApplet", "com.mojang.minecraft.MinecraftApplet");
+		} else {
+			entrypointClasses = Lists.newArrayList("net.minecraft.server.MinecraftServer", "com.mojang.minecraft.server.MinecraftServer");
+		}
 
 		Optional<GameProviderHelper.EntrypointResult> entrypointResult = GameProviderHelper.findFirstClass(loader, entrypointClasses);
 		if (!entrypointResult.isPresent()) {
@@ -147,16 +146,8 @@ public class MinecraftGameProvider implements GameProvider {
 		gameJar = entrypointResult.get().entrypointPath;
 		realmsJar = GameProviderHelper.getSource(loader, "realmsVersion").orElse(null);
 		hasModLoader = GameProviderHelper.getSource(loader, "ModLoader.class").isPresent();
+		versionData = McVersionLookup.getVersion(gameJar);
 
-		try (FileSystemUtil.FileSystemDelegate jarFs = FileSystemUtil.getJarFileSystem(gameJar, false)) {
-			Path versionJson = jarFs.get().getPath("version.json");
-			if (Files.exists(versionJson)) {
-				versionData = GSON.fromJson(new String(Files.readAllBytes(versionJson), StandardCharsets.UTF_8), VersionData.class);
-			}
-		} catch (IOException e) {
-			// TODO: migrate to Logger
-			e.printStackTrace();
-		}
 		return true;
 	}
 
@@ -182,7 +173,7 @@ public class MinecraftGameProvider implements GameProvider {
 		}
 
 		try {
-			Class<?> c = ((ClassLoader) loader).loadClass(targetClass);
+			Class<?> c = loader.loadClass(targetClass);
 			Method m = c.getMethod("main", String[].class);
 			m.invoke(null, (Object) arguments.toArray());
 		} catch (Exception e) {

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -18,10 +18,10 @@ package net.fabricmc.loader.launch;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
+import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.game.MinecraftGameProvider;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.launch.common.FabricMixinBootstrap;
-import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
 import net.minecraft.launchwrapper.ITweaker;
@@ -42,7 +42,7 @@ import java.util.List;
 
 public abstract class FabricTweaker extends FabricLauncherBase implements ITweaker {
 	protected static Logger LOGGER = LogManager.getFormatterLogger("Fabric|Tweaker");
-	protected Arguments arguments = new Arguments();
+	protected String[] arguments;
 	private LaunchClassLoader launchClassLoader;
 	private boolean isDevelopment;
 
@@ -59,7 +59,8 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public void acceptOptions(List<String> localArgs, File gameDir, File assetsDir, String profile) {
-		arguments.parse(localArgs);
+		arguments = localArgs.toArray(new String[0]);
+		/*arguments.parse(localArgs);
 
 		if (!arguments.containsKey("gameDir") && gameDir != null) {
 			arguments.put("gameDir", gameDir.getAbsolutePath());
@@ -69,7 +70,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 			arguments.put("assetsDir", assetsDir.getAbsolutePath());
 		}
 
-		FabricLauncherBase.processArgumentMap(arguments, getEnvironmentType());
+		FabricLauncherBase.processArgumentMap(arguments, getEnvironmentType());*/
 	}
 
 	@Override
@@ -86,8 +87,14 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.Environment");
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.EnvType");
 
-		File gameDir = getLaunchDirectory(arguments);
-		FabricLoader.INSTANCE.setGameDir(gameDir);
+		GameProvider provider = new MinecraftGameProvider();
+		provider.acceptArguments(arguments);
+
+		if (!provider.locateGame(getEnvironmentType(), launchClassLoader)) {
+			throw new RuntimeException("Could not locate Minecraft: provider locate failed");
+		}
+
+		FabricLoader.INSTANCE.setGameProvider(provider);
 		FabricLoader.INSTANCE.load();
 		FabricLoader.INSTANCE.freeze();
 
@@ -105,7 +112,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 					throw new RuntimeException("Could not locate Minecraft: " + jarFile.getAbsolutePath() + " not found");
 				}
 
-				FabricLauncherBase.deobfuscate("", gameDir.toPath(), jarFile.toPath(), this);
+				FabricLauncherBase.deobfuscate(provider.getGameId(), provider.getNormalizedGameVersion(), provider.getLaunchDirectory(), jarFile.toPath(), this);
 			} catch (IOException | UrlConversionException e) {
 				throw new RuntimeException("Failed to deobfuscate Minecraft!", e);
 			}
@@ -121,7 +128,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public String[] getLaunchArguments() {
-		return arguments.toArray();
+		return arguments;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
@@ -18,7 +18,6 @@ package net.fabricmc.loader.launch.knot;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
-import net.fabricmc.loader.entrypoint.EntrypointTransformer;
 import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.game.GameProviders;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
@@ -41,7 +40,7 @@ public final class Knot extends FabricLauncherBase {
 	private KnotClassLoaderInterface loader;
 	private boolean isDevelopment;
 	private EnvType envType;
-	private File gameJarFile;
+	private final File gameJarFile;
 	private GameProvider provider;
 
 	protected Knot(EnvType type, File gameJarFile) {
@@ -60,13 +59,14 @@ public final class Knot extends FabricLauncherBase {
 			}
 
 			switch (side.toLowerCase(Locale.ROOT)) {
-				case "client": {
+				case "client":
 					envType = EnvType.CLIENT;
-				} break;
-				case "server": {
+					break;
+				case "server":
 					envType = EnvType.SERVER;
-				} break;
-				default: throw new RuntimeException("Invalid side provided: must be \"client\" or \"server\"!");
+					break;
+				default:
+					throw new RuntimeException("Invalid side provided: must be \"client\" or \"server\"!");
 			}
 		}
 
@@ -84,11 +84,11 @@ public final class Knot extends FabricLauncherBase {
 		}
 
 		if (provider != null) {
-			LOGGER.info("Loading for game " + provider.getGameName());
+			LOGGER.info("Loading for game " + provider.getGameName() + " " + provider.getRawGameVersion());
 		} else {
 			LOGGER.error("Could not find valid game provider!");
 			for (GameProvider p : providers) {
-				LOGGER.error("- " + p.getGameName());
+				LOGGER.error("- " + p.getGameName()+ " " + p.getRawGameVersion());
 			}
 			throw new RuntimeException("Could not find valid game provider!");
 		}
@@ -105,7 +105,7 @@ public final class Knot extends FabricLauncherBase {
 		if(provider.isObfuscated()) {
 			for (Path path : provider.getGameContextJars()) {
 				FabricLauncherBase.deobfuscate(
-					provider.getGameId(),
+					provider.getGameId(), provider.getNormalizedGameVersion(),
 					provider.getLaunchDirectory(),
 					path,
 					this
@@ -118,7 +118,7 @@ public final class Knot extends FabricLauncherBase {
 
 		Thread.currentThread().setContextClassLoader((ClassLoader) loader);
 
-		FabricLoader.INSTANCE.setGameDir(new File("."));
+		FabricLoader.INSTANCE.setGameProvider(provider);
 		FabricLoader.INSTANCE.load();
 		FabricLoader.INSTANCE.freeze();
 

--- a/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.metadata;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import com.google.gson.JsonElement;
+
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.util.version.VersionDeserializer;
+import net.fabricmc.loader.util.version.VersionParsingException;
+
+public final class BuiltinModMetadata implements ModMetadata {
+	private final String id;
+	private final Version version;
+	private final String name;
+	private final String description;
+	private final Collection<Person> authors;
+	private final Collection<Person> contributors;
+	private final ContactInformation contact;
+	private final Collection<String> license;
+	private final NavigableMap<Integer, String> icons;
+
+	private BuiltinModMetadata(String id, Version version,
+			String name, String description,
+			Collection<Person> authors, Collection<Person> contributors,
+			ContactInformation contact,
+			Collection<String> license,
+			NavigableMap<Integer, String> icons) {
+		this.id = id;
+		this.version = version;
+		this.name = name;
+		this.description = description;
+		this.authors = authors;
+		this.contributors = contributors;
+		this.contact = contact;
+		this.license = license;
+		this.icons = icons;
+	}
+
+	@Override
+	public String getType() {
+		return "builtin";
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public Version getVersion() {
+		return version;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public Collection<Person> getAuthors() {
+		return authors;
+	}
+
+	@Override
+	public Collection<Person> getContributors() {
+		return contributors;
+	}
+
+	@Override
+	public ContactInformation getContact() {
+		return contact;
+	}
+
+	@Override
+	public Collection<String> getLicense() {
+		return license;
+	}
+
+	@Override
+	public Optional<String> getIconPath(int size) {
+		if (icons.isEmpty()) return Optional.empty();
+
+		Integer key = size;
+		Entry<Integer, String> ret = icons.ceilingEntry(key);
+		if (ret == null) ret = icons.lastEntry();
+
+		return Optional.of(ret.getValue());
+	}
+
+	@Override
+	public Collection<ModDependency> getDepends() { return Collections.emptyList(); }
+	@Override
+	public Collection<ModDependency> getRecommends() { return Collections.emptyList(); }
+	@Override
+	public Collection<ModDependency> getSuggests() { return Collections.emptyList(); }
+	@Override
+	public Collection<ModDependency> getConflicts() { return Collections.emptyList(); }
+	@Override
+	public Collection<ModDependency> getBreaks() { return Collections.emptyList(); }
+	@Override
+	public boolean containsCustomElement(String key) { return false; }
+	@Override
+	public JsonElement getCustomElement(String key) { return null; }
+	
+	public static class Builder {
+		private final String id;
+		private final Version version;
+		private String name;
+		private String description = "";
+		private final Collection<Person> authors = new ArrayList<>();
+		private final Collection<Person> contributors = new ArrayList<>();
+		private ContactInformation contact = ContactInformation.EMPTY;
+		private final Collection<String> license = new ArrayList<>();
+		private final NavigableMap<Integer, String> icons = new TreeMap<>();
+
+		public Builder(String id, String version) {
+			this.name = this.id = id;
+
+			try {
+				this.version = VersionDeserializer.deserializeSemantic(version);
+			} catch (VersionParsingException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		public Builder setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public Builder setDescription(String description) {
+			this.description = description;
+			return this;
+		}
+
+		public Builder addAuthor(String name, Map<String, String> contactMap) {
+			this.authors.add(createPerson(name, contactMap));
+			return this;
+		}
+
+		public Builder addContributor(String name, Map<String, String> contactMap) {
+			this.contributors.add(createPerson(name, contactMap));
+			return this;
+		}
+
+		public Builder setContact(ContactInformation contact) {
+			this.contact = contact;
+			return this;
+		}
+
+		public Builder addLicense(String license) {
+			this.license.add(license);
+			return this;
+		}
+
+		public Builder addIcon(int size, String path) {
+			this.icons.put(size, path);
+			return this;
+		}
+
+		public ModMetadata build() {
+			return new BuiltinModMetadata(id, version, name, description, authors, contributors, contact, license, icons);
+		}
+
+		private static Person createPerson(String name, Map<String, String> contactMap) {
+			return new Person() {
+				@Override
+				public String getName() {
+					return name;
+				}
+
+				@Override
+				public ContactInformation getContact() {
+					return contact;
+				}
+
+				private final ContactInformation contact = contactMap.isEmpty() ? ContactInformation.EMPTY : new MapBackedContactInformation(contactMap);
+			};
+		}
+	}
+}

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -14,7 +14,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:tiny-remapper:0.1.0.33",
+        "name": "net.fabricmc:tiny-remapper:0.1.0.40",
         "url": "https://maven.fabricmc.net/"
       },
       {

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -17,7 +17,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:tiny-remapper:0.1.0.33",
+        "name": "net.fabricmc:tiny-remapper:0.1.0.40",
         "url": "https://maven.fabricmc.net/"
       },
       {


### PR DESCRIPTION
This allows declaring a dependency on a specific Minecraft version, including snapshots and pre-releases.

The MC version gets normalized to be (mostly) semver compliant, examples:
1.14
1.14.4
1.15-alpha.19.34.a (snapshot 19w34a)
1.14.4-rc.7 (pre-release 1.14.4-pre7)