### PR TITLE
Make AppletForcedShutdownListener run a daemon thread, fixes the game locking up on close.

### DIFF
--- a/src/main/java/net/fabricmc/loader/entrypoint/applet/AppletFrame.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/applet/AppletFrame.java
@@ -120,8 +120,6 @@ public class AppletFrame extends Frame implements WindowListener {
 			applet.stop();
 			applet.destroy();
 		}
-
-		System.exit(0);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/entrypoint/applet/AppletFrame.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/applet/AppletFrame.java
@@ -112,7 +112,9 @@ public class AppletFrame extends Frame implements WindowListener {
 
 	@Override
 	public void windowClosing(WindowEvent e) {
-		new Thread(new AppletForcedShutdownListener(30000L)).start();
+		Thread shutdownListenerThread = new Thread(new AppletForcedShutdownListener(30000L));
+		shutdownListenerThread.setDaemon(true);
+		shutdownListenerThread.start();
 
 		if (applet != null) {
 			applet.stop();


### PR DESCRIPTION
Tested with b1.7.3 MultiMC instance from [js6pak/fabric-loader](https://github.com/js6pak/fabric-loader/releases) with this build of fabric-loader [fabric-loader-0.7.8%2Blocal.jar](https://ss.modmuss50.me/fabric-loader-0.7.8%2Blocal.jar)

Thanks to @Mumfrey for noticing this. Thanks Ashleez for finding and reporting the bug.