### PR TITLE
Update mixin version to 0.8+build17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	compile 'org.ow2.asm:asm-tree:7.2'
 	compile 'org.ow2.asm:asm-util:7.2'
 
-	compile('net.fabricmc:sponge-mixin:0.8+build.16') {
+	compile('net.fabricmc:sponge-mixin:0.8+build.17') {
 		exclude module: 'launchwrapper'
 		exclude module: 'guava'
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-version = 0.7.2
+version = 0.7.3

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -10,7 +10,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:sponge-mixin:0.8+build.16",
+        "name": "net.fabricmc:sponge-mixin:0.8+build.17",
         "url": "https://maven.fabricmc.net/"
       },
       {

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -13,7 +13,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:sponge-mixin:0.8+build.16",
+        "name": "net.fabricmc:sponge-mixin:0.8+build.17",
         "url": "https://maven.fabricmc.net/"
       },
       {


### PR DESCRIPTION
This is a supplementary PR for https://github.com/FabricMC/Mixin/pull/27.
Updates the mixins version to latest version.

Should fabric-loader's version be bumped with this PR as well (`0.7.2 -> 0.7.3`)?

Also consider:

> Looking at the ASM change for the supported versions, it looks like it now auto detects the correct version, so that shouldnt be an issue. It will still need testing on j8 thought to 14, but that can be done when running with loader.
> 
> _Originally posted by @modmuss50 in https://github.com/FabricMC/Mixin/pull/27#issuecomment-566970798_