### PR TITLE
Fake mod containers

### DIFF
--- a/src/main/java/net/fabricmc/api/FakeModProvider.java
+++ b/src/main/java/net/fabricmc/api/FakeModProvider.java
@@ -1,0 +1,13 @@
+package net.fabricmc.api;
+
+import net.fabricmc.loader.api.ModContainer;
+
+import java.util.Collection;
+
+/**
+ * Hook for adding "fake" mod containers to Loader's list.
+ * Should run <i>after</i> {@link ModInitializer#onInitialize()}
+ */
+public interface FakeModProvider {
+	Collection<ModContainer> getFakeMods();
+}

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -65,6 +65,8 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 
 	protected final Map<String, ModContainer> modMap = new HashMap<>();
 	protected List<ModContainer> mods = new ArrayList<>();
+	protected final Map<String, ModContainer> fakeModMap = new HashMap<>();
+	protected List<net.fabricmc.loader.api.ModContainer> fakeMods = new ArrayList<>();
 
 	private final Map<String, LanguageAdapter> adapterMap = new HashMap<>();
 	private final EntrypointStorage entrypointStorage = new EntrypointStorage();
@@ -243,6 +245,11 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	}
 
 	@Override
+	public Collection<net.fabricmc.loader.api.ModContainer> getFakeMods() {
+		return Collections.unmodifiableList(mods);
+	}
+
+	@Override
 	public boolean isModLoaded(String id) {
 		return modMap.containsKey(id);
 	}
@@ -414,6 +421,10 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		} else {
 			setGameDir(newRunDir);
 		}
+	}
+
+	public void appendFakeMods(Collection<net.fabricmc.loader.api.ModContainer> mods) {
+		fakeMods.addAll(mods);
 	}
 
 	public Logger getLogger() {

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -60,6 +60,12 @@ public interface FabricLoader {
 	Collection<ModContainer> getAllMods();
 
 	/**
+	 * Gets all mod containers added through {@link net.fabricmc.api.FakeModProvider}s.
+	 * @return A collection of all added fake mod containers.
+	 */
+	Collection<ModContainer> getFakeMods();
+
+	/**
 	 * Checks if a mod with a given ID is loaded.
 	 * @param id The ID of the mod, as defined in fabric.mod.json.
 	 * @return Whether or not the mod is present in this FabricLoader instance.

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointClient.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointClient.java
@@ -17,6 +17,7 @@
 package net.fabricmc.loader.entrypoint.minecraft.hooks;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.api.FakeModProvider;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.FabricLoader;
 
@@ -30,6 +31,7 @@ public final class EntrypointClient {
 
 		FabricLoader.INSTANCE.prepareModInit(runDir, gameInstance);
 		EntrypointUtils.invoke("main", ModInitializer.class, ModInitializer::onInitialize);
+		FabricLoader.INSTANCE.getEntrypoints("fake_mods", FakeModProvider.class).forEach(provider -> FabricLoader.INSTANCE.appendFakeMods(provider.getFakeMods()));
 		EntrypointUtils.invoke("client", ClientModInitializer.class, ClientModInitializer::onInitializeClient);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointServer.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointServer.java
@@ -17,6 +17,7 @@
 package net.fabricmc.loader.entrypoint.minecraft.hooks;
 
 import net.fabricmc.api.DedicatedServerModInitializer;
+import net.fabricmc.api.FakeModProvider;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.FabricLoader;
 
@@ -30,6 +31,7 @@ public final class EntrypointServer {
 
 		FabricLoader.INSTANCE.prepareModInit(runDir, gameInstance);
 		EntrypointUtils.invoke("main", ModInitializer.class, ModInitializer::onInitialize);
+		FabricLoader.INSTANCE.getEntrypoints("fake_mods", FakeModProvider.class).forEach(provider -> FabricLoader.INSTANCE.appendFakeMods(provider.getFakeMods()));
 		EntrypointUtils.invoke("server", DedicatedServerModInitializer.class, DedicatedServerModInitializer::onInitializeServer);
 	}
 }


### PR DESCRIPTION
Mainly intended as a conversation starter, absolutely not merge-ready

Adds a system for adding "fake" mods which exist primarily as metadata storage and do not have any entrypoints called or mixins applied. Intended for systems which want to add "mods" as metadta for systems like Mod Menu to access. Possibly not helpful in the first place.

Currently runs the `fake_mods` entrypoint right after `main` is run. No system is yet provided for removing fake mods or calling after mods are loaded.