### PR TITLE
catch Throwable instead of just Exception in entrypoint getting

### DIFF
--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -141,9 +141,9 @@ class EntrypointStorage {
 				if (result != null) {
 					results.add(result);
 				}
-			} catch (Exception e) {
+			} catch (Throwable t) {
 				hadException = true;
-				FabricLoader.INSTANCE.getLogger().error("Exception occured while getting '" + key + "' entrypoints @ " + entry, e);
+				FabricLoader.INSTANCE.getLogger().error("Exception occured while getting '" + key + "' entrypoints @ " + entry, t);
 			}
 		}
 


### PR DESCRIPTION
Currently, only Exceptions are caught during entrypoint loading. This results in uninformative crashlogs like https://puu.sh/Ef09b/0e1e093bcd.log if an Error is thrown during entrypoint loading, such as a NoClassDefFoundError if an entrypoint class references a missing class. The game crashes anyway, so why not make the crashlog a little more informative while we're at it?