### PR TITLE
Fix #286 (SemVer pre-release comparison)

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
+++ b/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
@@ -16,7 +16,9 @@
 
 package net.fabricmc.loader.api;
 
+import java.util.Enumeration;
 import java.util.Optional;
+import java.util.StringTokenizer;
 
 import net.fabricmc.loader.util.version.VersionDeserializer;
 
@@ -115,7 +117,30 @@ public interface SemanticVersion extends Version, Comparable<SemanticVersion> {
 
 		if (prereleaseA.isPresent() || prereleaseB.isPresent()) {
 			if (prereleaseA.isPresent() && prereleaseB.isPresent()) {
-				return prereleaseA.get().compareTo(prereleaseB.get());
+				StringTokenizer prereleaseATokenizer = new StringTokenizer(prereleaseA.get(), ".");
+				StringTokenizer prereleaseBTokenizer = new StringTokenizer(prereleaseB.get(), ".");
+
+				while (prereleaseATokenizer.hasMoreElements()) {
+					if (prereleaseBTokenizer.hasMoreElements()) {
+						String partA = prereleaseATokenizer.nextToken();
+						String partB = prereleaseBTokenizer.nextToken();
+
+						int compare;
+						try {
+							compare = Integer.compareUnsigned(Integer.parseUnsignedInt(partA), Integer.parseUnsignedInt(partB));
+						} catch (NumberFormatException e) {
+							compare = partA.compareTo(partB);
+						}
+						if (compare != 0)
+							return compare;
+					} else {
+						return 1;
+					}
+				}
+				if (prereleaseBTokenizer.hasMoreElements()) {
+					return -1;
+				}
+				return 0;
 			} else if (prereleaseA.isPresent()) {
 				return o.hasWildcard() ? 0 : -1;
 			} else { // prereleaseB.isPresent()

--- a/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
+++ b/src/main/java/net/fabricmc/loader/api/SemanticVersion.java
@@ -98,58 +98,7 @@ public interface SemanticVersion extends Version, Comparable<SemanticVersion> {
 	 * @return the result of comparison
 	 */
 	@Override
-	default int compareTo(SemanticVersion o) {
-		for (int i = 0; i < Math.max(getVersionComponentCount(), o.getVersionComponentCount()); i++) {
-			int first = getVersionComponent(i);
-			int second = o.getVersionComponent(i);
-			if (first == COMPONENT_WILDCARD || second == COMPONENT_WILDCARD) {
-				continue;
-			}
-
-			int compare = Integer.compare(first, second);
-			if (compare != 0) {
-				return compare;
-			}
-		}
-
-		Optional<String> prereleaseA = getPrereleaseKey();
-		Optional<String> prereleaseB = o.getPrereleaseKey();
-
-		if (prereleaseA.isPresent() || prereleaseB.isPresent()) {
-			if (prereleaseA.isPresent() && prereleaseB.isPresent()) {
-				StringTokenizer prereleaseATokenizer = new StringTokenizer(prereleaseA.get(), ".");
-				StringTokenizer prereleaseBTokenizer = new StringTokenizer(prereleaseB.get(), ".");
-
-				while (prereleaseATokenizer.hasMoreElements()) {
-					if (prereleaseBTokenizer.hasMoreElements()) {
-						String partA = prereleaseATokenizer.nextToken();
-						String partB = prereleaseBTokenizer.nextToken();
-
-						int compare;
-						try {
-							compare = Integer.compareUnsigned(Integer.parseUnsignedInt(partA), Integer.parseUnsignedInt(partB));
-						} catch (NumberFormatException e) {
-							compare = partA.compareTo(partB);
-						}
-						if (compare != 0)
-							return compare;
-					} else {
-						return 1;
-					}
-				}
-				if (prereleaseBTokenizer.hasMoreElements()) {
-					return -1;
-				}
-				return 0;
-			} else if (prereleaseA.isPresent()) {
-				return o.hasWildcard() ? 0 : -1;
-			} else { // prereleaseB.isPresent()
-				return hasWildcard() ? 0 : 1;
-			}
-		} else {
-			return 0;
-		}
-	}
+	int compareTo(SemanticVersion o);
 
 	/**
 	 * Parses a semantic version from a string notation.

--- a/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
+++ b/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
@@ -257,10 +257,7 @@ public class SemanticVersionImpl implements SemanticVersion {
 						return 1;
 					}
 				}
-				if (prereleaseBTokenizer.hasMoreElements()) {
-					return -1;
-				}
-				return 0;
+				return prereleaseBTokenizer.hasMoreElements() ? -1 : 0;
 			} else if (prereleaseA.isPresent()) {
 				return o.hasWildcard() ? 0 : -1;
 			} else { // prereleaseB.isPresent()

--- a/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
+++ b/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 public class SemanticVersionImpl implements SemanticVersion {
 	private static final Pattern DOT_SEPARATED_ID = Pattern.compile("|[-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*");
+	private static final Pattern UNSIGNED_INTEGER = Pattern.compile("0|[1-9][0-9]*");
 	private final int[] components;
 	private final String prerelease;
 	private final String build;
@@ -245,25 +246,25 @@ public class SemanticVersionImpl implements SemanticVersion {
 						String partA = prereleaseATokenizer.nextToken();
 						String partB = prereleaseBTokenizer.nextToken();
 
-						int compare;
-						try {
-							int numA = Integer.parseUnsignedInt(partA);
-							try {
-								int numB = Integer.parseUnsignedInt(partB);
-								compare = Integer.compareUnsigned(numA, numB);
-							} catch (NumberFormatException e) {
-								compare = -1;
+						if (UNSIGNED_INTEGER.matcher(partA).matches()) {
+							if (UNSIGNED_INTEGER.matcher(partB).matches()) {
+								int compare = Integer.compare(partA.length(), partB.length());
+								if (compare != 0) {
+									return compare;
+								}
+							} else {
+								return -1;
 							}
-						} catch (NumberFormatException e) {
-							try {
-								Integer.parseUnsignedInt(partB);
-								compare = 1;
-							} catch (NumberFormatException e2) {
-								compare = partA.compareTo(partB);
+						} else {
+							if (UNSIGNED_INTEGER.matcher(partB).matches()) {
+								return 1;
 							}
 						}
-						if (compare != 0)
+
+						int compare = partA.compareTo(partB);
+						if (compare != 0) {
 							return compare;
+						}
 					} else {
 						return 1;
 					}

--- a/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
+++ b/src/main/java/net/fabricmc/loader/util/version/SemanticVersionImpl.java
@@ -247,9 +247,20 @@ public class SemanticVersionImpl implements SemanticVersion {
 
 						int compare;
 						try {
-							compare = Integer.compareUnsigned(Integer.parseUnsignedInt(partA), Integer.parseUnsignedInt(partB));
+							int numA = Integer.parseUnsignedInt(partA);
+							try {
+								int numB = Integer.parseUnsignedInt(partB);
+								compare = Integer.compareUnsigned(numA, numB);
+							} catch (NumberFormatException e) {
+								compare = -1;
+							}
 						} catch (NumberFormatException e) {
-							compare = partA.compareTo(partB);
+							try {
+								Integer.parseUnsignedInt(partB);
+								compare = 1;
+							} catch (NumberFormatException e2) {
+								compare = partA.compareTo(partB);
+							}
 						}
 						if (compare != 0)
 							return compare;

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -161,7 +161,10 @@ public class VersionParsingTests {
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.e", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.d.10", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.9.d.5", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.final", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.d", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-alpha.9", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.8", false)));
 		}
 
 		// Test: x-range. "a.b.x" = ">=a.b.0- <a.(b+1).0-" (same major+minor, pre allowed)

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -153,7 +153,7 @@ public class VersionParsingTests {
 			testFalse(predicate.test(new SemanticVersionImpl("1.4", false)));
 		}
 
-		// Test pre-release parts
+		// Test: pre-release parts
 		{
 			Predicate<SemanticVersionImpl> predicate = SemanticVersionPredicateParser.create(">=0.3.1-beta.8.d.10");
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.9", false)));
@@ -162,7 +162,9 @@ public class VersionParsingTests {
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.d.10", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.9.d.5", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.final", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.7", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.d", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.a", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-alpha.9", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.8", false)));
 		}

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -162,6 +162,7 @@ public class VersionParsingTests {
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.d.10", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.9.d.5", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.final", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.-final-", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.7", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.d", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.a", false)));

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.test;
 
+import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.util.version.SemanticVersionImpl;
 import net.fabricmc.loader.util.version.SemanticVersionPredicateParser;
-import net.fabricmc.loader.util.version.VersionParsingException;
 
 import javax.annotation.Nullable;
 import java.util.function.Predicate;
@@ -101,6 +101,7 @@ public class VersionParsingTests {
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.7", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.4.0-alpha.1", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.4-beta.7", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.11", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.0", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.1", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.4.0", false)));
@@ -114,6 +115,7 @@ public class VersionParsingTests {
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.4+build.125", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.7", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("0.3.4-beta.7", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.11", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.0", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-beta.1", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("0.4.0-alpha.1", false)));
@@ -149,6 +151,17 @@ public class VersionParsingTests {
 			testFalse(predicate.test(new SemanticVersionImpl("1.4-beta.2", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("1.4+build.125", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("1.4", false)));
+		}
+
+		// Test pre-release parts
+		{
+			Predicate<SemanticVersionImpl> predicate = SemanticVersionPredicateParser.create(">=0.3.1-beta.8.d.10");
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.9", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.11", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.e", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.8.d.10", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("0.3.1-beta.9.d.5", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("0.3.1-alpha.9", false)));
 		}
 
 		// Test: x-range. "a.b.x" = ">=a.b.0- <a.(b+1).0-" (same major+minor, pre allowed)
@@ -224,6 +237,7 @@ public class VersionParsingTests {
 			testTrue(predicate.test(new SemanticVersionImpl("1.2.3-beta.2", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("1.2.3-beta.2.1", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("1.2.3-beta.3", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("1.2.3-beta.11", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("1.2.3-rc.7", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("1.2.3", false)));
 			testTrue(predicate.test(new SemanticVersionImpl("1.2.5", false)));
@@ -232,7 +246,6 @@ public class VersionParsingTests {
 			testFalse(predicate.test(new SemanticVersionImpl("1.2.2", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("1.2.3-beta.1", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("1.2.3-beta.1.9", false)));
-			testFalse(predicate.test(new SemanticVersionImpl("1.2.3-beta.11", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("1.2.3-alpha.4", false)));
 		}
 


### PR DESCRIPTION
* Fix #286 
* Fix wrong test case
* Also fix catching incorrect exception in test case

Not sure if pre-release splitting should be moved to `SemanticVersionImpl` though.

> Precedence for two pre-release versions with the same major, minor, and patch version MUST be determined by comparing each dot separated identifier from left to right until a difference is found as follows:
- [X]    Identifiers consisting of only digits are compared numerically.
- [X]    Identifiers with letters or hyphens are compared lexically in ASCII sort order.
- [x]    Numeric identifiers always have lower precedence than non-numeric identifiers.
- [X] A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal.
