### PR TITLE
Allowing using a JSON array of mod objects in fabric.mod.json

### DIFF
--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
@@ -24,6 +24,8 @@ import net.fabricmc.loader.util.version.VersionDeserializer;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ModMetadataParser {
 	public static final int LATEST_VERSION = 1;
@@ -74,6 +76,19 @@ public class ModMetadataParser {
 			if (metadata != null) {
 				return new LoaderModMetadata[] { metadata };
 			}
+		} else if (el.isJsonArray()) {
+			List<LoaderModMetadata> mods = new ArrayList<>();
+
+			for (JsonElement child : el.getAsJsonArray()) {
+				if (child.isJsonObject()) {
+					LoaderModMetadata metadata = getMod(loader, child.getAsJsonObject());
+					if (metadata != null) {
+						mods.add(metadata);
+					}
+				}
+			}
+
+			return mods.toArray(new LoaderModMetadata[0]);
 		}
 
 		return new LoaderModMetadata[0];


### PR DESCRIPTION
This is specified in the [original v1 specification](https://fabricmc.net/wiki/format:modjson?rev=1554655526) with the comment:
> this is not supported by Loader as of 0.4.0, but is a part of the specification

This is still untested so I'm marking it as a draft.