### PR TITLE
Add preLaunch entrypoint executing just before the game launch

### DIFF
--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -25,10 +25,9 @@ import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.metadata.EntrypointMetadata;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 class EntrypointStorage {
-	static interface Entry {
+	interface Entry {
 		<T> T getOrCreate(Class<T> type) throws Exception;
 	}
 
@@ -125,6 +124,10 @@ class EntrypointStorage {
 		getOrCreateEntries(key).add(new NewEntry(
 			modContainer, adapterMap.get(metadata.getAdapter()), metadata.getValue()
 		));
+	}
+
+	boolean hasEntrypoints(String key) {
+		return entryMap.containsKey(key);
 	}
 
 	protected <T> List<T> getEntrypoints(String key, Class<T> type) {

--- a/src/main/java/net/fabricmc/loader/ModContainer.java
+++ b/src/main/java/net/fabricmc/loader/ModContainer.java
@@ -17,8 +17,6 @@
 package net.fabricmc.loader;
 
 import net.fabricmc.loader.api.metadata.ModMetadata;
-import net.fabricmc.loader.language.LanguageAdapter;
-import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.util.FileSystemUtil;
 import net.fabricmc.loader.util.UrlConversionException;
@@ -28,8 +26,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ModContainer implements net.fabricmc.loader.api.ModContainer {
 	private final LoaderModMetadata info;
@@ -41,9 +37,9 @@ public class ModContainer implements net.fabricmc.loader.api.ModContainer {
 		this.originUrl = originUrl;
 	}
 
-	void instantiate() {
+	void setupRootPath() {
 		if (root != null) {
-			throw new RuntimeException("Not allowed to instantiate twice!");
+			throw new RuntimeException("Not allowed to setup mod root path twice!");
 		}
 
 		try {

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/PreLaunchEntrypoint.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/PreLaunchEntrypoint.java
@@ -20,12 +20,14 @@ package net.fabricmc.loader.api.entrypoint;
  * Entrypoint getting invoked just before launching the game.
  *
  * <p><b>Avoid interfering with the game from this!</b> Accessing anything needs careful consideration to avoid
- * interfering with its own initialization or otherwise harming its state.
+ * interfering with its own initialization or otherwise harming its state. It is recommended to implement this interface
+ * on its own class to avoid running static initializers too early, e.g. because they were referenced in field or method
+ * signatures in the same class.
  *
- * <p>The entrypoint is exposed as {@code preMain} in the mod json and runs for any environment. It usually executes
+ * <p>The entrypoint is exposed as {@code preLaunch} in the mod json and runs for any environment. It usually executes
  * several seconds before the main/client/server entrypoints.
  */
 @FunctionalInterface
-public interface PreMainEntrypoint {
-	void onPreMain();
+public interface PreLaunchEntrypoint {
+	void onPreLaunch();
 }

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/PreMainEntrypoint.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/PreMainEntrypoint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.api.entrypoint;
+
+/**
+ * Entrypoint getting invoked just before launching the game.
+ *
+ * <p><b>Avoid interfering with the game from this!</b> Accessing anything needs careful consideration to avoid
+ * interfering with its own initialization or otherwise harming its state.
+ *
+ * <p>The entrypoint is exposed as {@code preMain} in the mod json and runs for any environment. It usually executes
+ * several seconds before the main/client/server entrypoints.
+ */
+@FunctionalInterface
+public interface PreMainEntrypoint {
+	void onPreMain();
+}

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointClient.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointClient.java
@@ -28,8 +28,8 @@ public final class EntrypointClient {
 			runDir = new File(".");
 		}
 
-		FabricLoader.INSTANCE.instantiateMods(runDir, gameInstance);
-		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypoints("main", ModInitializer.class), ModInitializer::onInitialize);
-		EntrypointUtils.logErrors("client", FabricLoader.INSTANCE.getEntrypoints("client", ClientModInitializer.class), ClientModInitializer::onInitializeClient);
+		FabricLoader.INSTANCE.prepareModInit(runDir, gameInstance);
+		EntrypointUtils.invoke("main", ModInitializer.class, ModInitializer::onInitialize);
+		EntrypointUtils.invoke("client", ClientModInitializer.class, ClientModInitializer::onInitializeClient);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointServer.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointServer.java
@@ -28,8 +28,8 @@ public final class EntrypointServer {
 			runDir = new File(".");
 		}
 
-		FabricLoader.INSTANCE.instantiateMods(runDir, gameInstance);
-		EntrypointUtils.logErrors("main", FabricLoader.INSTANCE.getEntrypoints("main", ModInitializer.class), ModInitializer::onInitialize);
-		EntrypointUtils.logErrors("server", FabricLoader.INSTANCE.getEntrypoints("server", DedicatedServerModInitializer.class), DedicatedServerModInitializer::onInitializeServer);
+		FabricLoader.INSTANCE.prepareModInit(runDir, gameInstance);
+		EntrypointUtils.invoke("main", ModInitializer.class, ModInitializer::onInitialize);
+		EntrypointUtils.invoke("server", DedicatedServerModInitializer.class, DedicatedServerModInitializer::onInitializeServer);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
@@ -17,30 +17,39 @@
 package net.fabricmc.loader.entrypoint.minecraft.hooks;
 
 import net.fabricmc.loader.FabricLoader;
-import net.fabricmc.loader.gui.FabricGuiEntry;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
-final class EntrypointUtils {
-	private EntrypointUtils() {
+public final class EntrypointUtils {
+	public static <T> void invoke(String name, Class<T> type, Consumer<? super T> invoker) {
+		@SuppressWarnings("deprecation")
+		FabricLoader loader = FabricLoader.INSTANCE;
 
+		if (!loader.hasEntrypoints(name)) {
+			loader.getLogger().debug("No subscribers for entrypoint '" + name + "'");
+		} else {
+			invoke0(name, type, invoker);
+		}
 	}
 
-	static <T> void logErrors(String name, Collection<T> entrypoints, Consumer<T> entrypointConsumer) {
+	private static <T> void invoke0(String name, Class<T> type, Consumer<? super T> invoker) {
+		@SuppressWarnings("deprecation")
+		FabricLoader loader = FabricLoader.INSTANCE;
+		Collection<T> entrypoints = loader.getEntrypoints(name, type);
 		List<Throwable> errors = new ArrayList<>();
 
-		FabricLoader.INSTANCE.getLogger().debug("Iterating over entrypoint '" + name + "'");
+		loader.getLogger().debug("Iterating over entrypoint '" + name + "'");
 
-		entrypoints.forEach((e) -> {
+		for (T e : entrypoints) {
 			try {
-				entrypointConsumer.accept(e);
+				invoker.accept(e);
 			} catch (Throwable t) {
 				errors.add(t);
 			}
-		});
+		}
 
 		if (!errors.isEmpty()) {
 			RuntimeException exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors!");
@@ -48,7 +57,7 @@ final class EntrypointUtils {
 			for (Throwable t : errors) {
 				exception.addSuppressed(t);
 			}
-			
+
 			throw exception;
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -18,6 +18,8 @@ package net.fabricmc.loader.launch;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
+import net.fabricmc.loader.api.entrypoint.PreMainEntrypoint;
+import net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils;
 import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.game.MinecraftGameProvider;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
@@ -94,9 +96,11 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 			throw new RuntimeException("Could not locate Minecraft: provider locate failed");
 		}
 
-		FabricLoader.INSTANCE.setGameProvider(provider);
-		FabricLoader.INSTANCE.load();
-		FabricLoader.INSTANCE.freeze();
+		@SuppressWarnings("deprecation")
+		FabricLoader loader = FabricLoader.INSTANCE;
+		loader.setGameProvider(provider);
+		loader.load();
+		loader.freeze();
 
 		launchClassLoader.registerTransformer("net.fabricmc.loader.launch.FabricClassTransformer");
 
@@ -124,6 +128,8 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		MixinBootstrap.init();
 		FabricMixinBootstrap.init(getEnvironmentType(), FabricLoader.INSTANCE);
 		MixinEnvironment.getDefaultEnvironment().setSide(getEnvironmentType() == EnvType.CLIENT ? MixinEnvironment.Side.CLIENT : MixinEnvironment.Side.SERVER);
+
+		EntrypointUtils.invoke("preMain", PreMainEntrypoint.class, PreMainEntrypoint::onPreMain);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -18,7 +18,7 @@ package net.fabricmc.loader.launch;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
-import net.fabricmc.loader.api.entrypoint.PreMainEntrypoint;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils;
 import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.game.MinecraftGameProvider;
@@ -129,7 +129,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		FabricMixinBootstrap.init(getEnvironmentType(), FabricLoader.INSTANCE);
 		MixinEnvironment.getDefaultEnvironment().setSide(getEnvironmentType() == EnvType.CLIENT ? MixinEnvironment.Side.CLIENT : MixinEnvironment.Side.SERVER);
 
-		EntrypointUtils.invoke("preMain", PreMainEntrypoint.class, PreMainEntrypoint::onPreMain);
+		EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
@@ -18,6 +18,8 @@ package net.fabricmc.loader.launch.knot;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
+import net.fabricmc.loader.api.entrypoint.PreMainEntrypoint;
+import net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils;
 import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.game.GameProviders;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
@@ -37,7 +39,7 @@ import java.util.stream.Collectors;
 public final class Knot extends FabricLauncherBase {
 	protected Map<String, Object> properties = new HashMap<>();
 
-	private KnotClassLoaderInterface loader;
+	private KnotClassLoaderInterface classLoader;
 	private boolean isDevelopment;
 	private EnvType envType;
 	private final File gameJarFile;
@@ -100,9 +102,10 @@ public final class Knot extends FabricLauncherBase {
 		// Setup classloader
 		// TODO: Provide KnotCompatibilityClassLoader in non-exclusive-Fabric pre-1.13 environments?
 		boolean useCompatibility = provider.requiresUrlClassLoader() || Boolean.parseBoolean(System.getProperty("fabric.loader.useCompatibilityClassLoader", "false"));
-		loader = useCompatibility ? new KnotCompatibilityClassLoader(isDevelopment(), envType, provider) : new KnotClassLoader(isDevelopment(), envType, provider);
+		classLoader = useCompatibility ? new KnotCompatibilityClassLoader(isDevelopment(), envType, provider) : new KnotClassLoader(isDevelopment(), envType, provider);
+		ClassLoader cl = (ClassLoader) classLoader;
 
-		if(provider.isObfuscated()) {
+		if (provider.isObfuscated()) {
 			for (Path path : provider.getGameContextJars()) {
 				FabricLauncherBase.deobfuscate(
 					provider.getGameId(), provider.getNormalizedGameVersion(),
@@ -116,19 +119,23 @@ public final class Knot extends FabricLauncherBase {
 		// Locate entrypoints before switching class loaders
 		provider.getEntrypointTransformer().locateEntrypoints(this);
 
-		Thread.currentThread().setContextClassLoader((ClassLoader) loader);
+		Thread.currentThread().setContextClassLoader(cl);
 
-		FabricLoader.INSTANCE.setGameProvider(provider);
-		FabricLoader.INSTANCE.load();
-		FabricLoader.INSTANCE.freeze();
+		@SuppressWarnings("deprecation")
+		FabricLoader loader = FabricLoader.INSTANCE;
+		loader.setGameProvider(provider);
+		loader.load();
+		loader.freeze();
 
 		MixinBootstrap.init();
-		FabricMixinBootstrap.init(getEnvironmentType(), FabricLoader.INSTANCE);
+		FabricMixinBootstrap.init(getEnvironmentType(), loader);
 		FabricLauncherBase.finishMixinBootstrapping();
 
-		loader.getDelegate().initializeTransformers();
+		classLoader.getDelegate().initializeTransformers();
 
-		provider.launch((ClassLoader) loader);
+		EntrypointUtils.invoke("preMain", PreMainEntrypoint.class, PreMainEntrypoint::onPreMain);
+
+		provider.launch(cl);
 	}
 
 	@Override
@@ -166,7 +173,7 @@ public final class Knot extends FabricLauncherBase {
 	@Override
 	public void propose(URL url) {
 		FabricLauncherBase.LOGGER.debug("[Knot] Proposed " + url + " to classpath.");
-		loader.addURL(url);
+		classLoader.addURL(url);
 	}
 
 	@Override
@@ -176,13 +183,13 @@ public final class Knot extends FabricLauncherBase {
 
 	@Override
 	public boolean isClassLoaded(String name) {
-		return loader.isClassLoaded(name);
+		return classLoader.isClassLoaded(name);
 	}
 
 	@Override
 	public InputStream getResourceAsStream(String name) {
 		try {
-			return loader.getResourceAsStream(name, false);
+			return classLoader.getResourceAsStream(name, false);
 		} catch (IOException e) {
 			throw new RuntimeException("Failed to read file '" + name + "'!", e);
 		}
@@ -190,12 +197,12 @@ public final class Knot extends FabricLauncherBase {
 
 	@Override
 	public ClassLoader getTargetClassLoader() {
-		return (ClassLoader) loader;
+		return (ClassLoader) classLoader;
 	}
 
 	@Override
 	public byte[] getClassByteArray(String name) throws IOException {
-		return loader.getDelegate().getClassByteArray(name, false);
+		return classLoader.getDelegate().getClassByteArray(name, false);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
@@ -18,7 +18,7 @@ package net.fabricmc.loader.launch.knot;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
-import net.fabricmc.loader.api.entrypoint.PreMainEntrypoint;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils;
 import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.game.GameProviders;
@@ -133,7 +133,7 @@ public final class Knot extends FabricLauncherBase {
 
 		classLoader.getDelegate().initializeTransformers();
 
-		EntrypointUtils.invoke("preMain", PreMainEntrypoint.class, PreMainEntrypoint::onPreMain);
+		EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
 
 		provider.launch(cl);
 	}

--- a/src/test/java/net/fabricmc/test/TestMod.java
+++ b/src/test/java/net/fabricmc/test/TestMod.java
@@ -17,23 +17,29 @@
 package net.fabricmc.test;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.api.entrypoint.PreMainEntrypoint;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class TestMod implements PreMainEntrypoint, ModInitializer {
+public class TestMod implements PreLaunchEntrypoint, ModInitializer {
 
 	private static final Logger LOGGER = LogManager.getFormatterLogger("TestMod");
 
+	/**
+	 * Entrypoint implementation for preLaunch.
+	 *
+	 * <p>Warning: This should normally be in a separate class from later entrypoints to avoid accidentally loading
+	 * and/or initializing game classes. This is just trivial test code not meant for production use.
+	 */
 	@Override
-	public void onPreMain() {
+	public void onPreLaunch() {
 		if (TestMod.class.getClassLoader() != FabricLauncherBase.getLauncher().getTargetClassLoader()) {
 			throw new IllegalStateException("invalid class loader: "+TestMod.class.getClassLoader());
 		}
 
-		LOGGER.info("In preMain (cl "+TestMod.class.getClassLoader()+")");
+		LOGGER.info("In preLaunch (cl "+TestMod.class.getClassLoader()+")");
 	}
 
 	@Override

--- a/src/test/java/net/fabricmc/test/TestMod.java
+++ b/src/test/java/net/fabricmc/test/TestMod.java
@@ -17,16 +17,31 @@
 package net.fabricmc.test;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.FabricLoader;
+import net.fabricmc.loader.api.entrypoint.PreMainEntrypoint;
+import net.fabricmc.loader.launch.common.FabricLauncherBase;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class TestMod implements ModInitializer {
+public class TestMod implements PreMainEntrypoint, ModInitializer {
 
 	private static final Logger LOGGER = LogManager.getFormatterLogger("TestMod");
 
 	@Override
+	public void onPreMain() {
+		if (TestMod.class.getClassLoader() != FabricLauncherBase.getLauncher().getTargetClassLoader()) {
+			throw new IllegalStateException("invalid class loader: "+TestMod.class.getClassLoader());
+		}
+
+		LOGGER.info("In preMain (cl "+TestMod.class.getClassLoader()+")");
+	}
+
+	@Override
 	public void onInitialize() {
+		if (TestMod.class.getClassLoader() != FabricLauncherBase.getLauncher().getTargetClassLoader()) {
+			throw new IllegalStateException("invalid class loader: "+TestMod.class.getClassLoader());
+		}
+
 		LOGGER.info("**************************");
 		LOGGER.info("Hello from Fabric");
 		LOGGER.info("**************************");

--- a/src/test/resources/fabric.mod.json
+++ b/src/test/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     }
   ],
   "entrypoints": {
-    "preMain": [
+    "preLaunch": [
       "net.fabricmc.test.TestMod"
     ],
     "main": [

--- a/src/test/resources/fabric.mod.json
+++ b/src/test/resources/fabric.mod.json
@@ -1,12 +1,21 @@
 {
+  "schemaVersion": 1,
   "id": "test",
   "name": "Test Mod",
   "version": "1.0.0",
   "side": "client",
-  "mixins": {
-    "client": "fabricmc.test.mixins.client.json"
-  },
-  "initializers": [
-    "net.fabricmc.test.TestMod"
-  ]
+  "mixins": [
+    {
+      "config": "fabricmc.test.mixins.client.json",
+      "environment": "client"
+    }
+  ],
+  "entrypoints": {
+    "preMain": [
+      "net.fabricmc.test.TestMod"
+    ],
+    "main": [
+      "net.fabricmc.test.TestMod"
+    ]
+  }
 }


### PR DESCRIPTION
The normal entrypoints execute fairly late and after MC did a lot of initialization work, which may be too late or less effective for some tasks.

This new preLaunch entrypoint happens when it is already safe to do anything from a class loading or fabric loader POV, but before any MC code executes. As mentioned in the PreLaunchEntrypoint some care has to be taken to not cause undesirable side effects like the static initializer of a MC class assuming some dependency being already initialized.

Language adapter, mod root path and entrypoint initialization had to be moved earlier, I am not aware of any reason why this has to be done late. Some elements were renamed to better reflect their actual purpose and the entry point invocation helper was expanded to remove some duplicated code.