### PR TITLE
Add methods to get the ModContainer which as provided an entrypoint

### DIFF
--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -146,7 +146,6 @@ class EntrypointStorage {
 
 	protected <T> List<T> getEntrypoints(String key, Class<T> type) {
 		List<Entry> entries = entryMap.get(key);
-
 		if (entries == null) return Collections.emptyList();
 
 		EntrypointException exception = null;
@@ -177,7 +176,6 @@ class EntrypointStorage {
 
 	protected <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
 		List<Entry> entries = entryMap.get(key);
-
 		if (entries == null) return Collections.emptyList();
 
 		EntrypointException exception = null;

--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -181,7 +181,7 @@ class EntrypointStorage {
 		}
 	}
 
-	protected <T> Collection<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
+	protected <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
 		List<Entry> entries = entryMap.get(key);
 		if (entries == null) {
 			return Collections.emptyList();

--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -146,15 +146,16 @@ class EntrypointStorage {
 
 	protected <T> List<T> getEntrypoints(String key, Class<T> type) {
 		List<Entry> entries = entryMap.get(key);
-		if (entries == null) {
-			return Collections.emptyList();
-		}
+
+		if (entries == null) return Collections.emptyList();
 
 		EntrypointException exception = null;
 		List<T> results = new ArrayList<>(entries.size());
+
 		for (Entry entry : entries) {
 			try {
 				T result = entry.getOrCreate(type);
+
 				if (result != null) {
 					results.add(result);
 				}
@@ -176,15 +177,16 @@ class EntrypointStorage {
 
 	protected <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
 		List<Entry> entries = entryMap.get(key);
-		if (entries == null) {
-			return Collections.emptyList();
-		}
+
+		if (entries == null) return Collections.emptyList();
 
 		EntrypointException exception = null;
 		List<EntrypointContainer<T>> results = new ArrayList<>(entries.size());
+
 		for (Entry entry : entries) {
 			try {
 				T result = entry.getOrCreate(type);
+
 				if (result != null) {
 					results.add(new EntrypointContainerImpl<>(entry.getModContainer(), result));
 				}

--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -21,6 +21,8 @@ import net.fabricmc.loader.ModContainer;
 import net.fabricmc.loader.api.EntrypointException;
 import net.fabricmc.loader.api.LanguageAdapter;
 import net.fabricmc.loader.api.LanguageAdapterException;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+import net.fabricmc.loader.entrypoint.EntrypointContainerImpl;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.metadata.EntrypointMetadata;
 
@@ -29,6 +31,8 @@ import java.util.*;
 class EntrypointStorage {
 	interface Entry {
 		<T> T getOrCreate(Class<T> type) throws Exception;
+
+		ModContainer getModContainer();
 	}
 
 	private static class OldEntry implements Entry {
@@ -66,6 +70,11 @@ class EntrypointStorage {
 				return (T) object;
 			}
 		}
+
+		@Override
+		public ModContainer getModContainer() {
+			return mod;
+		}
 	}
 
 	private static class NewEntry implements Entry {
@@ -94,6 +103,11 @@ class EntrypointStorage {
 			}
 			//noinspection unchecked
 			return (T) o;
+		}
+
+		@Override
+		public ModContainer getModContainer() {
+			return mod;
 		}
 
 		private <T> T create(Class<T> type) throws Exception {
@@ -136,6 +150,7 @@ class EntrypointStorage {
 			return Collections.emptyList();
 		}
 
+		ModContainer rootErrorCause = null;
 		List<Throwable> errors = new ArrayList<>();
 		List<T> results = new ArrayList<>(entries.size());
 		for (Entry entry : entries) {
@@ -145,13 +160,54 @@ class EntrypointStorage {
 					results.add(result);
 				}
 			} catch (Throwable t) {
+				if (errors.isEmpty()) {
+					rootErrorCause = entry.getModContainer();
+				}
 				errors.add(t);
 			}
 		}
 
 		if (!errors.isEmpty()) {
 			Iterator<Throwable> it = errors.iterator();
-			EntrypointException e = new EntrypointException(key, it.next());
+			EntrypointException e = new EntrypointException(key, rootErrorCause.getMetadata().getId(), it.next());
+
+			while (it.hasNext()) {
+				e.addSuppressed(it.next());
+			}
+
+			throw e;
+		} else {
+			return results;
+		}
+	}
+
+	protected <T> Collection<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
+		List<Entry> entries = entryMap.get(key);
+		if (entries == null) {
+			return Collections.emptyList();
+		}
+
+		ModContainer rootErrorCause = null;
+		List<Throwable> errors = new ArrayList<>();
+		List<EntrypointContainer<T>> results = new ArrayList<>(entries.size());
+		for (Entry entry : entries) {
+			try {
+				T result = entry.getOrCreate(type);
+				if (result != null) {
+					results.add(new EntrypointContainerImpl<>(entry.getModContainer(), result));
+				}
+			} catch (Throwable t) {
+				if (errors.isEmpty()) {
+					rootErrorCause = entry.getModContainer();
+				}
+
+				errors.add(t);
+			}
+		}
+
+		if (!errors.isEmpty()) {
+			Iterator<Throwable> it = errors.iterator();
+			EntrypointException e = new EntrypointException(key, rootErrorCause.getMetadata().getId(), it.next());
 
 			while (it.hasNext()) {
 				e.addSuppressed(it.next());

--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -150,8 +150,7 @@ class EntrypointStorage {
 			return Collections.emptyList();
 		}
 
-		ModContainer rootErrorCause = null;
-		List<Throwable> errors = new ArrayList<>();
+		EntrypointException exception = null;
 		List<T> results = new ArrayList<>(entries.size());
 		for (Entry entry : entries) {
 			try {
@@ -160,25 +159,19 @@ class EntrypointStorage {
 					results.add(result);
 				}
 			} catch (Throwable t) {
-				if (errors.isEmpty()) {
-					rootErrorCause = entry.getModContainer();
+				if (exception == null) {
+					exception = new EntrypointException(key, entry.getModContainer().getMetadata().getId(), t);
+				} else {
+					exception.addSuppressed(t);
 				}
-				errors.add(t);
 			}
 		}
 
-		if (!errors.isEmpty()) {
-			Iterator<Throwable> it = errors.iterator();
-			EntrypointException e = new EntrypointException(key, rootErrorCause.getMetadata().getId(), it.next());
-
-			while (it.hasNext()) {
-				e.addSuppressed(it.next());
-			}
-
-			throw e;
-		} else {
-			return results;
+		if (exception != null) {
+			throw exception;
 		}
+
+		return results;
 	}
 
 	protected <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
@@ -187,8 +180,7 @@ class EntrypointStorage {
 			return Collections.emptyList();
 		}
 
-		ModContainer rootErrorCause = null;
-		List<Throwable> errors = new ArrayList<>();
+		EntrypointException exception = null;
 		List<EntrypointContainer<T>> results = new ArrayList<>(entries.size());
 		for (Entry entry : entries) {
 			try {
@@ -197,25 +189,18 @@ class EntrypointStorage {
 					results.add(new EntrypointContainerImpl<>(entry.getModContainer(), result));
 				}
 			} catch (Throwable t) {
-				if (errors.isEmpty()) {
-					rootErrorCause = entry.getModContainer();
+				if (exception == null) {
+					exception = new EntrypointException(key, entry.getModContainer().getMetadata().getId(), t);
+				} else {
+					exception.addSuppressed(t);
 				}
-
-				errors.add(t);
 			}
 		}
 
-		if (!errors.isEmpty()) {
-			Iterator<Throwable> it = errors.iterator();
-			EntrypointException e = new EntrypointException(key, rootErrorCause.getMetadata().getId(), it.next());
-
-			while (it.hasNext()) {
-				e.addSuppressed(it.next());
-			}
-
-			throw e;
-		} else {
-			return results;
+		if (exception != null) {
+			throw exception;
 		}
+
+		return results;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -218,6 +219,11 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	@Override
 	public <T> List<T> getEntrypoints(String key, Class<T> type) {
 		return entrypointStorage.getEntrypoints(key, type);
+	}
+
+	@Override
+	public <T> Collection<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
+		return entrypointStorage.getEntrypointContainers(key, type);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -222,7 +222,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	}
 
 	@Override
-	public <T> Collection<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
+	public <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
 		return entrypointStorage.getEntrypointContainers(key, type);
 	}
 

--- a/src/main/java/net/fabricmc/loader/api/EntrypointException.java
+++ b/src/main/java/net/fabricmc/loader/api/EntrypointException.java
@@ -24,13 +24,14 @@ public class EntrypointException extends RuntimeException {
 	 */
 	@Deprecated
 	public EntrypointException(String key, Throwable cause) {
-		super("Exception while loading entries for entrypoint " + key + "!", cause);
+		super("Exception while loading entries for entrypoint '" + key + "'!", cause);
 		this.key = key;
 	}
 
 	/**
 	 * @deprecated For internal use only, use regular exceptions!
 	 */
+	@Deprecated
 	public EntrypointException(String key, String causeModid, Throwable cause) {
 		super("Exception while loading entries for entrypoint '" + key + "' provided by '" + causeModid + "'", cause);
 		this.key = key;

--- a/src/main/java/net/fabricmc/loader/api/EntrypointException.java
+++ b/src/main/java/net/fabricmc/loader/api/EntrypointException.java
@@ -20,7 +20,7 @@ public class EntrypointException extends RuntimeException {
 	private final String key;
 
 	/**
-	 * @deprecated For internal use only, use regular exceptions!
+	 * @deprecated For internal use only, to be removed!
 	 */
 	@Deprecated
 	public EntrypointException(String key, Throwable cause) {
@@ -32,8 +32,8 @@ public class EntrypointException extends RuntimeException {
 	 * @deprecated For internal use only, use regular exceptions!
 	 */
 	@Deprecated
-	public EntrypointException(String key, String causeModid, Throwable cause) {
-		super("Exception while loading entries for entrypoint '" + key + "' provided by '" + causeModid + "'", cause);
+	public EntrypointException(String key, String causingMod, Throwable cause) {
+		super("Exception while loading entries for entrypoint '" + key + "' provided by '" + causingMod + "'", cause);
 		this.key = key;
 	}
 

--- a/src/main/java/net/fabricmc/loader/api/EntrypointException.java
+++ b/src/main/java/net/fabricmc/loader/api/EntrypointException.java
@@ -29,6 +29,14 @@ public class EntrypointException extends RuntimeException {
 	}
 
 	/**
+	 * @deprecated For internal use only, use regular exceptions!
+	 */
+	public EntrypointException(String key, String causeModid, Throwable cause) {
+		super("Exception while loading entries for entrypoint '" + key + "' provided by '" + causeModid + "'", cause);
+		this.key = key;
+	}
+
+	/**
 	 * @deprecated For internal use only, to be removed!
 	 */
 	@Deprecated

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -17,6 +17,7 @@
 package net.fabricmc.loader.api;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 
 import java.io.File;
 import java.util.Collection;
@@ -38,6 +39,8 @@ public interface FabricLoader {
 	}
 
 	<T> List<T> getEntrypoints(String key, Class<T> type);
+
+	<T> Collection<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type);
 
 	/**
 	 * Get the current mapping resolver.

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -40,7 +40,7 @@ public interface FabricLoader {
 
 	<T> List<T> getEntrypoints(String key, Class<T> type);
 
-	<T> Collection<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type);
+	<T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type);
 
 	/**
 	 * Get the current mapping resolver.

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
@@ -21,5 +21,5 @@ import net.fabricmc.loader.api.ModContainer;
 public interface EntrypointContainer<T> {
 	T getEntrypoint();
 
-	ModContainer getProvidingModContainer();
+	ModContainer getProvider();
 }

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.api.entrypoint;
+
+import net.fabricmc.loader.api.ModContainer;
+
+public interface EntrypointContainer<T> {
+	T getEntrypoint();
+
+	ModContainer getProvidingModContainer();
+}

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
@@ -18,8 +18,20 @@ package net.fabricmc.loader.api.entrypoint;
 
 import net.fabricmc.loader.api.ModContainer;
 
+/**
+ * Represents a container which holds both an entrypoint instance and the {@link ModContainer} which has provided the entrypoint,
+ * @param <T> The type of the entrypoint
+ */
 public interface EntrypointContainer<T> {
+	/**
+	 * Gets the entrypoint.
+	 * @return An entrypoint instance.
+	 */
 	T getEntrypoint();
 
+	/**
+	 * Gets the mod which has provided this entrypoint.
+	 * @return The mod which as provided this entrypoint.
+	 */
 	ModContainer getProvider();
 }

--- a/src/main/java/net/fabricmc/loader/entrypoint/EntrypointContainerImpl.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/EntrypointContainerImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.entrypoint;
+
+import net.fabricmc.loader.ModContainer;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+
+public class EntrypointContainerImpl<T> implements EntrypointContainer<T> {
+	private final ModContainer container;
+	private final T entrypoint;
+
+	public EntrypointContainerImpl(ModContainer container, T entrypoint) {
+		this.container = container;
+		this.entrypoint = entrypoint;
+	}
+
+	@Override
+	public T getEntrypoint() {
+		return entrypoint;
+	}
+
+	@Override
+	public ModContainer getProvidingModContainer() {
+		return container;
+	}
+}

--- a/src/main/java/net/fabricmc/loader/entrypoint/EntrypointContainerImpl.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/EntrypointContainerImpl.java
@@ -34,7 +34,7 @@ public class EntrypointContainerImpl<T> implements EntrypointContainer<T> {
 	}
 
 	@Override
-	public ModContainer getProvidingModContainer() {
+	public ModContainer getProvider() {
 		return container;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
@@ -51,7 +51,7 @@ public final class EntrypointUtils {
 				invoker.accept(container.getEntrypoint());
 			} catch (Throwable t) {
 				if (errors.isEmpty()) {
-					rootErrorCause = container.getProvidingModContainer();
+					rootErrorCause = container.getProvider();
 				}
 
 				errors.add(t);


### PR DESCRIPTION
This is for #199 

This adds a getEntrypointProvider(Object) method which optionally returns the mod container the entrypoint is from (assuming the object is actually an entrypoint).

Also included is some more rich exception handling where the mod which causes an entrypoint error is mentioned, (some restructuring may be needed).