### PR TITLE
Don't load .jar files which are *nix hidden files

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
@@ -59,7 +59,7 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 					/*
-					 * We only load propose a file as a possible mod in the following scenarios:
+					 * We only propose a file as a possible mod in the following scenarios:
 					 * General: Must be a jar file
 					 *
 					 * Some OSes Generate metadata so consider the following because of OSes:

--- a/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
@@ -67,7 +67,9 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 					 * MacOS: Exclude hidden + startsWith "." since Mac OS names their metadata files in the form of `.mod.jar`
 					 */
 
-					if (!Files.isHidden(file) && !file.toString().startsWith(".") && file.toString().endsWith(".jar")) {
+					String fileName = file.getFileName().toString();
+
+					if (fileName.endsWith(".jar") && !fileName.startsWith(".") && !Files.isHidden(file)) {
 						try {
 							urlProposer.accept(UrlUtil.asUrl(file), requiresRemap);
 						} catch (UrlConversionException e) {
@@ -75,7 +77,7 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 						}
 					}
 
-					return super.visitFile(file, attrs);
+					return FileVisitResult.CONTINUE;
 
 				}
 			});

--- a/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/discovery/DirectoryModCandidateFinder.java
@@ -23,8 +23,12 @@ import net.fabricmc.loader.util.UrlUtil;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.EnumSet;
 import java.util.function.BiConsumer;
 
 public class DirectoryModCandidateFinder implements ModCandidateFinder {
@@ -51,13 +55,28 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 		}
 
 		try {
-			Files.walk(path, 1, FileVisitOption.FOLLOW_LINKS).forEach((modPath) -> {
-				if (!Files.isDirectory(modPath) && modPath.toString().endsWith(".jar")) {
-					try {
-						urlProposer.accept(UrlUtil.asUrl(modPath), requiresRemap);
-					} catch (UrlConversionException e) {
-						throw new RuntimeException("Failed to convert URL for mod '" + modPath + "'!", e);
+			Files.walkFileTree(this.path, EnumSet.of(FileVisitOption.FOLLOW_LINKS), 1, new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					/*
+					 * We only load propose a file as a possible mod in the following scenarios:
+					 * General: Must be a jar file
+					 *
+					 * Some OSes Generate metadata so consider the following because of OSes:
+					 * UNIX: Exclude if file is hidden; this occurs when starting a file name with `.`
+					 * MacOS: Exclude hidden + startsWith "." since Mac OS names their metadata files in the form of `.mod.jar`
+					 */
+
+					if (!Files.isHidden(file) && !file.toString().startsWith(".") && file.toString().endsWith(".jar")) {
+						try {
+							urlProposer.accept(UrlUtil.asUrl(file), requiresRemap);
+						} catch (UrlConversionException e) {
+							throw new RuntimeException("Failed to convert URL for mod '" + file + "'!", e);
+						}
 					}
+
+					return super.visitFile(file, attrs);
+
 				}
 			});
 		} catch (IOException e) {


### PR DESCRIPTION
Fixes #325

The gist of the issue is that some *nix operating systems like Mac OS name their metadata `.FILE_NAME.jar` which loader tries to load and fails.