### PR TITLE
Improved modlist output

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -239,7 +239,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 
 	/**
 	 * Prints the mod list according to the setting specified by
-	 * {@code -Dfabric_loader_modlist_style}. Valid values for this setting are:
+	 * {@code -Dfabric.modListStyle}. Valid values for this setting are:
 	 * <ul>
 	 *     <li>
 	 *         {@code verbose}. Prints each mod id, version, and path to the jar
@@ -251,9 +251,9 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	 *         readable than {@code short}.
 	 *         <br>
 	 *         The {@code ncols} setting determines the maximum width each line
-	 *         can take up. Using {@code -Dfabric_loader_modlist_style=col80}
-	 *         for example means that it will auto-wrap the printed text after
-	 *         80 characters. If {@code ncols} is left away, it will default to
+	 *         can take up. Using {@code -Dfabric.modListStyle=col80} for
+	 *         example means that it will auto-wrap the printed text after 80
+	 *         characters. If {@code ncols} is left away, it will default to
 	 *         120.
 	 *     </li>
 	 *     <li>
@@ -261,7 +261,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	 *         and version.
 	 *     </li>
 	 * </ul>
-	 * The default value for {@code -Dfabric_loader_modlist_style} is 'col'.
+	 * The default value for {@code -Dfabric.modListStyle} is 'col'.
 	 * @param candidateMap the mod candidate map to print
 	 */
 	private void printModList(Map<String, ModCandidate> candidateMap) {
@@ -278,7 +278,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 				break;
 		}
 
-		String style = System.getProperty("fabric_loader_modlist_style", "col");
+		String style = System.getProperty(SystemProperties.MOD_LIST_STYLE, "col");
 		int maxWidth = 120;
 
 		if (style.startsWith("col")) {
@@ -320,7 +320,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 				.map(info -> String.format("%s@%s", info.getInfo().getId(), info.getInfo().getVersion().getFriendlyString()))
 				.collect(Collectors.joining(", ")));
 		} else {
-			LOGGER.error("Invalid setting for fabric_loader_modlist_style: '{}'. Valid values are: verbose, col *, short", style);
+			LOGGER.error("Invalid setting for -D{}: '{}'. Valid values are: verbose, col *, short", SystemProperties.MOD_LIST_STYLE, style);
 			LOGGER.error("* You can add the maximum width the output will have by adding it as a suffix to col, for example col80 for an 80 columns terminal. Default is 120.");
 			LOGGER.info("Not displaying mod list due to invalid configuration.");
 		}

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -74,6 +74,7 @@ public class ModResolver {
 			.build()
 	);
 	private static final Map<String, List<Path>> inMemoryCache = new ConcurrentHashMap<>();
+	private static final Map<URL, String> readableNestedJarPaths = new ConcurrentHashMap<>();
 	private static final Pattern MOD_ID_PATTERN = Pattern.compile("[a-z][a-z0-9-_]{1,63}");
 	private static final Object launcherSyncObject = new Object();
 
@@ -88,6 +89,22 @@ public class ModResolver {
 
 	private static IVecInt toVecInt(IntStream stream) {
 		return new VecInt(stream.toArray());
+	}
+
+	public static String getReadablePath(FabricLoader loader, ModCandidate c) {
+		Path path;
+		try {
+			path = UrlUtil.asPath(c.getOriginUrl());
+		} catch (UrlConversionException e) {
+			throw new RuntimeException(e);
+		}
+
+		Path gameDir = loader.getGameDirectory().toPath();
+		if (path.startsWith(gameDir)) {
+			path = gameDir.relativize(path);
+		}
+
+		return readableNestedJarPaths.getOrDefault(c.getOriginUrl(), path.toString());
 	}
 
 	// TODO: Find a way to sort versions of mods by suggestions and conflicts (not crucial, though)
@@ -696,6 +713,12 @@ public class ModResolver {
 									}
 
 									list.add(dest);
+
+									try {
+										readableNestedJarPaths.put(UrlUtil.asUrl(dest), String.format("%s!%s", getReadablePath(loader, candidate), modPath));
+									} catch (UrlConversionException e) {
+										e.printStackTrace();
+									}
 								}
 							});
 

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -99,7 +99,7 @@ public class ModResolver {
 			throw new RuntimeException(e);
 		}
 
