### PR TITLE
Improve/fix semantic version parsing and comparison.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-version = 0.5.0
+version = 0.6.0

--- a/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
+++ b/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
@@ -22,13 +22,14 @@ import net.fabricmc.loader.util.version.VersionParsingException;
 import java.util.Optional;
 
 public interface SemanticVersion extends Version, Comparable<SemanticVersion> {
-	static final int COMPONENT_WILDCARD = Integer.MIN_VALUE;
+	int COMPONENT_WILDCARD = Integer.MIN_VALUE;
 
 	int getVersionComponentCount();
 	int getVersionComponent(int pos);
 
 	Optional<String> getPrereleaseKey();
 	Optional<String> getBuildKey();
+	boolean hasWildcard();
 
 	@Override
 	default int compareTo(SemanticVersion o) {
@@ -51,8 +52,10 @@ public interface SemanticVersion extends Version, Comparable<SemanticVersion> {
 		if (prereleaseA.isPresent() || prereleaseB.isPresent()) {
 			if (prereleaseA.isPresent() && prereleaseB.isPresent()) {
 				return prereleaseA.get().compareTo(prereleaseB.get());
-			} else {
-				return prereleaseA.isPresent() ? -1 : 1;
+			} else if (prereleaseA.isPresent()) {
+				return o.hasWildcard() ? 0 : -1;
+			} else { // prereleaseB.isPresent()
+				return hasWildcard() ? 0 : 1;
 			}
 		} else {
 			return 0;


### PR DESCRIPTION
This PR makes pre-release versions more available to dependency declarations and everything except lesser comparison should work more intuitively. The drawback is that an expression like "<1.2" will now permit a 1.2-prerelease until updated to "<1.2-" to set the bound just before any 1.2 pre-release version.

Versions with pre-release suffixes are no longer excluded, they are less
than their associated release and greater than the previous release.
Wildcard ranges automatically include pre-releases at the start and
exclude them at the end.
Carret (^, same major) and tilde (~, same major+minor) ranges exclude
pre-releases at the end, but not at the start without lowering it with
an empty pre-release (trailing -), e.g. "~1.15-".
The upper bound has to be specified with a pre-release now to exclude any
builds for its release, e.g. "<1.15-" to exclude 1.15-alpha.1, otherwise
it will be allowed.
For maximum ease of use, the wildcard form ("1.14.x", "1.x") should be
chosen, alternatively the ^ or ~ form if the start range can't be .0.

The major version 0 ("initial development") is no longer special cased, it doesn't make much sense to do so since the author of the dependency string can specify the desired behavior directly instead of letting the dependency checker guess what may be right.

I also plugged a few missing verification steps during parsing to catch user errors early.

Please refer to the test cases for the changed behavior, especially where `testTrue()` changed to `testFalse()` and vice versa.