### PR TITLE
Inverse field and method mapper

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/MappingResolver.java
+++ b/src/main/java/net/fabricmc/loader/api/MappingResolver.java
@@ -50,7 +50,7 @@ public interface MappingResolver {
 	String mapClassName(String namespace, String className);
 
 	/**
-	 * Unmap a class name to the mapping currently used at runtime.
+	 * Unmap a class name from the mapping currently used at runtime.
 	 *
 	 * @param targetNamespace The target namespace for unmapping.
 	 * @param className The provided class name, in dot-format ("mypackage.MyClass$Inner"),
@@ -71,6 +71,17 @@ public interface MappingResolver {
 	String mapFieldName(String namespace, String owner, String name, String descriptor);
 
 	/**
+	 * Unmap a field name from the mapping currently used at runtime.
+	 *
+	 * @param targetNamespace The target namespace for unmapping.
+	 * @param owner The owner of the field, in dot-format ("mypackage.MyClass$Inner").
+	 * @param name The name of the field.
+	 * @param descriptor The descriptor of the field.
+	 * @return The unmapped field name, or name if such a mapping is not present
+	 */
+	String unmapFieldName(String targetNamespace, String owner, String name, String descriptor);
+
+	/**
 	 * Map a method name to the mapping currently used at runtime.
 	 *
 	 * @param namespace The namespace of the provided method name.
@@ -80,4 +91,15 @@ public interface MappingResolver {
 	 * @return The mapped method name, or name if such a mapping is not present.
 	 */
 	String mapMethodName(String namespace, String owner, String name, String descriptor);
+
+	/**
+	 * Unmap a method name from the mapping currently used at runtime.
+	 *
+	 * @param targetNamespace The target namespace for unmapping.
+	 * @param owner The owner of the method, in dot-format ("mypackage.MyClass$Inner").
+	 * @param name The name of the method.
+	 * @param descriptor The descriptor of the method.
+	 * @return The unmapped method name, or name if such a mapping is not present.
+	 */
+	String unmapMethodName(String targetNamespace, String owner, String name, String descriptor);
 }

--- a/src/test/java/net/fabricmc/loader/FabricMappingResolverTest.java
+++ b/src/test/java/net/fabricmc/loader/FabricMappingResolverTest.java
@@ -1,0 +1,48 @@
+package net.fabricmc.loader;
+
+import net.fabricmc.mapping.tree.TinyMappingFactory;
+import net.fabricmc.mapping.tree.TinyTree;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+public class FabricMappingResolverTest {
+	public static void main(String[] args) {
+		FabricMappingResolver mappingResolver = new FabricMappingResolver(FabricMappingResolverTest::createTestMappings, "bar");
+
+		assertEquals("class_bar", mappingResolver.mapClassName("foo", "class_foo"));
+		assertEquals("class_bar", mappingResolver.mapClassName("baz", "class_baz"));
+		assertEquals("field_bar", mappingResolver.mapFieldName("foo", "class_foo", "field_foo", "Lclass_foo;"));
+		assertEquals("field_bar", mappingResolver.mapFieldName("baz", "class_baz", "field_baz", "Lclass_baz;"));
+		assertEquals("method_bar", mappingResolver.mapMethodName("foo", "class_foo", "method_foo", "(ILclass_foo;)Lclass_foo;"));
+		assertEquals("method_bar", mappingResolver.mapMethodName("baz", "class_baz", "method_baz", "(ILclass_baz;)Lclass_baz;"));
+
+		assertEquals("class_foo", mappingResolver.unmapClassName("foo", "class_bar"));
+		assertEquals("class_baz", mappingResolver.unmapClassName("baz", "class_bar"));
+		assertEquals("field_foo", mappingResolver.unmapFieldName("foo", "class_bar", "field_bar", "Lclass_bar;"));
+		assertEquals("field_baz", mappingResolver.unmapFieldName("baz", "class_bar", "field_bar", "Lclass_bar;"));
+		assertEquals("method_foo", mappingResolver.unmapMethodName("foo", "class_bar", "method_bar", "(ILclass_bar;)Lclass_bar;"));
+		assertEquals("method_baz", mappingResolver.unmapMethodName("baz", "class_bar", "method_bar", "(ILclass_bar;)Lclass_bar;"));
+
+		System.out.println("All tests successful");
+	}
+
+	private static void assertEquals(String a, String b) {
+		if (!a.equals(b)) {
+			throw new AssertionError(a + " != " + b);
+		}
+	}
+
+	private static TinyTree createTestMappings() {
+		String mappings = "tiny\t2\t0\tfoo\tbar\tbaz\n" +
+			"c\tclass_foo\tclass_bar\tclass_baz\n" +
+			"\tf\tLclass_foo;\tfield_foo\tfield_bar\tfield_baz\n" +
+			"\tm\t(ILclass_foo;)Lclass_foo;\tmethod_foo\tmethod_bar\tmethod_baz\n";
+		try {
+			return TinyMappingFactory.load(new BufferedReader(new StringReader(mappings)));
+		} catch (IOException e) {
+			throw new AssertionError("Failed to load mappings", e);
+		}
+	}
+}


### PR DESCRIPTION
Quite a rare usecase, but without this PR it's annoying when you do need it. Because it's so rare, the mappings are lazily computed to save memory.