### PR TITLE
Replace GSON JsonElement in ModMetadata custom values, always delegate GSON to parent CL in KnotClassLoader.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-version = 0.6.0
+version = 0.6.1

--- a/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.api.metadata;
+
+import java.util.Map;
+
+public interface CustomValue {
+	CvType getType();
+	CvObject getAsObject();
+	CvArray getAsArray();
+	String getAsString();
+	Number getAsNumber();
+	boolean getAsBoolean();
+
+	interface CvObject extends CustomValue, Iterable<Map.Entry<String, CustomValue>> {
+		int size();
+		boolean containsKey(String key);
+		CustomValue get(String key);
+	}
+
+	interface CvArray extends CustomValue, Iterable<CustomValue> {
+		int size();
+		CustomValue get(int index);
+	}
+
+	enum CvType {
+		OBJECT, ARRAY, STRING, NUMBER, BOOLEAN, NULL;
+	}
+}

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
@@ -61,6 +61,18 @@ public interface ModMetadata {
 	 */
 	Optional<String> getIconPath(int size);
 
+	boolean containsCustomValue(String key);
+	CustomValue getCustomValue(String key);
+
+	/**
+	 * @deprecated Use {@link #containsCustomValue} instead, this will be removed (can't expose GSON types)!
+	 */
+	@Deprecated
 	boolean containsCustomElement(String key);
+
+	/**
+	 * @deprecated Use {@link #getCustomValue} instead, this will be removed (can't expose GSON types)!
+	 */
+	@Deprecated
 	JsonElement getCustomElement(String key);
 }

--- a/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
@@ -24,19 +24,19 @@ import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
-import com.google.gson.JsonElement;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.metadata.AbstractModMetadata;
 import net.fabricmc.loader.metadata.EntrypointMetadata;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.metadata.NestedJarEntry;
 
