### PR TITLE
Fix the javadoc of getConflicts() and getBreaks() being the wrong way round

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
@@ -75,12 +75,12 @@ public interface ModMetadata {
 	Collection<ModDependency> getSuggests();
 
 	/**
-	 * Returns the mod's conflicts, with which the Loader will terminate loading.
+	 * Returns the mod's conflicts, with which the Loader will emit a warning.
 	 */
 	Collection<ModDependency> getConflicts();
 
 	/**
-	 * Returns the mod's conflicts, with which the Loader will emit a warning.
+	 * Returns the mod's conflicts, with which the Loader will terminate loading.
 	 */
 	Collection<ModDependency> getBreaks();
 


### PR DESCRIPTION
(See https://fabricmc.net/wiki/documentation:fabric_mod_json_spec for more details).

*Edited for a proper description*

Loader currently treats these the same way as the wiki, and mods almost certainly do too. However the javadocs (and as far as I can tell *only* the javadocs) swap their meaning.