### PR TITLE
ASM 9 support for java 16 support and sealed class support for access wideners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,11 @@ dependencies {
 	compile 'com.google.code.findbugs:jsr305:3.0.2'
 
 	// fabric-loader dependencies
-	compile 'org.ow2.asm:asm:8.0'
-	compile 'org.ow2.asm:asm-analysis:8.0'
-	compile 'org.ow2.asm:asm-commons:8.0'
-	compile 'org.ow2.asm:asm-tree:8.0'
-	compile 'org.ow2.asm:asm-util:8.0'
+	compile 'org.ow2.asm:asm:9.0-beta'
+	compile 'org.ow2.asm:asm-analysis:9.0-beta'
+	compile 'org.ow2.asm:asm-commons:9.0-beta'
+	compile 'org.ow2.asm:asm-tree:9.0-beta'
+	compile 'org.ow2.asm:asm-util:9.0-beta'
 
 	compile('net.fabricmc:sponge-mixin:0.8+build.18') {
 		exclude module: 'launchwrapper'

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -53,6 +53,7 @@ import net.fabricmc.loader.metadata.EntrypointMetadata;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.util.DefaultLanguageAdapter;
 import net.fabricmc.loader.transformer.accesswidener.AccessWidener;
+import org.objectweb.asm.Opcodes;
 
 /**
  * The main class for mod loading operations.
@@ -64,6 +65,8 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	 */
 	@Deprecated
 	public static final FabricLoader INSTANCE = new FabricLoader();
+
+	public static final int ASM_VERSION = Opcodes.ASM9;
 
 	protected static Logger LOGGER = LogManager.getFormatterLogger("Fabric|Loader");
 

--- a/src/main/java/net/fabricmc/loader/minecraft/McVersionLookup.java
+++ b/src/main/java/net/fabricmc/loader/minecraft/McVersionLookup.java
@@ -35,6 +35,7 @@ import org.objectweb.asm.Opcodes;
 
 import com.google.gson.stream.JsonReader;
 
+import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.loader.util.FileSystemUtil;
 import net.fabricmc.loader.util.version.SemanticVersionImpl;
 import net.fabricmc.loader.util.version.SemanticVersionPredicateParser;
@@ -393,7 +394,7 @@ public final class McVersionLookup {
 
 	private static final class FieldStringConstantVisitor extends ClassVisitor implements Analyzer {
 		public FieldStringConstantVisitor(String fieldName) {
-			super(Opcodes.ASM8);
+			super(FabricLoader.ASM_VERSION);
 
 			this.fieldName = fieldName;
 		}
@@ -464,7 +465,7 @@ public final class McVersionLookup {
 
 	private static final class MethodStringConstantContainsVisitor extends ClassVisitor implements Analyzer {
 		public MethodStringConstantContainsVisitor(String methodOwner, String methodName) {
-			super(Opcodes.ASM8);
+			super(FabricLoader.ASM_VERSION);
 
 			this.methodOwner = methodOwner;
 			this.methodName = methodName;
@@ -519,7 +520,7 @@ public final class McVersionLookup {
 
 	private static final class MethodConstantRetVisitor extends ClassVisitor implements Analyzer {
 		public MethodConstantRetVisitor(String methodName) {
-			super(Opcodes.ASM8);
+			super(FabricLoader.ASM_VERSION);
 
 			this.methodName = methodName;
 		}
@@ -577,7 +578,7 @@ public final class McVersionLookup {
 
 	private static final class MethodConstantVisitor extends ClassVisitor implements Analyzer {
 		public MethodConstantVisitor(String methodNameHint) {
-			super(Opcodes.ASM8);
+			super(FabricLoader.ASM_VERSION);
 
 			this.methodNameHint = methodNameHint;
 		}
@@ -595,7 +596,7 @@ public final class McVersionLookup {
 				return null;
 			}
 
-			return new MethodVisitor(Opcodes.ASM8) {
+			return new MethodVisitor(FabricLoader.ASM_VERSION) {
 				@Override
 				public void visitLdcInsn(Object value) {
 					String str;
@@ -617,7 +618,7 @@ public final class McVersionLookup {
 
 	private static abstract class InsnFwdMethodVisitor extends MethodVisitor {
 		public InsnFwdMethodVisitor() {
-			super(Opcodes.ASM8);
+			super(FabricLoader.ASM_VERSION);
 		}
 
 		protected abstract void visitAnyInsn();

--- a/src/main/java/net/fabricmc/loader/transformer/FabricTransformer.java
+++ b/src/main/java/net/fabricmc/loader/transformer/FabricTransformer.java
@@ -60,23 +60,23 @@ public final class FabricTransformer {
 		int visitorCount = 0;
 
 		if (applyAccessWidener) {
-			visitor = new AccessWidenerVisitor(Opcodes.ASM8, visitor, FabricLoader.INSTANCE.getAccessWidener());
+			visitor = new AccessWidenerVisitor(FabricLoader.ASM_VERSION, visitor, FabricLoader.INSTANCE.getAccessWidener());
 			visitorCount++;
 		}
 
 		if (transformAccess) {
-			visitor = new PackageAccessFixer(Opcodes.ASM8, visitor);
+			visitor = new PackageAccessFixer(FabricLoader.ASM_VERSION, visitor);
 			visitorCount++;
 		}
 
 		if (environmentStrip) {
-			EnvironmentStrippingData stripData = new EnvironmentStrippingData(Opcodes.ASM8, envType.toString());
+			EnvironmentStrippingData stripData = new EnvironmentStrippingData(FabricLoader.ASM_VERSION, envType.toString());
 			classReader.accept(stripData, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
 			if (stripData.stripEntireClass()) {
 				throw new RuntimeException("Cannot load class " + name + " in environment type " + envType);
 			}
 			if (!stripData.isEmpty()) {
-				visitor = new ClassStripper(Opcodes.ASM8, visitor, stripData.getStripInterfaces(), stripData.getStripFields(), stripData.getStripMethods());
+				visitor = new ClassStripper(FabricLoader.ASM_VERSION, visitor, stripData.getStripInterfaces(), stripData.getStripFields(), stripData.getStripMethods());
 				visitorCount++;
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/transformer/accesswidener/AccessWidenerVisitor.java
+++ b/src/main/java/net/fabricmc/loader/transformer/accesswidener/AccessWidenerVisitor.java
@@ -21,6 +21,7 @@ import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.mappings.EntryTriple;
 
 public class AccessWidenerVisitor extends ClassVisitor {
@@ -82,7 +83,7 @@ public class AccessWidenerVisitor extends ClassVisitor {
 
 	private class AccessWidenerMethodVisitor extends MethodVisitor {
 		AccessWidenerMethodVisitor(MethodVisitor methodVisitor) {
-			super(Opcodes.ASM7, methodVisitor);
+			super(FabricLoader.ASM_VERSION, methodVisitor);
 		}
 
 		@Override
@@ -96,6 +97,15 @@ public class AccessWidenerVisitor extends ClassVisitor {
 			}
 
 			super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+		}
+	}
+
+	@Override
+	public void visitPermittedSubclass(String permittedSubclass) {
+		super.visitPermittedSubclass(permittedSubclass);
+
+		for (String permittedClass : accessWidener.getPermittedClasses(className)) {
+			super.visitPermittedSubclass(permittedClass);
 		}
 	}
 }

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -26,23 +26,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:8.0",
+        "name": "org.ow2.asm:asm:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:8.0",
+        "name": "org.ow2.asm:asm-analysis:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:8.0",
+        "name": "org.ow2.asm:asm-commons:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:8.0",
+        "name": "org.ow2.asm:asm-tree:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:8.0",
+        "name": "org.ow2.asm:asm-util:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       }
     ],

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -29,23 +29,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:8.0",
+        "name": "org.ow2.asm:asm:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:8.0",
+        "name": "org.ow2.asm:asm-analysis:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:8.0",
+        "name": "org.ow2.asm:asm-commons:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:8.0",
+        "name": "org.ow2.asm:asm-tree:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:8.0",
+        "name": "org.ow2.asm:asm-util:9.0-beta",
         "url": "https://maven.fabricmc.net/"
       }
     ],


### PR DESCRIPTION
Moves the asm version constant to a single location.

Expands access widerner's to support sealed classes:

`permits	<targetClass>	<childClass>`

The sealed class support is there becuase it was easy to add, once asm 9 is out of beta this can be reviewed in more detail.