### PR TITLE
Get LaunchWrapper / FabricTweaker working again

### DIFF
--- a/src/main/java/net/fabricmc/loader/entrypoint/EntrypointTransformer.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/EntrypointTransformer.java
@@ -42,7 +42,7 @@ public class EntrypointTransformer {
 	}
 
 	ClassNode loadClass(FabricLauncher launcher, String className) throws IOException {
-		byte[] data = patchedClasses.containsKey(className) ? patchedClasses.get(className) : launcher.getClassByteArray(className, false);
+		byte[] data = patchedClasses.containsKey(className) ? patchedClasses.get(className) : launcher.getClassByteArray(className, true);
 		if (data != null) {
 			ClassReader reader = new ClassReader(data);
 			ClassNode node = new ClassNode();

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -27,6 +27,7 @@ import net.fabricmc.loader.launch.common.FabricMixinBootstrap;
 import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
+import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.launchwrapper.ITweaker;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.launchwrapper.LaunchClassLoader;
@@ -34,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.transformer.Proxy;
 
 import java.io.File;
 import java.io.IOException;
@@ -174,19 +176,17 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public byte[] getClassByteArray(String name, boolean runTransformers) throws IOException {
-		if (runTransformers) {
-			// TODO: we need a way of applying the class transformers without applying mixins
-			throw new UnsupportedOperationException("TODO getClassByteArray/launchwrapper");
-		}
-
 		String transformedName = name.replace('/', '.');
 		byte[] classBytes = launchClassLoader.getClassBytes(name);
 
-//		if (runTransformers && !classLoaderUtil.isClassExcluded(name, transformedName)) {
-//			for (IClassTransformer transformer : launchClassLoader.getTransformers()) {
-//				classBytes = transformer.transform(name, transformedName, classBytes);
-//			}
-//		}
+		if (runTransformers) {
+			for (IClassTransformer transformer : launchClassLoader.getTransformers()) {
+				if (transformer instanceof Proxy) {
+					continue; // skip mixin as per method contract
+				}
+				classBytes = transformer.transform(name, transformedName, classBytes);
+			}
+		}
 
 		return classBytes;
 	}

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -90,11 +90,11 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.EnvType");
 
 		GameProvider provider = new MinecraftGameProvider();
-		provider.acceptArguments(arguments);
 
 		if (!provider.locateGame(getEnvironmentType(), launchClassLoader)) {
 			throw new RuntimeException("Could not locate Minecraft: provider locate failed");
 		}
+		provider.acceptArguments(arguments.toArray());
 
 		@SuppressWarnings("deprecation")
 		FabricLoader loader = FabricLoader.INSTANCE;

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -24,6 +24,7 @@ import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.game.MinecraftGameProvider;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.launch.common.FabricMixinBootstrap;
+import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
 import net.minecraft.launchwrapper.ITweaker;
@@ -41,12 +42,16 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public abstract class FabricTweaker extends FabricLauncherBase implements ITweaker {
 	protected static Logger LOGGER = LogManager.getFormatterLogger("Fabric|Tweaker");
-	protected String[] arguments;
+	protected Arguments arguments;
 	private LaunchClassLoader launchClassLoader;
 	private boolean isDevelopment;
+
+	@SuppressWarnings("unchecked")
+	private final boolean isPrimaryTweaker = ((List<ITweaker>) Launch.blackboard.get("Tweaks")).isEmpty();
 
 	@Override
 	public String getEntrypoint() {
@@ -61,8 +66,8 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public void acceptOptions(List<String> localArgs, File gameDir, File assetsDir, String profile) {
-		arguments = localArgs.toArray(new String[0]);
-		/*arguments.parse(localArgs);
+		arguments = new Arguments();
+		arguments.parse(localArgs);
 
 		if (!arguments.containsKey("gameDir") && gameDir != null) {
 			arguments.put("gameDir", gameDir.getAbsolutePath());
@@ -72,7 +77,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 			arguments.put("assetsDir", assetsDir.getAbsolutePath());
 		}
 
-		FabricLauncherBase.processArgumentMap(arguments, getEnvironmentType());*/
+		FabricLauncherBase.processArgumentMap(arguments, getEnvironmentType());
 	}
 
 	@Override
@@ -139,7 +144,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public String[] getLaunchArguments() {
-		return arguments;
+		return isPrimaryTweaker ? arguments.toArray() : new String[0];
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -105,6 +105,9 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.ClientModInitializer");
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.DedicatedServerModInitializer");
 
+		// FIXME: remove the GSON exclusion once loader stops using it (or repackages it)
+		launchClassLoader.addClassLoaderExclusion("com.google.gson.");
+
 		GameProvider provider = new MinecraftGameProvider();
 
 		if (!provider.locateGame(getEnvironmentType(), launchClassLoader)) {

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -37,14 +37,20 @@ import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.transformer.Proxy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
 
 public abstract class FabricTweaker extends FabricLauncherBase implements ITweaker {
 	protected static Logger LOGGER = LogManager.getFormatterLogger("Fabric|Tweaker");
@@ -126,7 +132,11 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 					throw new RuntimeException("Could not locate Minecraft: " + jarFile.getAbsolutePath() + " not found");
 				}
 
-				FabricLauncherBase.deobfuscate(provider.getGameId(), provider.getNormalizedGameVersion(), provider.getLaunchDirectory(), jarFile.toPath(), this);
+				Path obfuscated = jarFile.toPath();
+				Path remapped = FabricLauncherBase.deobfuscate(provider.getGameId(), provider.getNormalizedGameVersion(), provider.getLaunchDirectory(), obfuscated, this);
+				if (remapped != obfuscated) {
+					preloadRemappedJar(remapped);
+				}
 			} catch (IOException | UrlConversionException e) {
 				throw new RuntimeException("Failed to deobfuscate Minecraft!", e);
 			}
@@ -189,6 +199,56 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		}
 
 		return classBytes;
+	}
+
+	// By default the remapped jar will be on the classpath after the obfuscated one.
+	// This will lead to us finding and the launching the obfuscated one when we search
+	// for the entrypoint.
+	// To work around that, we pre-popuplate the LaunchClassLoader's resource cache,
+	// which will then cause it to use the one we need it to.
+	private void preloadRemappedJar(Path remappedJarFile) throws IOException {
+		Map<String, byte[]> resourceCache = null;
+		try {
+			Field f = LaunchClassLoader.class.getDeclaredField("resourceCache");
+			f.setAccessible(true);
+			//noinspection unchecked
+			resourceCache = (Map<String, byte[]>) f.get(launchClassLoader);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		if (resourceCache == null) {
+			LOGGER.warn("Resource cache not pre-populated - this will probably cause issues...");
+			return;
+		}
+
+		try (FileInputStream jarFileStream = new FileInputStream(remappedJarFile.toFile());
+			 JarInputStream jarStream = new JarInputStream(jarFileStream)) {
+			JarEntry entry;
+
+			while ((entry = jarStream.getNextJarEntry()) != null) {
+				if (entry.getName().startsWith("net/minecraft/class_") || !entry.getName().endsWith(".class")) {
+					// These will never be in the obfuscated jar, so we can safely skip them
+					continue;
+				}
+				String className = entry.getName();
+				className = className.substring(0, className.length() - 6).replace('/', '.');
+				LOGGER.debug("Appending " + className + " to resource cache...");
+				resourceCache.put(className, toByteArray(jarStream));
+			}
+		}
+	}
+
+	private byte[] toByteArray(InputStream inputStream) throws IOException {
+		int estimate = inputStream.available();
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream(estimate < 32 ? 32768 : estimate);
+		byte[] buffer = new byte[8192];
+		int len;
+		while ((len = inputStream.read(buffer)) > 0) {
+			outputStream.write(buffer, 0, len);
+		}
+
+		return outputStream.toByteArray();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -88,6 +88,9 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.Environment");
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.EnvType");
+		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.ModInitializer");
+		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.ClientModInitializer");
+		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.DedicatedServerModInitializer");
 
 		GameProvider provider = new MinecraftGameProvider();
 

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
@@ -66,7 +66,7 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 
 	private static boolean emittedInfo = false;
 
-	protected static void deobfuscate(String gameId, String gameVersion, Path gameDir, Path jarFile, FabricLauncher launcher) {
+	protected static Path deobfuscate(String gameId, String gameVersion, Path gameDir, Path jarFile, FabricLauncher launcher) {
 		Path resultJarFile = jarFile;
 
 		LOGGER.debug("Requesting deobfuscation of " + jarFile.getFileName());
@@ -206,6 +206,8 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 		if (minecraftJar == null) {
 			minecraftJar = resultJarFile;
 		}
+
+		return resultJarFile;
 	}
 
 	public static void processArgumentMap(Arguments argMap, EnvType envType) {


### PR DESCRIPTION
Fabric*Tweaker can now be used to launch fabric-loader on LaunchWrapper either as the primary tweaker, which should be functionally equivalent to launching with Knot (except for LaunchWrapper caveats ofc), or as a secondary tweaker, which allows fabric-loader (and mods, provided they were built for the right mappings) to run next to third-party tweaker-based mods.

See individual commits for details.

Fixes #202 
Fixes #168 
Partially #137 (only the LaunchWrapper part, I did not look at KnotCompatibilityClassLoader)


Tested configurations (both on MultiMC):
- All of Fabric 3 on LaunchWrapper (skipping Jumploader, no clue how to configure it)
- ReplayMod with a small subset of fabric-api (both compiled to `official` instead of `intermediary` mappings) running on Vivecraft (which includes Optifine, both are tweakers) on MC 1.15.2

I have not tested the tweaker on the server side (but given it was completely broken before, it could hardly have become worse).