### PR TITLE
Clarify nullability of getGameInstance method

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -154,8 +154,11 @@ public interface FabricLoader {
 	 * server object. As such, the exact return is dependent on the
 	 * current environment type.
 	 *
+	 * <p>The game instance may not always be availible depending on the game version.
+	 *
 	 * @return A client or server instance object
 	 */
+	/* @Nullable */
 	Object getGameInstance();
 
 	/**

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -154,11 +154,13 @@ public interface FabricLoader {
 	 * server object. As such, the exact return is dependent on the
 	 * current environment type.
 	 *
-	 * <p>The game instance may not always be availible depending on the game version.
+	 * <p>The game instance may not always be available depending on the game version and {@link EnvType environment}.
 	 *
 	 * @return A client or server instance object
+	 * @deprecated This method is experimental and it's use is discouraged.
 	 */
 	/* @Nullable */
+	@Deprecated
 	Object getGameInstance();
 
 	/**


### PR DESCRIPTION
Due to 20w22a+ dedicated server game instance changes (#269), the game instance may not always be available.