### PR TITLE
Add handshake opt-out for Handshake API in Fabric API

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,5 +5,8 @@
   "version": "${version}",
   "environment": "*",
   "description": "The base mod loader.",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "custom": {
+    "fabric-networking.shouldHandshake": false
+  }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,6 +7,6 @@
   "description": "The base mod loader.",
   "license": "Apache-2.0",
   "custom": {
-    "fabric-networking.shouldHandshake": false
+    "fabric-networking:shouldHandshake": false
   }
 }


### PR DESCRIPTION
This adds a custom element to the `fabric.mod.json` so that the future handshake within fabric-api can exclude the loader from the client mod verification list.

This is a sister PR for: https://github.com/FabricMC/fabric/pull/332/commits/d914896249d3840ec05f37b5657b1000c6a0f9e1 and should only be merged at same time as the sister PR.