### PR TITLE
Expose VersionParsingException in the API

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
+++ b/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
@@ -17,7 +17,6 @@
 package net.fabricmc.loader.api;
 
 import net.fabricmc.loader.util.version.VersionDeserializer;
-import net.fabricmc.loader.util.version.VersionParsingException;
 
 import java.util.Optional;
 

--- a/src/main/java/net/fabricmc/loader/api/VersionParsingException.java
+++ b/src/main/java/net/fabricmc/loader/api/VersionParsingException.java
@@ -16,12 +16,21 @@
 
 package net.fabricmc.loader.api;
 
-import net.fabricmc.loader.util.version.VersionDeserializer;
+@SuppressWarnings("deprecation") //Extending the deprecated one for backwards compatibility
+public class VersionParsingException extends net.fabricmc.loader.util.version.VersionParsingException {
+	public VersionParsingException() {
+		super();
+	}
 
-public interface Version {
-	String getFriendlyString();
+	public VersionParsingException(Throwable t) {
+		super(t);
+	}
 
-	static Version parse(String string) throws VersionParsingException {
-		return VersionDeserializer.deserialize(string);
+	public VersionParsingException(String s) {
+		super(s);
+	}
+
+	public VersionParsingException(String s, Throwable t) {
+		super(s, t);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
@@ -26,13 +26,13 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.api.metadata.Person;
 import net.fabricmc.loader.util.version.VersionDeserializer;
-import net.fabricmc.loader.util.version.VersionParsingException;
 
 public final class BuiltinModMetadata extends AbstractModMetadata {
 	private final String id;

--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataV1.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataV1.java
@@ -20,10 +20,10 @@ import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.api.metadata.ModDependency;
-import net.fabricmc.loader.util.version.VersionParsingException;
 import net.fabricmc.loader.util.version.VersionPredicateParser;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
+++ b/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
@@ -17,6 +17,7 @@
 package net.fabricmc.loader.util.version;
 
 import net.fabricmc.loader.api.SemanticVersion;
+import net.fabricmc.loader.api.VersionParsingException;
 
 import java.util.Arrays;
 import java.util.Objects;

--- a/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
+++ b/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
@@ -78,9 +78,9 @@ public class SemanticVersionImpl implements SemanticVersion {
 						throw new VersionParsingException("Pre-release versions are not allowed to use X-ranges!");
 					}
 
-					components[i] = Integer.MIN_VALUE;
+					components[i] = COMPONENT_WILDCARD;
 					continue;
-				} else if (i > 0 && components[i - 1] == Integer.MIN_VALUE) {
+				} else if (i > 0 && components[i - 1] == COMPONENT_WILDCARD) {
 					throw new VersionParsingException("Interjacent wildcard (1.x.2) are disallowed!");
 				}
 			}
@@ -99,7 +99,7 @@ public class SemanticVersionImpl implements SemanticVersion {
 			}
 		}
 
-		if (storeX && components.length == 1 && components[0] == Integer.MIN_VALUE) {
+		if (storeX && components.length == 1 && components[0] == COMPONENT_WILDCARD) {
 			throw new VersionParsingException("Versions of form 'x' or 'X' not allowed!");
 		}
 
@@ -117,7 +117,7 @@ public class SemanticVersionImpl implements SemanticVersion {
 				fnBuilder.append('.');
 			}
 
-			if (i == Integer.MIN_VALUE) {
+			if (i == COMPONENT_WILDCARD) {
 				fnBuilder.append('x');
 			} else {
 				fnBuilder.append(i);
@@ -146,7 +146,7 @@ public class SemanticVersionImpl implements SemanticVersion {
 			throw new RuntimeException("Tried to access negative version number component!");
 		} else if (pos >= components.length) {
 			// Repeat "x" if x-range, otherwise repeat "0".
-			return components[components.length - 1] == Integer.MIN_VALUE ? Integer.MIN_VALUE : 0;
+			return components[components.length - 1] == COMPONENT_WILDCARD ? COMPONENT_WILDCARD : 0;
 		} else {
 			return components[pos];
 		}

--- a/src/main/java/net/fabricmc/loader/util/version/SemanticVersionPredicateParser.java
+++ b/src/main/java/net/fabricmc/loader/util/version/SemanticVersionPredicateParser.java
@@ -20,6 +20,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import net.fabricmc.loader.api.VersionParsingException;
+
 public final class SemanticVersionPredicateParser {
 	private static final Map<String, Function<SemanticVersionImpl, Predicate<SemanticVersionImpl>>> PREFIXES;
 

--- a/src/main/java/net/fabricmc/loader/util/version/StringVersionPredicateParser.java
+++ b/src/main/java/net/fabricmc/loader/util/version/StringVersionPredicateParser.java
@@ -18,6 +18,8 @@ package net.fabricmc.loader.util.version;
 
 import java.util.function.Predicate;
 
+import net.fabricmc.loader.api.VersionParsingException;
+
 public final class StringVersionPredicateParser {
 	public static Predicate<StringVersion> create(String text) throws VersionParsingException {
 		final String compared = text.trim();

--- a/src/main/java/net/fabricmc/loader/util/version/VersionDeserializer.java
+++ b/src/main/java/net/fabricmc/loader/util/version/VersionDeserializer.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
 
 import java.lang.reflect.Type;
 

--- a/src/main/java/net/fabricmc/loader/util/version/VersionParsingException.java
+++ b/src/main/java/net/fabricmc/loader/util/version/VersionParsingException.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.loader.util.version;
 
+/** @deprecated Replaced by {@link net.fabricmc.loader.api.VersionParsingException} */
 @Deprecated
 public class VersionParsingException extends Exception {
 	public VersionParsingException() {

--- a/src/main/java/net/fabricmc/loader/util/version/VersionParsingException.java
+++ b/src/main/java/net/fabricmc/loader/util/version/VersionParsingException.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.loader.util.version;
 
+@Deprecated
 public class VersionParsingException extends Exception {
 	public VersionParsingException() {
 		super();

--- a/src/main/java/net/fabricmc/loader/util/version/VersionPredicateParser.java
+++ b/src/main/java/net/fabricmc/loader/util/version/VersionPredicateParser.java
@@ -17,6 +17,7 @@
 package net.fabricmc.loader.util.version;
 
 import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
 
 import java.util.function.Predicate;
 


### PR DESCRIPTION
Both `Version` and `SemanticVersion` have `parse` methods which throw `VersionParsingException` which is checked, forcing an internal loader import (which is discouraged). This moves the exception class into the API so it can be imported from there instead. Should be completely backwards compatible as anything catching the old one will catch the new subclass of it too.