### PR TITLE
catch Throwables instead of just Exceptions during entrypoint loading

### DIFF
--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -136,7 +136,7 @@ class EntrypointStorage {
 			return Collections.emptyList();
 		}
 
-		List<Throwable> throwables = new ArrayList<>();
+		List<Throwable> errors = new ArrayList<>();
 		List<T> results = new ArrayList<>(entries.size());
 		for (Entry entry : entries) {
 			try {
@@ -145,14 +145,14 @@ class EntrypointStorage {
 					results.add(result);
 				}
 			} catch (Throwable t) {
-				throwables.add(t);
+				errors.add(t);
 			}
 		}
 
-		if (!throwables.isEmpty()) {
+		if (!errors.isEmpty()) {
 			EntrypointException e = new EntrypointException("Could not look up entries for entrypoint " + key + "!");
 
-			for (Throwable suppressed : throwables) {
+			for (Throwable suppressed : errors) {
 				e.addSuppressed(suppressed);
 			}
 

--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -136,7 +136,7 @@ class EntrypointStorage {
 			return Collections.emptyList();
 		}
 
-		List<Exception> exceptions = new ArrayList<>();
+		List<Throwable> throwables = new ArrayList<>();
 		List<T> results = new ArrayList<>(entries.size());
 		for (Entry entry : entries) {
 			try {
@@ -144,15 +144,15 @@ class EntrypointStorage {
 				if (result != null) {
 					results.add(result);
 				}
-			} catch (Exception e) {
-				exceptions.add(e);
+			} catch (Throwable t) {
+				throwables.add(t);
 			}
 		}
 
-		if (!exceptions.isEmpty()) {
+		if (!throwables.isEmpty()) {
 			EntrypointException e = new EntrypointException("Could not look up entries for entrypoint " + key + "!");
 
-			for (Exception suppressed : exceptions) {
+			for (Throwable suppressed : throwables) {
 				e.addSuppressed(suppressed);
 			}
 


### PR DESCRIPTION
An up-to-date version of #153's fix for uninformative crashlogs if a throwable that doesn't subclass Exception is thrown during entrypoint loading.