### PR TITLE
Fix error from json migration

### DIFF
--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -263,7 +263,13 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 			return Collections.emptyList();
 		}
 
-		return this.entrypoints.get(type);
+		final List<EntrypointMetadata> entrypoints = this.entrypoints.get(type);
+
+		if (entrypoints != null) {
+			return entrypoints;
+		}
+
+		return Collections.emptyList();
 	}
 
 	@Override


### PR DESCRIPTION
There was a change that was overlooked where if no mod provides an entrypoint, the list of entrypoints is null which causes an NPE.

This returns an empty list if no entrypoints of the key are found so old behavior is restored.

Fixes #323