### PR TITLE
Add Documented to Environment* annotations

### DIFF
--- a/src/main/java/net/fabricmc/api/Environment.java
+++ b/src/main/java/net/fabricmc/api/Environment.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.api;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -28,6 +29,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR })
+@Documented
 public @interface Environment {
 	EnvType value();
 }

--- a/src/main/java/net/fabricmc/api/EnvironmentInterface.java
+++ b/src/main/java/net/fabricmc/api/EnvironmentInterface.java
@@ -26,6 +26,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.CLASS)
 @Repeatable(EnvironmentInterfaces.class)
 @Target(ElementType.TYPE)
+@Documented
 public @interface EnvironmentInterface {
 	EnvType value();
 	Class<?> itf();

--- a/src/main/java/net/fabricmc/api/EnvironmentInterfaces.java
+++ b/src/main/java/net/fabricmc/api/EnvironmentInterfaces.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.api;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -28,6 +29,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
+@Documented
 public @interface EnvironmentInterfaces {
 	EnvironmentInterface[] value();
 }


### PR DESCRIPTION
This makes them show up in javadocs, and it's useful to know when a class or a method is environment-only.