### PR TITLE
Include the modid in mixin configs when logging

### DIFF
--- a/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
@@ -45,7 +45,9 @@ public final class FabricMixinBootstrap {
 	private static boolean initialized = false;
 
 	static void addConfiguration(String modId, String configuration) {
-		Mixins.addConfiguration(MOD_PREFIX + modId + ":" + configuration);
+		if (configuration != null && !configuration.isEmpty()) {
+			Mixins.addConfiguration(MOD_PREFIX + modId + ":" + configuration);
+		}
 	}
 
 	public static void init(EnvType side, FabricLoader loader) {

--- a/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.loader.launch.knot;
 
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.launch.common.FabricMixinBootstrap;
 
@@ -27,12 +29,16 @@ import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.service.*;
 import org.spongepowered.asm.util.ReEntranceLock;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBytecodeProvider, ITransformerProvider, IClassTracker {
 	private final ReEntranceLock lock;
@@ -179,8 +185,26 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 			int secondColon = name.indexOf(":", FabricMixinBootstrap.MOD_PREFIX.length());
 
 			if (secondColon > 0) {
-				// TODO: Load the resource from the mod!
-				name = name.substring(secondColon + 1);
+				String modid = name.substring(FabricMixinBootstrap.MOD_PREFIX.length(), secondColon);
+				String path = name.substring(secondColon + 1);
+
+				Optional<ModContainer> mc = FabricLoader.getInstance().getModContainer(modid);
+				if (!mc.isPresent()) {
+					return null;
+				}
+				ModContainer mod = mc.get();
+				Path pathInMod = mod.getPath(path);
+				try {
+					InputStream stream = Files.newInputStream(pathInMod);
+					// FIXME: Unlike ClassLoader.getResourceAsStream() this
+					// won't auto-close the returned input stream.
+					// Which is a problem as MixinConfig doesn't close this itself.
+					return stream;
+				} catch (FileNotFoundException e) {
+					return null;
+				} catch (IOException e) {
+					throw new RuntimeException("Failed to read file '" + name + "' in mod " + modid + "!", e);
+				}
 			}
 		}
 		return FabricLauncherBase.getLauncher().getResourceAsStream(name);

--- a/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
@@ -17,6 +17,8 @@
 package net.fabricmc.loader.launch.knot;
 
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
+import net.fabricmc.loader.launch.common.FabricMixinBootstrap;
+
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.launch.platform.container.ContainerHandleURI;
@@ -173,6 +175,14 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 
 	@Override
 	public InputStream getResourceAsStream(String name) {
+		if (name.startsWith(FabricMixinBootstrap.MOD_PREFIX)) {
+			int secondColon = name.indexOf(":", FabricMixinBootstrap.MOD_PREFIX.length());
+
+			if (secondColon > 0) {
+				// TODO: Load the resource from the mod!
+				name = name.substring(secondColon);
+			}
+		}
 		return FabricLauncherBase.getLauncher().getResourceAsStream(name);
 	}
 

--- a/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
@@ -203,7 +203,7 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 				} catch (FileNotFoundException e) {
 					return null;
 				} catch (IOException e) {
-					throw new RuntimeException("Failed to read file '" + name + "' in mod " + modid + "!", e);
+					throw new RuntimeException("Failed to read file '" + path + "' in mod " + modid + "!", e);
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/MixinServiceKnot.java
@@ -180,7 +180,7 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 
 			if (secondColon > 0) {
 				// TODO: Load the resource from the mod!
-				name = name.substring(secondColon);
+				name = name.substring(secondColon + 1);
 			}
 		}
 		return FabricLauncherBase.getLauncher().getResourceAsStream(name);


### PR DESCRIPTION
...so that we know which mod contained them.

This works as mixin only seems to use the name for logging purposes, or to load the actual config from `IMixinService`. This only works so long as fabric provides the `IMixinService` though, although I'm not sure of the implications for that.

(Player requested that someone look into this a few days ago in discord).

This is a draft because:
- ~~This doesn't load from the specific mod that provided the config - so mods will still break if multiple mods include a mixin config with the same name (which is a bit confusing as it almost looks like it could do).~~ Done in 3rd commit.
- This doesn't log the actual location that the mixin was loaded from. (if #266 is merged with `verbose` as the default then this wouldn't be necessary - however as that doesn't seem to be happening it might be a good idea to re-use it's `getRealLocation()` method).
- ~~I haven't tested this outside of a dev environment.~~ Tested in AOF3 and it works correctly.

This also allows multiple mods to use the same mixin config name without overwriting each other.