### PR TITLE
Include mod name in errors related to entrypoints.

### DIFF
--- a/src/main/java/net/fabricmc/loader/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/EntrypointStorage.java
@@ -190,7 +190,7 @@ class EntrypointStorage {
 				}
 			} catch (Throwable t) {
 				if (exception == null) {
-					exception = new EntrypointException(key, entry.getModContainer().getMetadata().getId(), t);
+					exception = new EntrypointException(key, entry.getModContainer().getMetadata(), t);
 				} else {
 					exception.addSuppressed(t);
 				}

--- a/src/main/java/net/fabricmc/loader/api/EntrypointException.java
+++ b/src/main/java/net/fabricmc/loader/api/EntrypointException.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.loader.api;
 
+import net.fabricmc.loader.api.metadata.ModMetadata;
+
 public class EntrypointException extends RuntimeException {
 	private final String key;
 
@@ -34,6 +36,14 @@ public class EntrypointException extends RuntimeException {
 	@Deprecated
 	public EntrypointException(String key, String causingMod, Throwable cause) {
 		super("Exception while loading entries for entrypoint '" + key + "' provided by '" + causingMod + "'", cause);
+		this.key = key;
+	}
+
+	/**
+	 * @deprecated For internal use only, to be removed!
+	 */
+	public EntrypointException(String key, ModMetadata causingMod, Throwable cause) {
+		super("Exception while loading entries for entrypoint '" + key + "' provided by '" + causingMod.getName() + "' (" + causingMod.getId() + ")", cause);
 		this.key = key;
 	}
 

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/hooks/EntrypointUtils.java
@@ -50,7 +50,7 @@ public final class EntrypointUtils {
 				invoker.accept(container.getEntrypoint());
 			} catch (Throwable t) {
 				if (exception == null) {
-					exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors, provided by '" + container.getProvider().getMetadata().getId() + "'!", t);
+					exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors, provided by '" + container.getProvider().getMetadata().getName() + "' (" + container.getProvider().getMetadata().getId() + ")!", t);
 				} else {
 					exception.addSuppressed(t);
 				}


### PR DESCRIPTION
Per #245, we include the name of the mod in entrypoint errors for easier identification by users and to remove some of the confusion of mods using old mod ids and new names within crash logs.