### PR TITLE
Catch all exceptions json deserialization of mod metadata could throw.

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -462,11 +462,13 @@ public class ModResolver {
 			try (InputStream stream = Files.newInputStream(modJson)) {
 				info = ModMetadataParser.getMods(loader, stream);
 			} catch (JsonParseException e) {
-				throw new RuntimeException("Mod at '" + path + "' has an invalid fabric.mod.json file!", e);
+				throw new RuntimeException(String.format("Mod at \"%s\" has an invalid fabric.mod.json file!", path), e);
 			} catch (NoSuchFileException e) {
 				info = new LoaderModMetadata[0];
 			} catch (IOException e) {
-				throw new RuntimeException("Failed to open fabric.mod.json for mod at '" + path + "'!", e);
+				throw new RuntimeException(String.format("Failed to open fabric.mod.json for mod at \"%s\"!", path), e);
+			} catch (Throwable t) {
+				throw new RuntimeException(String.format("Failed to parse mod metadata for mod at \"%s\"", path), t);
 			}
 
 			for (LoaderModMetadata i : info) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -461,7 +461,7 @@ public class ModResolver {
 
 			try (InputStream stream = Files.newInputStream(modJson)) {
 				info = ModMetadataParser.getMods(loader, stream);
-			} catch (JsonSyntaxException e) {
+			} catch (JsonParseException e) {
 				throw new RuntimeException("Mod at '" + path + "' has an invalid fabric.mod.json file!", e);
 			} catch (NoSuchFileException e) {
 				info = new LoaderModMetadata[0];

--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
@@ -51,22 +51,17 @@ public class ModMetadataParser {
 	private static final JsonParser JSON_PARSER = new JsonParser();
 
 	private static LoaderModMetadata getMod(FabricLoader loader, JsonObject object) {
-		try {
-			if (!object.has("schemaVersion")) {
-				return GSON_V0.fromJson(object, ModMetadataV0.class);
-			} else {
-				//noinspection SwitchStatementWithTooFewBranches
-				switch (object.get("schemaVersion").getAsInt()) {
-					case 1:
-						return GSON_V1.fromJson(object, ModMetadataV1.class);
-					default:
-						loader.getLogger().warn("Mod ID " + (object.has("id") ? object.get("id").getAsString() : "<unknown>") + " has invalid schema version: " + object.get("schemaVersion").getAsInt());
-						return null;
-				}
+		if (!object.has("schemaVersion")) {
+			return GSON_V0.fromJson(object, ModMetadataV0.class);
+		} else {
+			//noinspection SwitchStatementWithTooFewBranches
+			switch (object.get("schemaVersion").getAsInt()) {
+				case 1:
+					return GSON_V1.fromJson(object, ModMetadataV1.class);
+				default:
+					loader.getLogger().warn("Mod ID " + (object.has("id") ? object.get("id").getAsString() : "<unknown>") + " has invalid schema version: " + object.get("schemaVersion").getAsInt());
+					return null;
 			}
-		} catch (Throwable t) {
-			// Catch all exceptions that could occur from parsing metadata and rethrow as JsonSyntaxException.
-			throw new JsonParseException(t);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
@@ -51,17 +51,22 @@ public class ModMetadataParser {
 	private static final JsonParser JSON_PARSER = new JsonParser();
 
 	private static LoaderModMetadata getMod(FabricLoader loader, JsonObject object) {
-		if (!object.has("schemaVersion")) {
-			return GSON_V0.fromJson(object, ModMetadataV0.class);
-		} else {
-			//noinspection SwitchStatementWithTooFewBranches
-			switch (object.get("schemaVersion").getAsInt()) {
-				case 1:
-					return GSON_V1.fromJson(object, ModMetadataV1.class);
-				default:
-					loader.getLogger().warn("Mod ID " + (object.has("id") ? object.get("id").getAsString() : "<unknown>") + " has invalid schema version: " + object.get("schemaVersion").getAsInt());
-					return null;
+		try {
+			if (!object.has("schemaVersion")) {
+				return GSON_V0.fromJson(object, ModMetadataV0.class);
+			} else {
+				//noinspection SwitchStatementWithTooFewBranches
+				switch (object.get("schemaVersion").getAsInt()) {
+					case 1:
+						return GSON_V1.fromJson(object, ModMetadataV1.class);
+					default:
+						loader.getLogger().warn("Mod ID " + (object.has("id") ? object.get("id").getAsString() : "<unknown>") + " has invalid schema version: " + object.get("schemaVersion").getAsInt());
+						return null;
+				}
 			}
+		} catch (Throwable t) {
+			// Catch all exceptions that could occur from parsing metadata and rethrow as JsonSyntaxException.
+			throw new JsonParseException(t);
 		}
 	}
 


### PR DESCRIPTION
This prevents some more cryptic stack traces like this by actually blaming the mod that broke:
https://gist.github.com/modmuss50/7c13acaed89a56b491430cbb08fd34d4

Of course this is a tiny fix which may actually be the wrong way to approach it, so comment away.