### PR TITLE
Finish off the package defining in Knot's class loaders.

### DIFF
--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotClassLoader.java
@@ -159,16 +159,16 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 									URL source = realMeta == null ? null : realMeta.codeSource.getLocation();
 									throw new SecurityException("Cannot load the class " + name + " from "
 										+ ModResolver.describeRealLocation(metadata.codeSource.getLocation())
-										+ " because it's package has already been loaded (and sealed) from "
+										+ " because its package has already been loaded (and sealed) from "
 										+ ModResolver.describeRealLocation(source));
 								}
 							} else if (metadata.isPackageSealed(pkgName)) {
 								KnotClassDelegate.Metadata realMeta = delegate.packages.get(currentPackage);
 								URL source = realMeta == null ? null : realMeta.codeSource.getLocation();
 								throw new SecurityException("Cannot load the class " + name
-									+ " (and seal it's package) from "
+									+ " (and seal its package) from "
 									+ ModResolver.describeRealLocation(metadata.codeSource.getLocation())
-									+ " because it's package has already been loaded (but not sealed) from"
+									+ " because its package has already been loaded (but not sealed) from"
 									+ ModResolver.describeRealLocation(source));
 							}
 						} else {

--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotCompatibilityClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotCompatibilityClassLoader.java
@@ -69,16 +69,16 @@ class KnotCompatibilityClassLoader extends URLClassLoader implements KnotClassLo
 									URL source = realMeta == null ? null : realMeta.codeSource.getLocation();
 									throw new SecurityException("Cannot load the class " + name + " from "
 										+ ModResolver.describeRealLocation(metadata.codeSource.getLocation())
-										+ " because it's package has already been loaded (and sealed) from "
+										+ " because its package has already been loaded (and sealed) from "
 										+ ModResolver.describeRealLocation(source));
 								}
 							} else if (metadata.isPackageSealed(pkgName)) {
 								KnotClassDelegate.Metadata realMeta = delegate.packages.get(currentPackage);
 								URL source = realMeta == null ? null : realMeta.codeSource.getLocation();
 								throw new SecurityException("Cannot load the class " + name
-									+ " (and seal it's package) from "
+									+ " (and seal its package) from "
 									+ ModResolver.describeRealLocation(metadata.codeSource.getLocation())
-									+ " because it's package has already been loaded (but not sealed) from"
+									+ " because its package has already been loaded (but not sealed) from"
 									+ ModResolver.describeRealLocation(source));
 							}
 						} else {


### PR DESCRIPTION
This primarily implements [package sealing](https://docs.oracle.com/javase/tutorial/deployment/jar/sealman.html).

(As well as [package version information](https://docs.oracle.com/javase/tutorial/deployment/jar/packageman.html), but those are less likely to be useful).

### Motivation
I'm looking into making a "flattened fat jar" available for LBA ([LibBlockAttributes](https://github.com/AlexIIL/LibBlockAttributes)) to make it quicker to browse it's sources inside of an IDE, as looking in 3 separate jars is a bit more annoying than 1 big one.

While this isn't intended for end-users to use (and LBA will have tests to make sure the fat jar is only used in a development environment) it doesn't stop people from accidentally adding a newer version of the modular variants, which could cause issues. For example if a new class is added which requires methods not present in an older version of a previously existing class, and the older fat jar is added to the classpath first, then the new class will throw an unhelpful `NoSuchMethodError` sometime later. (This happened before: when I first split LBA up into modules some mods used to ship the entire old jar - which caused difficult to debug errors). While this PR doesn't fully address the problem, it does help quite a lot for mods that tend to stick in a small number of packages.

In addition this removes a `TODO` from the code - and sealed packages are part of the jar spec, even if very few mods actually wish to use this. 

(In the future I'd also like to make a "flattened fat jar" variant of buildcraft for the same reasons, as buildcraft is likely to end up with about ~45 modules rather than just 3. This is mostly because all of the API's will likely get their own individual jar, and that's a much more significant pain than LBA's 3, or even fabric-api's ~28).

### Unnecessary Changes

All of the changes to `ModResolver` were made purely to allow the real file system location of every mod jar to be described in the error message - as otherwise informing the user that `jimfs://nestedJarStore/450bfac0-82e9-4ce6-932d-dda012249a67.jar` and `jimfs://nestedJarStore/cdce0e44-b625-4dd9-8d7d-31c8118dd0fc.jar` contain the same sealed package isn't very useful.

(However as the additional text isn't strictly necessary I'd be happy to remove those changes).

### Potential problems

This won't affect any mod that doesn't seal it's packages - which seems unlikely to be used considering it wasn't implemented before now. In addition when I loaded AOF 2 none of the mods defined any packages as "sealed".

This might affect any mod that uses another mods package as a way to access package-private members of the target mod (and if the target mod adds `Sealed` to it's manifest), however as that's a bit of a hack (and mixin's can be used instead if desired) I don't think this would be an issue.

### Notes

While this is primarily intended to help ship fat jars for libs+mods, it doesn't solve any of the much larger problems that making a fabric-api fat jar has. (However to allow it properly then loader would have to be changed to support "multiple mods in a single jar", and then only allow loading all of them, or none of them from that jar, which seems to be against many people's wishes).

(In addition fat jars tend to be *bigger* than their modular conterparts - likely due to zip compression applying to files individually, rather than to the zip as a whole - which make using them more then necessary undesirable).

### Extensions

Technically just sealing singular packages isn't enough to guarantee that loading the wrong classes will fail quickly - ideally we may want to seal an entire mod, to ensure that all of it's packages are loaded from the same URL. However that would require defining additional manifest entries, and isn't covered by the jar spec so that would have to be discussed separately. (Although I quite like the idea).