### PR TITLE
Add FabricLoader#getLaunchArguments(sanitize)

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -470,4 +470,9 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 
 		this.gameInstance = gameInstance;
 	}
+
+	@Override
+	public String[] getLaunchArguments(boolean sanitize) {
+		return getGameProvider().getLaunchArguments(sanitize);
+	}
 }

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -192,8 +192,7 @@ public interface FabricLoader {
 	String[] getLaunchArguments(boolean sanitize);
 
 	/**
-	 * Gets the command line arguments used to launch the game. This overload sets {@code sanitize} to {@code true}.
-	 * @return the launch arguments
+	 * @see FabricLoader#getLaunchArguments(boolean)
 	 */
 	default String[] getLaunchArguments() {
 		return getLaunchArguments(true);

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -190,13 +190,4 @@ public interface FabricLoader {
 	 * @return the launch arguments
 	 */
 	String[] getLaunchArguments(boolean sanitize);
-
-	/**
-	 * @see FabricLoader#getLaunchArguments(boolean)
-	 * <p>
-	 * Does not contain any sensitive information.
-	 */
-	default String[] getLaunchArguments() {
-		return getLaunchArguments(true);
-	}
 }

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -185,7 +185,7 @@ public interface FabricLoader {
 	File getConfigDirectory();
 
 	/**
-	 * Get the launch arguments
+	 * Gets the command line arguments used to launch the game.
 	 * @param sanitize Whether to remove sensitive information
 	 * @return the launch arguments
 	 */

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -185,9 +185,17 @@ public interface FabricLoader {
 	File getConfigDirectory();
 
 	/**
-	 * Gets the command line arguments used to launch the game.
+	 * Gets the command line arguments used to launch the game. If this is printed for debugging, make sure {@code sanitize} is {@code true}.
 	 * @param sanitize Whether to remove sensitive information
 	 * @return the launch arguments
 	 */
 	String[] getLaunchArguments(boolean sanitize);
+
+	/**
+	 * Gets the command line arguments used to launch the game. This overload sets {@code sanitize} to {@code true}.
+	 * @return the launch arguments
+	 */
+	default String[] getLaunchArguments() {
+		return getLaunchArguments(true);
+	}
 }

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -193,6 +193,8 @@ public interface FabricLoader {
 
 	/**
 	 * @see FabricLoader#getLaunchArguments(boolean)
+	 * <p>
+	 * Does not contain any sensitive information.
 	 */
 	default String[] getLaunchArguments() {
 		return getLaunchArguments(true);

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -183,4 +183,11 @@ public interface FabricLoader {
 
 	@Deprecated
 	File getConfigDirectory();
+
+	/**
+	 * Get the launch arguments
+	 * @param sanitize Whether to remove sensitive information
+	 * @return the launch arguments
+	 */
+	String[] getLaunchArguments(boolean sanitize);
 }

--- a/src/main/java/net/fabricmc/loader/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/GameProvider.java
@@ -43,6 +43,8 @@ public interface GameProvider {
 	EntrypointTransformer getEntrypointTransformer();
 	void launch(ClassLoader loader);
 
+	String[] getLaunchArguments(boolean sanitize);
+
 	default boolean canOpenErrorGui() {
 		return true;
 	}

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -156,6 +157,31 @@ public class MinecraftGameProvider implements GameProvider {
 		arguments.parse(argStrs);
 
 		FabricLauncherBase.processArgumentMap(arguments, envType);
+	}
+
+	@Override
+	public String[] getLaunchArguments(boolean sanitize) {
+		if (arguments != null) {
+			List<String> list = new ArrayList<>(Arrays.asList(arguments.toArray()));
+			if (sanitize) {
+				int remove = 0;
+				Iterator<String> iterator = list.iterator();
+				while (iterator.hasNext()) {
+					String next = iterator.next();
+					if ("--accessToken".equals(next)) {
+						remove = 2;
+					}
+
+					if (remove > 0) {
+						iterator.remove();
+						remove--;
+					}
+				}
+			}
+			return list.toArray(new String[0]);
+		} else {
+			return new String[0];
+		}
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -182,8 +182,10 @@ public class MinecraftGameProvider implements GameProvider {
 					}
 				}
 			}
+
 			return list.toArray(new String[0]);
 		}
+
 		return new String[0];
 	}
 

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -168,6 +168,7 @@ public class MinecraftGameProvider implements GameProvider {
 			if (sanitize) {
 				int remove = 0;
 				Iterator<String> iterator = list.iterator();
+
 				while (iterator.hasNext()) {
 					String next = iterator.next();
 

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -161,13 +161,16 @@ public class MinecraftGameProvider implements GameProvider {
 
 	@Override
 	public String[] getLaunchArguments(boolean sanitize) {
+
 		if (arguments != null) {
 			List<String> list = new ArrayList<>(Arrays.asList(arguments.toArray()));
+
 			if (sanitize) {
 				int remove = 0;
 				Iterator<String> iterator = list.iterator();
 				while (iterator.hasNext()) {
 					String next = iterator.next();
+
 					if ("--accessToken".equals(next)) {
 						remove = 2;
 					}
@@ -179,9 +182,8 @@ public class MinecraftGameProvider implements GameProvider {
 				}
 			}
 			return list.toArray(new String[0]);
-		} else {
-			return new String[0];
 		}
+		return new String[0];
 	}
 
 	@Override


### PR DESCRIPTION
The ``sanitize`` parameter removes the access token so it isn't accidentally exposed.