-		Path gameDir = loader.getGameDirectory().toPath();
+		Path gameDir = loader.getGameDir();
 		if (path.startsWith(gameDir)) {
 			path = gameDir.relativize(path);
 		}

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -96,15 +96,16 @@ public class ModResolver {
 		try {
 			path = UrlUtil.asPath(c.getOriginUrl());
 		} catch (UrlConversionException e) {
-			throw new RuntimeException(e);
+			loader.getLogger().error("Failed to turn '{}' (URL for mod '{}') into a path!", c.getOriginUrl(), c.getInfo().getId());
+			path = null;
 		}
 
 		Path gameDir = loader.getGameDir();
-		if (path.startsWith(gameDir)) {
+		if (path != null && path.startsWith(gameDir)) {
 			path = gameDir.relativize(path);
 		}
 
-		return readableNestedJarPaths.getOrDefault(c.getOriginUrl().toString(), path.toString());
+		return readableNestedJarPaths.getOrDefault(c.getOriginUrl().toString(), path != null ? path.toString() : "<unknown>");
 	}
 
 	// TODO: Find a way to sort versions of mods by suggestions and conflicts (not crucial, though)
@@ -717,7 +718,7 @@ public class ModResolver {
 									try {
 										readableNestedJarPaths.put(UrlUtil.asUrl(dest).toString(), String.format("%s!%s", getReadablePath(loader, candidate), modPath));
 									} catch (UrlConversionException e) {
-										e.printStackTrace();
+										loader.getLogger().error("Failed to turn '{}' (path to mod '{}') into URL!", dest, candidate.getInfo().getId());
 									}
 								}
 							});

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -74,7 +74,7 @@ public class ModResolver {
 			.build()
 	);
 	private static final Map<String, List<Path>> inMemoryCache = new ConcurrentHashMap<>();
-	private static final Map<URL, String> readableNestedJarPaths = new ConcurrentHashMap<>();
+	private static final Map<String, String> readableNestedJarPaths = new ConcurrentHashMap<>();
 	private static final Pattern MOD_ID_PATTERN = Pattern.compile("[a-z][a-z0-9-_]{1,63}");
 	private static final Object launcherSyncObject = new Object();
 
@@ -104,7 +104,7 @@ public class ModResolver {
 			path = gameDir.relativize(path);
 		}
 
-		return readableNestedJarPaths.getOrDefault(c.getOriginUrl(), path.toString());
+		return readableNestedJarPaths.getOrDefault(c.getOriginUrl().toString(), path.toString());
 	}
 
 	// TODO: Find a way to sort versions of mods by suggestions and conflicts (not crucial, though)
@@ -715,7 +715,7 @@ public class ModResolver {
 									list.add(dest);
 
 									try {
-										readableNestedJarPaths.put(UrlUtil.asUrl(dest), String.format("%s!%s", getReadablePath(loader, candidate), modPath));
+										readableNestedJarPaths.put(UrlUtil.asUrl(dest).toString(), String.format("%s!%s", getReadablePath(loader, candidate), modPath));
 									} catch (UrlConversionException e) {
 										e.printStackTrace();
 									}

--- a/src/main/java/net/fabricmc/loader/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/util/SystemProperties.java
@@ -23,6 +23,13 @@ public final class SystemProperties {
 	public static final String GAME_VERSION = "fabric.gameVersion";
 	public static final String REMAP_CLASSPATH_FILE = "fabric.remapClasspathFile";
 
+	/**
+	 * Property that defines how the mod list is displayed at game startup.
+	 *
+	 * @see net.fabricmc.loader.FabricLoader#printModList(java.util.Map)
+	 */
+	public static final String MOD_LIST_STYLE = "fabric.modListStyle";
+
 	private SystemProperties() {
 	}
 }


### PR DESCRIPTION
Improves the mod list output that Fabric Loader prints on startup. This output is configurable via the `-Dfabric.modListStyle` setting. It has 3 variants, `short`, which is the original output, but it's sorted alphabetically by mod ID now, `col`, which displays the mods in columns similar to `ls`, and `verbose` which prints mod ID, version and the path to the jar (including nested jars) each in a seperate line. A max length for each line can be specified after `col`, for example `col160` will ensure that the printed line length never exceeds 160 (unless one mod alone exceeds that length). The default max length is 120.
The default for this setting is `-Dfabric.modListStyle=col`.

## Example outputs:
`-Dfabric.modListStyle=short`: [screenshot](https://user-images.githubusercontent.com/3987560/85922753-022f3c80-b886-11ea-91a3-5efff3a5af1c.png)
`-Dfabric.modListStyle=col180`: [screenshot](https://user-images.githubusercontent.com/3987560/85922787-41f62400-b886-11ea-8331-25132c452578.png)
`-Dfabric.modListStyle=verbose`: [screenshot](https://user-images.githubusercontent.com/3987560/85922802-59cda800-b886-11ea-9914-08576cc05b27.png)

Closes #311.
