### PR TITLE
Remove uses of Guava

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
@@ -16,11 +16,7 @@
 
 package net.fabricmc.loader.discovery;
 
-import com.google.common.base.Joiner;
-import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.metadata.ModMetadata;
-
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -80,11 +76,11 @@ public class ModCandidateSet {
 
 	public Collection<ModCandidate> toSortedSet() throws ModResolutionException {
 		if (depthZeroCandidates.size() > 1) {
-			Set<String> modVersionStrings = depthZeroCandidates.stream()
+			String modVersions = depthZeroCandidates.stream()
 				.map((c) -> "[" + c.getInfo().getVersion() + " at " + c.getOriginUrl().getFile() + "]")
-				.collect(Collectors.toSet());
+				.collect(Collectors.joining(", "));
 
-			throw new ModResolutionException("Duplicate versions for mod ID '" + modId + "': " + Joiner.on(", ").join(modVersionStrings));
+			throw new ModResolutionException("Duplicate versions for mod ID '" + modId + "': " + modVersions);
 		} else if (depthZeroCandidates.size() == 1) {
 			return depthZeroCandidates;
 		} else if (candidates.size() > 1) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -252,7 +252,7 @@ public class ModResolver {
 		StringBuilder errorsSoft = new StringBuilder();
 
 		if (!missingMods.isEmpty()) {
-			errorsHard.append("\n - Missing mods: ").append(missingMods.stream().collect(Collectors.joining(", ")));
+			errorsHard.append("\n - Missing mods: ").append(String.join(", ", missingMods));
 		} else {
 			// verify result: dependencies
 			for (ModCandidate candidate : result.values()) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.discovery;
 
-import com.google.common.base.Joiner;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.google.common.jimfs.PathType;
@@ -253,7 +252,7 @@ public class ModResolver {
 		StringBuilder errorsSoft = new StringBuilder();
 
 		if (!missingMods.isEmpty()) {
-			errorsHard.append("\n - Missing mods: ").append(Joiner.on(", ").join(missingMods));
+			errorsHard.append("\n - Missing mods: ").append(missingMods.stream().collect(Collectors.joining(", ")));
 		} else {
 			// verify result: dependencies
 			for (ModCandidate candidate : result.values()) {

--- a/src/main/java/net/fabricmc/loader/entrypoint/EntrypointTransformer.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/EntrypointTransformer.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.entrypoint;
 
-import com.google.common.collect.ImmutableList;
 import net.fabricmc.loader.launch.common.FabricLauncher;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,7 +38,7 @@ public class EntrypointTransformer {
 	private boolean entrypointsLocated = false;
 
 	public EntrypointTransformer(Function<EntrypointTransformer, List<EntrypointPatch>> patches) {
-		this.patches = ImmutableList.copyOf(patches.apply(this));
+		this.patches = patches.apply(this);
 	}
 
 	ClassNode loadClass(FabricLauncher launcher, String className) throws IOException {

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchBranding.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchBranding.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.entrypoint.minecraft;
 
-import com.google.common.collect.ImmutableList;
 import net.fabricmc.loader.entrypoint.EntrypointPatch;
 import net.fabricmc.loader.entrypoint.EntrypointTransformer;
 import net.fabricmc.loader.launch.common.FabricLauncher;
@@ -37,10 +36,10 @@ public final class EntrypointPatchBranding extends EntrypointPatch {
 
 	@Override
 	public void process(FabricLauncher launcher, Consumer<ClassNode> classEmitter) {
-		for (String brandClassName : ImmutableList.of(
+		for (String brandClassName : new String[] {
 			"net.minecraft.client.ClientBrandRetriever",
 			"net.minecraft.server.MinecraftServer"
-		)) {
+		}) {
 			try {
 				ClassNode brandClass = loadClass(launcher, brandClassName);
 				if (brandClass != null) {

--- a/src/main/java/net/fabricmc/loader/game/GameProviders.java
+++ b/src/main/java/net/fabricmc/loader/game/GameProviders.java
@@ -16,13 +16,13 @@
 
 package net.fabricmc.loader.game;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public final class GameProviders {
 	private GameProviders() { }
 
 	public static List<GameProvider> create() {
-		return Arrays.asList(new MinecraftGameProvider());
+		return Collections.singletonList(new MinecraftGameProvider());
 	}
 }

--- a/src/main/java/net/fabricmc/loader/game/GameProviders.java
+++ b/src/main/java/net/fabricmc/loader/game/GameProviders.java
@@ -16,14 +16,13 @@
 
 package net.fabricmc.loader.game;
 
-import com.google.common.collect.ImmutableList;
-
+import java.util.Arrays;
 import java.util.List;
 
 public final class GameProviders {
 	private GameProviders() { }
 
 	public static List<GameProvider> create() {
-		return ImmutableList.of(new MinecraftGameProvider());
+		return Arrays.asList(new MinecraftGameProvider());
 	}
 }

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.game;
 
-import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.entrypoint.EntrypointTransformer;
@@ -132,9 +131,9 @@ public class MinecraftGameProvider implements GameProvider {
 		List<String> entrypointClasses;
 
 		if (envType == EnvType.CLIENT) {
-			entrypointClasses = Lists.newArrayList("net.minecraft.client.main.Main", "net.minecraft.client.MinecraftApplet", "com.mojang.minecraft.MinecraftApplet");
+			entrypointClasses = Arrays.asList("net.minecraft.client.main.Main", "net.minecraft.client.MinecraftApplet", "com.mojang.minecraft.MinecraftApplet");
 		} else {
-			entrypointClasses = Lists.newArrayList("net.minecraft.server.MinecraftServer", "com.mojang.minecraft.server.MinecraftServer");
+			entrypointClasses = Arrays.asList("net.minecraft.server.MinecraftServer", "com.mojang.minecraft.server.MinecraftServer");
 		}
 
 		Optional<GameProviderHelper.EntrypointResult> entrypointResult = GameProviderHelper.findFirstClass(loader, entrypointClasses);

--- a/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.loader.launch.knot;
 
-import com.google.common.collect.ImmutableList;
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.tree.ClassNode;
@@ -31,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -156,7 +155,7 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 
 	@Override
 	public Collection<String> getPlatformAgents() {
-		return ImmutableList.of("org.spongepowered.asm.launch.platform.MixinPlatformAgentDefault");
+		return Arrays.asList("org.spongepowered.asm.launch.platform.MixinPlatformAgentDefault");
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -155,7 +154,7 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 
 	@Override
 	public Collection<String> getPlatformAgents() {
-		return Arrays.asList("org.spongepowered.asm.launch.platform.MixinPlatformAgentDefault");
+		return Collections.singletonList("org.spongepowered.asm.launch.platform.MixinPlatformAgentDefault");
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataV0.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataV0.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.loader.metadata;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import com.google.gson.*;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.metadata.ContactInformation;
@@ -30,6 +28,8 @@ import java.lang.reflect.Type;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Definition class for "fabric.mod.json" files.
@@ -335,7 +335,7 @@ public class ModMetadataV0 extends AbstractModMetadata implements LoaderModMetad
 							} else if (matchers.length == 1) {
 								return getModId() + " @ " + matchers[0];
 							} else {
-								return getModId() + " @ [" + Joiner.on(", ").join(Arrays.asList(matchers)) + "]";
+								return getModId() + " @ [" + Stream.of(matchers).collect(Collectors.joining(", ")) + "]";
 							}
 						}
 					});
@@ -382,7 +382,7 @@ public class ModMetadataV0 extends AbstractModMetadata implements LoaderModMetad
 
 		@Override
 		public String toString() {
-			return "[" + Joiner.on(", ").join(versionMatchers) + "]";
+			return "[" + Stream.of(versionMatchers).collect(Collectors.joining(", ")) + "]";
 		}
 
 		public static class Deserializer implements JsonDeserializer<Dependency> {
@@ -470,20 +470,20 @@ public class ModMetadataV0 extends AbstractModMetadata implements LoaderModMetad
 			public Person deserialize(JsonElement element, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
 				if (element.isJsonPrimitive()) {
 					String person = element.getAsString();
-					List<String> parts = Lists.newArrayList(person.split(" "));
+					String[] parts = person.split(" ");
 
 					String name, email = "", website = "";
 
-					Matcher websiteMatcher = WEBSITE_PATTERN.matcher(parts.get(parts.size() - 1));
+					Matcher websiteMatcher = WEBSITE_PATTERN.matcher(parts[parts.length - 1]);
 					if (websiteMatcher.matches()) {
 						website = websiteMatcher.group(1);
-						parts.remove(parts.size() - 1);
+						parts = Arrays.copyOf(parts, parts.length - 1);
 					}
 
-					Matcher emailMatcher = EMAIL_PATTERN.matcher(parts.get(parts.size() - 1));
+					Matcher emailMatcher = EMAIL_PATTERN.matcher(parts[parts.length - 1]);
 					if (emailMatcher.matches()) {
 						email = emailMatcher.group(1);
-						parts.remove(parts.size() - 1);
+						parts = Arrays.copyOf(parts, parts.length - 1);
 					}
 
 					name = String.join(" ", parts);

--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataV0.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataV0.java
@@ -28,8 +28,6 @@ import java.lang.reflect.Type;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Definition class for "fabric.mod.json" files.
@@ -335,7 +333,7 @@ public class ModMetadataV0 extends AbstractModMetadata implements LoaderModMetad
 							} else if (matchers.length == 1) {
 								return getModId() + " @ " + matchers[0];
 							} else {
-								return getModId() + " @ [" + Stream.of(matchers).collect(Collectors.joining(", ")) + "]";
+								return getModId() + " @ "+Arrays.toString(matchers);
 							}
 						}
 					});
@@ -382,7 +380,7 @@ public class ModMetadataV0 extends AbstractModMetadata implements LoaderModMetad
 
 		@Override
 		public String toString() {
-			return "[" + Stream.of(versionMatchers).collect(Collectors.joining(", ")) + "]";
+			return Arrays.toString(versionMatchers);
 		}
 
 		public static class Deserializer implements JsonDeserializer<Dependency> {


### PR DESCRIPTION
Minimally invasive removal of Guava uses, part of the dependency stripping efforts to avoid conflicts with the game and load order sensitivity.