### PR TITLE
Fix injection point in 19w38a

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-version = 0.6.1
+version = 0.6.2

--- a/src/main/java/net/fabricmc/loader/entrypoint/EntrypointPatch.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/EntrypointPatch.java
@@ -100,6 +100,20 @@ public abstract class EntrypointPatch {
 		it.previous();
 	}
 
+	protected void moveAfter(ListIterator<AbstractInsnNode> it, AbstractInsnNode targetNode) {
+		while (it.hasNext()) {
+			AbstractInsnNode node = it.next();
+			if (node == targetNode) {
+				break;
+			}
+		}
+	}
+
+	protected void moveBefore(ListIterator<AbstractInsnNode> it, AbstractInsnNode targetNode) {
+		moveAfter(it, targetNode);
+		it.previous();
+	}
+
 	protected boolean isStatic(int access) {
 		return ((access & Opcodes.ACC_STATIC) != 0);
 	}

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
@@ -253,7 +253,7 @@ public class EntrypointPatchHook extends EntrypointPatch {
 						} else {
 							it = gameMethod.instructions.iterator();
 						}
-						if(lwjglLogNode != null){
+						if (lwjglLogNode != null) {
 							moveBefore(it, lwjglLogNode);
 						}
 						it.add(new VarInsnNode(Opcodes.ALOAD, 0));

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
@@ -126,6 +126,7 @@ public class EntrypointPatchHook extends EntrypointPatch {
 
 			MethodNode gameMethod = null;
 			MethodNode gameConstructor = null;
+			AbstractInsnNode lwjglLogNode = null;
 			int gameMethodQuality = 0;
 
 			for (MethodNode gmCandidate : gameClass.methods) {
@@ -135,9 +136,10 @@ public class EntrypointPatchHook extends EntrypointPatch {
 						gameMethod = gmCandidate;
 						gameMethodQuality = 1;
 					}
-				} else if (type == EnvType.CLIENT && !isApplet && gameMethodQuality < 2) {
-					// Try to find a non-constructor with an LDC string "LWJGL Version: ".
-					// This is the "init()" method, or called somewhere in that vicinity,
+				}
+				if (type == EnvType.CLIENT && !isApplet && gameMethodQuality < 2) {
+					// Try to find a method with an LDC string "LWJGL Version: ".
+					// This is the "init()" method, or as of 19w38a is the constructor, or called somewhere in that vicinity,
 					// and is by far superior in hooking into for a well-off mod start.
 
 					int qual = 2;
@@ -154,6 +156,7 @@ public class EntrypointPatchHook extends EntrypointPatch {
 									hasLwjglLog = true;
 									if ("LWJGL Version: ".equals(s) || "LWJGL Version: {}".equals(s) || "Backend library: {}".equals(s)) {
 										qual = 3;
+										lwjglLogNode = insn;
 									}
 									break;
 								}
@@ -249,6 +252,9 @@ public class EntrypointPatchHook extends EntrypointPatch {
 							it = consIt;
 						} else {
 							it = gameMethod.instructions.iterator();
+						}
+						if(lwjglLogNode != null){
+							moveBefore(it, lwjglLogNode);
 						}
 						it.add(new VarInsnNode(Opcodes.ALOAD, 0));
 						it.add(new FieldInsnNode(Opcodes.GETFIELD, ((FieldInsnNode) insn).owner, ((FieldInsnNode) insn).name, ((FieldInsnNode) insn).desc));


### PR DESCRIPTION
Inject before the LDC node, does slightly shift the injection point on older versions.
Also added a moveBefore and moveAfter that work on instructions over opcodes.
Bump version.