### PR TITLE
Allow the mods directory to be a symlink

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
@@ -22,6 +22,7 @@ import net.fabricmc.loader.util.UrlUtil;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
@@ -48,7 +49,7 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 		}
 
 		try {
-			Files.walk(path, 1).forEach((modPath) -> {
+			Files.walk(path, 1, FileVisitOption.FOLLOW_LINKS).forEach((modPath) -> {
 				if (!Files.isDirectory(modPath) && modPath.toString().endsWith(".jar")) {
 					try {
 						urlProposer.accept(UrlUtil.asUrl(modPath));


### PR DESCRIPTION
I noticed the fabric loader did not load mods if the "mods" directory was a symlink.

I have a "mods" directory on Dropbox so it is sync'd between PCs, and want to make a symlink to it under a game directory on each PC to get fabric to load mods in it.  On Windows, fabric is able to detect mods when "mods" is a directory junction, but on macOS and Linux, fabric does not load mods when "mods" is a symlink to a directory.

java.nio.file.Files.isDirectory() follows a symlink by default but Files.walk does not, so I guess this patch could fix it.