### PR TITLE
Do not ignore exception

### DIFF
--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
@@ -51,9 +51,8 @@ public final class EntrypointUtils {
 			} catch (Throwable t) {
 				if (exception == null) {
 					exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors, provided by '" + container.getProvider().getMetadata().getId() + "'!");
-				} else {
-					exception.addSuppressed(t);
 				}
+				exception.addSuppressed(t);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
@@ -50,9 +50,10 @@ public final class EntrypointUtils {
 				invoker.accept(container.getEntrypoint());
 			} catch (Throwable t) {
 				if (exception == null) {
-					exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors, provided by '" + container.getProvider().getMetadata().getId() + "'!");
+					exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors, provided by '" + container.getProvider().getMetadata().getId() + "'!", t);
+				} else {
+					exception.addSuppressed(t);
 				}
-				exception.addSuppressed(t);
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/FabricMC/fabric-loader/pull/207/files#r395191539

As that PR brings logs like: 
```
[13:22:51] [main/FATAL]: Failed to start the minecraft server
java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'roughlyenoughresources'!
        at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils.invoke0(EntrypointUtils.java:53) ~[fabric-server-launch.jar:?]
        at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils.invoke(EntrypointUtils.java:36) ~[fabric-server-launch.jar:?]
        at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointServer.start(EntrypointServer.java:32) ~[fabric-server-launch.jar:?]
        at net.minecraft.class_3176.<init>(class_3176.java:100) ~[intermediary-server.jar:?]
        at net.minecraft.server.MinecraftServer.main(MinecraftServer.java:941) [intermediary-server.jar:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_221]
        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_221]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_221]
        at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_221]
        at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:192) [fabric-server-launch.jar:?]
        at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:138) [fabric-server-launch.jar:?]
        at net.fabricmc.loader.launch.knot.KnotServer.main(KnotServer.java:26) [fabric-server-launch.jar:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_221]
        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_221]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_221]
        at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_221]
        at net.fabricmc.loader.launch.server.FabricServerLauncher.launch(FabricServerLauncher.java:61) [fabric-server-launch.jar:?]
        at net.fabricmc.loader.launch.server.FabricServerLauncher.setup(FabricServerLauncher.java:105) [fabric-server-launch.jar:?]
        at net.fabricmc.loader.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:49) [fabric-server-launch.jar:?]
```