### PR TITLE
Fix fabric-loader in developmental environments

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ClasspathModCandidateFinder.java
@@ -68,8 +68,8 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 								// Fabric being supposedly uninitialized.
 								// This heuristic could probably be better, but I doubt that any sane
 								// mod would include a second FabricLoader.
-								if (!(net.fabricmc.loader.api.FabricLoader.getInstance().isDevelopmentEnvironment()
-										&& new File(file, "net/fabricmc/loader/FabricLoader.class".replace('/', File.separatorChar)).exists())) {
+								if (!FabricLoader.INSTANCE.isDevelopmentEnvironment()
+										|| !new File(file, "net/fabricmc/loader/FabricLoader.class".replace('/', File.separatorChar)).exists()) {
 									FabricLauncherBase.getLauncher().propose(url);
 								}
 							}


### PR DESCRIPTION
This PR fixes a small issue that makes it impossible to run fabric-loader in development.

In development, ClasspathModCandidateFinder adds the fabric-loader classes to KnotClassLoader as if it were a mod. This creates a situation where the entrypoint hooks are loaded on KnotClassLoader rather than AppClassLoader, which crashes the game when the hooks are run due to an unfrozen FabricLoader.

This fix involves a tiny heuristic that checks if `net/fabricmc/loader/FabricLoader.class` would be added to the classpath; if so, the dev classpath isn't added. This shouldn't affect any mods, unless they happen to also include a `net/fabricmc/loader/FabricLoader.class` file, which is probably not a good thing anyway.