### PR TITLE
Improve error messages

### DIFF
--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -148,9 +148,11 @@ class EntrypointStorage {
 
 		if (!exceptions.isEmpty()) {
 			EntrypointException e = new EntrypointException("Could not look up entries for entrypoint " + key + "!");
+
 			for (Exception suppressed : exceptions) {
 				e.addSuppressed(suppressed);
 			}
+
 			throw e;
 		} else {
 			return results;

--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -133,7 +133,7 @@ class EntrypointStorage {
 			return Collections.emptyList();
 		}
 
-		boolean hadException = false;
+		List<Exception> exceptions = new ArrayList<>();
 		List<T> results = new ArrayList<>(entries.size());
 		for (Entry entry : entries) {
 			try {
@@ -142,13 +142,16 @@ class EntrypointStorage {
 					results.add(result);
 				}
 			} catch (Exception e) {
-				hadException = true;
-				FabricLoader.INSTANCE.getLogger().error("Exception occured while getting '" + key + "' entrypoints @ " + entry, e);
+				exceptions.add(e);
 			}
 		}
 
-		if (hadException) {
-			throw new EntrypointException("Could not look up entries for entrypoint " + key + "!");
+		if (!exceptions.isEmpty()) {
+			EntrypointException e = new EntrypointException("Could not look up entries for entrypoint " + key + "!");
+			for (Exception suppressed : exceptions) {
+				e.addSuppressed(suppressed);
+			}
+			throw e;
 		} else {
 			return results;
 		}

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -167,7 +167,7 @@ public class ModResolver {
 						try {
 							solver.addClause(new VecInt(clause));
 						} catch (ContradictionException e) {
-							throw new ModResolutionException("Could not resolve valid mod collection (at: " + mod.getInfo().getId() + " requires " + dep + ")", e);
+							throw new ModResolutionException("Could not find required mod: " + mod.getInfo().getId() + " requires " + dep, e);
 						}
 					}
 
@@ -188,7 +188,7 @@ public class ModResolver {
 								solver.addClause(new VecInt(new int[] { -modClauseId, -m }));
 							}
 						} catch (ContradictionException e) {
-							throw new ModResolutionException("Could not resolve valid mod collection (at: " + mod.getInfo().getId() + " breaks " + dep + ")", e);
+							throw new ModResolutionException("Found conflicting mods: " + mod.getInfo().getId() + " breaks " + dep, e);
 						}
 					}
 				}


### PR DESCRIPTION
- Adds the errors of "Could not look up entries for entrypoint Z!" as suppressed so they show up in crash reports (before they were just logged, so they only appeared in full logs)
- Changed some error messages:
  - "Could not resolve valid mod collection (at: X requires Y@version)"
    -> "Could not find required mod: X requires Y@version"
  - "Could not resolve valid mod collection (at: X breaks Y@version)"
    -> "Found conflicting mods: X breaks Y@version"