-class BuiltinMetadataWrapper implements LoaderModMetadata {
+class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMetadata {
 	private final ModMetadata parent;
 
 	public BuiltinMetadataWrapper(ModMetadata parent) {
@@ -74,9 +74,9 @@ class BuiltinMetadataWrapper implements LoaderModMetadata {
 	@Override
 	public Optional<String> getIconPath(int size) { return parent.getIconPath(size); }
 	@Override
-	public boolean containsCustomElement(String key) { return parent.containsCustomElement(key); }
+	public boolean containsCustomValue(String key) { return parent.containsCustomValue(key); }
 	@Override
-	public JsonElement getCustomElement(String key) { return parent.getCustomElement(key); }
+	public CustomValue getCustomValue(String key) { return parent.getCustomValue(key); }
 	@Override
 	public int getSchemaVersion() { return Integer.MAX_VALUE; }
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotClassLoader.java
@@ -139,7 +139,7 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 		synchronized (getClassLoadingLock(name)) {
 			Class<?> c = findLoadedClass(name);
 
-			if (c == null) {
+			if (c == null && !name.startsWith("com.google.gson.")) { // FIXME: remove the GSON exclusion once loader stops using it (or repackages it)
 				byte[] input = delegate.loadClassData(name, resolve);
 				if (input != null) {
 					KnotClassDelegate.Metadata metadata = delegate.getMetadata(name, urlLoader.getResource(delegate.getClassFileName(name)));

--- a/src/main/java/net/fabricmc/loader/metadata/AbstractModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/AbstractModMetadata.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.metadata;
+
+import java.util.Map;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+
+public abstract class AbstractModMetadata implements ModMetadata {
+	@Override
+	public boolean containsCustomElement(String key) {
+		return containsCustomValue(key);
+	}
+
+	@Override
+	public JsonElement getCustomElement(String key) {
+		CustomValue value = getCustomValue(key);
+
+		return value != null ? convert(value) : null;
+	}
+
+	private static JsonElement convert(CustomValue value) {
+		switch (value.getType()) {
+		case ARRAY: {
+			JsonArray ret = new JsonArray();
+
+			for (CustomValue v : value.getAsArray()) {
+				ret.add(convert(v));
+			}
+
+			return ret;
+		}
+		case BOOLEAN:
+			return new JsonPrimitive(value.getAsBoolean());
+		case NULL:
+			return JsonNull.INSTANCE;
+		case NUMBER:
+			return new JsonPrimitive(value.getAsNumber());
+		case OBJECT: {
+			JsonObject ret = new JsonObject();
+
+			for (Map.Entry<String, CustomValue> entry : value.getAsObject()) {
+				ret.add(entry.getKey(), convert(entry.getValue()));
+			}
+
+			return ret;
+		}
+		case STRING:
+			return new JsonPrimitive(value.getAsString());
+		}
+
+		throw new IllegalStateException();
+	}
+}

--- a/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
@@ -25,17 +25,16 @@ import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 
-import com.google.gson.JsonElement;
-
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.api.metadata.Person;
 import net.fabricmc.loader.util.version.VersionDeserializer;
 import net.fabricmc.loader.util.version.VersionParsingException;
 
-public final class BuiltinModMetadata implements ModMetadata {
+public final class BuiltinModMetadata extends AbstractModMetadata {
 	private final String id;
 	private final Version version;
 	private final String name;
@@ -130,10 +129,10 @@ public final class BuiltinModMetadata implements ModMetadata {
 	@Override
 	public Collection<ModDependency> getBreaks() { return Collections.emptyList(); }
 	@Override
-	public boolean containsCustomElement(String key) { return false; }
+	public boolean containsCustomValue(String key) { return false; }
 	@Override
-	public JsonElement getCustomElement(String key) { return null; }
-	
+	public CustomValue getCustomValue(String key) { return null; }
+
 	public static class Builder {
 		private final String id;
 		private final Version version;

--- a/src/main/java/net/fabricmc/loader/metadata/CustomValueImpl.java
+++ b/src/main/java/net/fabricmc/loader/metadata/CustomValueImpl.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.metadata;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Map.Entry;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import net.fabricmc.loader.api.metadata.CustomValue;
+
+abstract class CustomValueImpl implements CustomValue {
+	static final CustomValue BOOLEAN_TRUE = new BooleanImpl(true);
+	static final CustomValue BOOLEAN_FALSE = new BooleanImpl(false);
+	static final CustomValue NULL = new NullImpl();
+
+	public static CustomValue fromJsonElement(JsonElement e) {
+		if (e instanceof JsonObject) {
+			JsonObject o = (JsonObject) e;
+			Map<String, CustomValue> entries = new LinkedHashMap<>(o.size());
+
+			for (Map.Entry<String, JsonElement> entry : o.entrySet()) {
+				entries.put(entry.getKey(), fromJsonElement(entry.getValue()));
+			}
+
+			return new ObjectImpl(entries);
+		} else if (e instanceof JsonArray) {
+			JsonArray o = (JsonArray) e;
+			List<CustomValue> entries = new ArrayList<>(o.size());
+
+			for (int i = 0, max = o.size(); i < max; i++) {
+				entries.add(fromJsonElement(o.get(i)));
+			}
+
+			return new ArrayImpl(entries);
+		} else if (e instanceof JsonPrimitive) {
+			JsonPrimitive o = (JsonPrimitive) e;
+
+			if (o.isString()) {
+				return new StringImpl(o.getAsString());
+			} else if (o.isNumber()) {
+				return new NumberImpl(o.getAsNumber());
+			} else if (o.isBoolean()) {
+				return o.getAsBoolean() ? BOOLEAN_TRUE : BOOLEAN_FALSE;
+			} else {
+				throw new IllegalStateException();
+			}
+		} else if (e instanceof JsonNull) {
+			return NULL;
+		} else {
+			throw new IllegalArgumentException(Objects.toString(e));
+		}
+	}
+
+	@Override
+	public final CvObject getAsObject() {
+		if (this instanceof ObjectImpl) {
+			return (ObjectImpl) this;
+		} else {
+			throw new ClassCastException("can't convert "+getType().name()+" to Object");
+		}
+	}
+
+	@Override
+	public final CvArray getAsArray() {
+		if (this instanceof ArrayImpl) {
+			return (ArrayImpl) this;
+		} else {
+			throw new ClassCastException("can't convert "+getType().name()+" to Array");
+		}
+	}
+
+	@Override
+	public final String getAsString() {
+		if (this instanceof StringImpl) {
+			return ((StringImpl) this).value;
+		} else {
+			throw new ClassCastException("can't convert "+getType().name()+" to String");
+		}
+	}
+
+	@Override
+	public final Number getAsNumber() {
+		if (this instanceof NumberImpl) {
+			return ((NumberImpl) this).value;
+		} else {
+			throw new ClassCastException("can't convert "+getType().name()+" to Number");
+		}
+	}
+
+	@Override
+	public final boolean getAsBoolean() {
+		if (this instanceof BooleanImpl) {
+			return ((BooleanImpl) this).value;
+		} else {
+			throw new ClassCastException("can't convert "+getType().name()+" to Boolean");
+		}
+	}
+
+	private static final class ObjectImpl extends CustomValueImpl implements CvObject {
+		private final Map<String, CustomValue> entries;
+
+		public ObjectImpl(Map<String, CustomValue> entries) {
+			this.entries = entries;
+		}
+
+		@Override
+		public CvType getType() {
+			return CvType.OBJECT;
+		}
+
+		@Override
+		public int size() {
+			return entries.size();
+		}
+
+		@Override
+		public boolean containsKey(String key) {
+			return entries.containsKey(key);
+		}
+
+		@Override
+		public CustomValue get(String key) {
+			return entries.get(key);
+		}
+
+		@Override
+		public Iterator<Entry<String, CustomValue>> iterator() {
+			return entries.entrySet().iterator();
+		}
+	}
+
+	private static final class ArrayImpl extends CustomValueImpl implements CvArray {
+		private final List<CustomValue> entries;
+
+		public ArrayImpl(List<CustomValue> entries) {
+			this.entries = entries;
+		}
+
+		@Override
+		public CvType getType() {
+			return CvType.ARRAY;
+		}
+
+		@Override
+		public int size() {
+			return entries.size();
+		}
+
+		@Override
+		public CustomValue get(int index) {
+			return entries.get(index);
+		}
+
+		@Override
+		public Iterator<CustomValue> iterator() {
+			return entries.iterator();
+		}
+	}
+
+	private static final class StringImpl extends CustomValueImpl {
+		final String value;
+
+		public StringImpl(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public CvType getType() {
+			return CvType.STRING;
+		}
+	}
+
+	private static final class NumberImpl extends CustomValueImpl {
+		final Number value;
+
+		public NumberImpl(Number value) {
+			this.value = value;
+		}
+
+		@Override
+		public CvType getType() {
+			return CvType.NUMBER;
+		}
+	}
+
+	private static final class BooleanImpl extends CustomValueImpl {
+		final boolean value;
+
+		public BooleanImpl(boolean value) {
+			this.value = value;
+		}
+
+		@Override
+		public CvType getType() {
+			return CvType.BOOLEAN;
+		}
+	}
+
+	private static final class NullImpl extends CustomValueImpl {
+		@Override
+		public CvType getType() {
+			return CvType.NULL;
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loader/metadata/LoaderModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/LoaderModMetadata.java
@@ -18,10 +18,10 @@ package net.fabricmc.loader.metadata;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.metadata.ModMetadata;
+
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataV0.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataV0.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.*;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.api.Version;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +34,7 @@ import java.util.regex.Pattern;
 /**
  * Definition class for "fabric.mod.json" files.
  */
-public class ModMetadataV0 implements LoaderModMetadata {
+public class ModMetadataV0 extends AbstractModMetadata implements LoaderModMetadata {
 	// Required
 	private String id;
 	private Version version;
@@ -184,12 +185,12 @@ public class ModMetadataV0 implements LoaderModMetadata {
 	}
 
 	@Override
-	public boolean containsCustomElement(String key) {
+	public boolean containsCustomValue(String key) {
 		return false;
 	}
 
 	@Override
-	public JsonElement getCustomElement(String key) {
+	public CustomValue getCustomValue(String key) {
 		return null;
 	}
 

--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataV1.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataV1.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.loader.metadata;
 
-import com.google.common.base.Joiner;
 import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.util.version.VersionParsingException;
 import net.fabricmc.loader.util.version.VersionPredicateParser;
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 /**
  * Definition class for "fabric.mod.json" files.
  */
-public class ModMetadataV1 implements LoaderModMetadata {
+public class ModMetadataV1 extends AbstractModMetadata implements LoaderModMetadata {
 	// Required
 	private String id;
 	private Version version;
@@ -185,13 +185,16 @@ public class ModMetadataV1 implements LoaderModMetadata {
 	}
 
 	@Override
-	public boolean containsCustomElement(String key) {
+	public boolean containsCustomValue(String key) {
 		return custom.containsKey(key);
 	}
 
 	@Override
-	public JsonElement getCustomElement(String key) {
-		return custom.get(key);
+	public CustomValue getCustomValue(String key) {
+		JsonElement e = custom.get(key);
+		if (e == null) return null;
+
+		return CustomValueImpl.fromJsonElement(e);
 	}
 
 	@Override


### PR DESCRIPTION
This PR prepares GSON for removal or repackaging by offering a replacement custom value API and deprecating the old one. It also works around https://github.com/FabricMC/fabric-loader/issues/149 by forcing GSON class loading into InjectingURLClassLoader.