### PR TITLE
Update asm to 7.3.1 for java 15 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 	id 'idea'
 	id 'eclipse'
-	id("fabric-loom") version "0.2.3-SNAPSHOT"
+	id("fabric-loom") version "0.2.6-SNAPSHOT"
 }
 
 sourceCompatibility = 1.8
@@ -45,11 +45,11 @@ dependencies {
 	compile 'com.google.code.findbugs:jsr305:3.0.2'
 
 	// fabric-loader dependencies
-	compile 'org.ow2.asm:asm:7.2'
-	compile 'org.ow2.asm:asm-analysis:7.2'
-	compile 'org.ow2.asm:asm-commons:7.2'
-	compile 'org.ow2.asm:asm-tree:7.2'
-	compile 'org.ow2.asm:asm-util:7.2'
+	compile 'org.ow2.asm:asm:7.3.1'
+	compile 'org.ow2.asm:asm-analysis:7.3.1'
+	compile 'org.ow2.asm:asm-commons:7.3.1'
+	compile 'org.ow2.asm:asm-tree:7.3.1'
+	compile 'org.ow2.asm:asm-util:7.3.1'
 
 	compile('net.fabricmc:sponge-mixin:0.8+build.18') {
 		exclude module: 'launchwrapper'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-version = 0.7.4
+version = 0.7.5

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -26,23 +26,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:7.2",
+        "name": "org.ow2.asm:asm:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:7.2",
+        "name": "org.ow2.asm:asm-analysis:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:7.2",
+        "name": "org.ow2.asm:asm-commons:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:7.2",
+        "name": "org.ow2.asm:asm-tree:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:7.2",
+        "name": "org.ow2.asm:asm-util:7.3.1",
         "url": "https://maven.fabricmc.net/"
       }
     ],

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -29,23 +29,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:7.2",
+        "name": "org.ow2.asm:asm:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:7.2",
+        "name": "org.ow2.asm:asm-analysis:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:7.2",
+        "name": "org.ow2.asm:asm-commons:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:7.2",
+        "name": "org.ow2.asm:asm-tree:7.3.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:7.2",
+        "name": "org.ow2.asm:asm-util:7.3.1",
         "url": "https://maven.fabricmc.net/"
       }
     ],


### PR DESCRIPTION
ASM 7.3 seems to have added support for Java 14's records, as far I can can see tiny remapper may need to handle these. As records are still a preview feature I dont think it is a high priority issue. I have included some links bellow with more info

- [Merge branch 'asm8-record' into 'master'](https://gitlab.ow2.org/asm/asm/commit/db802e6eb64784567b81277f28734421b9dc878e)

- [JEP 359: Records (Preview)](https://openjdk.java.net/jeps/359)

Updating ASM should be fairly safe, I have tested on j8 and j15 with fabric api. Mixin no longer has a set list of supported ASM version so that does not need to be updated.

I have also bumped the loom version, as loader was using a very old version, at somepoint we can evaluate the use of loom for loader see (#161).