### PR TITLE
Add aliases to Fabric Loader

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -334,6 +334,9 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		mods.add(container);
 		modMap.put(info.getId(), container);
 		for (String alias : info.getAliases()) {
+			if(modMap.containsKey(alias)) {
+				throw new ModResolutionException("Duplicate alias: " + alias + "! (" + modMap.get(info.getId()).getOriginUrl().getFile() + ", " + originUrl.getFile() + ")");
+			}
 			modMap.put(alias, container);
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -333,7 +333,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		ModContainer container = new ModContainer(info, originUrl);
 		mods.add(container);
 		modMap.put(info.getId(), container);
-		for (String alias : info.getAliases()) {
+		for (String alias : info.getProvides()) {
 			if(modMap.containsKey(alias)) {
 				throw new ModResolutionException("Duplicate alias: " + alias + "! (" + modMap.get(info.getId()).getOriginUrl().getFile() + ", " + originUrl.getFile() + ")");
 			}

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -333,11 +333,11 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		ModContainer container = new ModContainer(info, originUrl);
 		mods.add(container);
 		modMap.put(info.getId(), container);
-		for (String alias : info.getProvides()) {
-			if(modMap.containsKey(alias)) {
-				throw new ModResolutionException("Duplicate alias: " + alias + "! (" + modMap.get(info.getId()).getOriginUrl().getFile() + ", " + originUrl.getFile() + ")");
+		for (String provides : info.getProvides()) {
+			if(modMap.containsKey(provides)) {
+				throw new ModResolutionException("Duplicate provided alias: " + provides + "! (" + modMap.get(info.getId()).getOriginUrl().getFile() + ", " + originUrl.getFile() + ")");
 			}
-			modMap.put(alias, container);
+			modMap.put(provides, container);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -333,6 +333,9 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		ModContainer container = new ModContainer(info, originUrl);
 		mods.add(container);
 		modMap.put(info.getId(), container);
+		for (String alias : info.getAliases()) {
+			modMap.put(alias, container);
+		}
 	}
 
 	protected void postprocessModMetadata() {

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
@@ -16,12 +16,13 @@
 
 package net.fabricmc.loader.api.metadata;
 
-import com.google.gson.JsonElement;
-import net.fabricmc.loader.api.Version;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+
+import com.google.gson.JsonElement;
+
+import net.fabricmc.loader.api.Version;
 
 /**
  * The metadata of a mod.

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
@@ -16,13 +16,12 @@
 
 package net.fabricmc.loader.api.metadata;
 
+import com.google.gson.JsonElement;
+import net.fabricmc.loader.api.Version;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-
-import com.google.gson.JsonElement;
-
-import net.fabricmc.loader.api.Version;
 
 /**
  * The metadata of a mod.
@@ -48,6 +47,15 @@ public interface ModMetadata {
 	 * @return the mod's ID.
 	 */
 	String getId();
+
+	/**
+	 * Returns the mod's ID aliases.
+	 *
+	 * <p>The aliases follow the same rules as ID</p>
+	 *
+	 * @return the mod's ID aliases
+	 */
+	Collection<String> getAliases();
 
 	/**
 	 * Returns the mod's version.

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
@@ -50,13 +50,13 @@ public interface ModMetadata {
 	String getId();
 
 	/**
-	 * Returns the mod's ID aliases.
+	 * Returns the mod's ID provides.
 	 *
 	 * <p>The aliases follow the same rules as ID</p>
 	 *
-	 * @return the mod's ID aliases
+	 * @return the mod's ID provides
 	 */
-	Collection<String> getAliases();
+	Collection<String> getProvides();
 
 	/**
 	 * Returns the mod's version.

--- a/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
@@ -50,7 +50,7 @@ class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMet
 	public String getId() { return parent.getId(); }
 
 	@Override
-	public Collection<String> getAliases() { return parent.getAliases(); }
+	public Collection<String> getProvides() { return parent.getProvides(); }
 
 	@Override
 	public Version getVersion() { return parent.getVersion(); }

--- a/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
@@ -16,16 +16,26 @@
 
 package net.fabricmc.loader.discovery;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Logger;
+
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.metadata.*;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.Person;
 import net.fabricmc.loader.metadata.AbstractModMetadata;
 import net.fabricmc.loader.metadata.EntrypointMetadata;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.metadata.NestedJarEntry;
-import org.apache.logging.log4j.Logger;
-
-import java.util.*;
 
 class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMetadata {
 	private final ModMetadata parent;
@@ -35,120 +45,53 @@ class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMet
 	}
 
 	@Override
-	public String getType() {
-		return parent.getType();
-	}
+	public String getType() { return parent.getType(); }
+	@Override
+	public String getId() { return parent.getId(); }
 
 	@Override
-	public String getId() {
-		return parent.getId();
-	}
+	public Collection<String> getAliases() { return parent.getAliases(); }
 
 	@Override
-	public Collection<String> getAliases() {
-		return parent.getAliases();
-	}
-
+	public Version getVersion() { return parent.getVersion(); }
 	@Override
-	public Version getVersion() {
-		return parent.getVersion();
-	}
-
+	public ModEnvironment getEnvironment() { return parent.getEnvironment(); }
 	@Override
-	public ModEnvironment getEnvironment() {
-		return parent.getEnvironment();
-	}
-
+	public Collection<ModDependency> getDepends() { return parent.getDepends(); }
 	@Override
-	public Collection<ModDependency> getDepends() {
-		return parent.getDepends();
-	}
-
+	public Collection<ModDependency> getRecommends() { return parent.getRecommends(); }
 	@Override
-	public Collection<ModDependency> getRecommends() {
-		return parent.getRecommends();
-	}
-
+	public Collection<ModDependency> getSuggests() { return parent.getSuggests(); }
 	@Override
-	public Collection<ModDependency> getSuggests() {
-		return parent.getSuggests();
-	}
-
+	public Collection<ModDependency> getConflicts() { return parent.getConflicts(); }
 	@Override
-	public Collection<ModDependency> getConflicts() {
-		return parent.getConflicts();
-	}
-
+	public Collection<ModDependency> getBreaks() { return parent.getBreaks(); }
 	@Override
-	public Collection<ModDependency> getBreaks() {
-		return parent.getBreaks();
-	}
-
+	public String getName() { return parent.getName(); }
 	@Override
-	public String getName() {
-		return parent.getName();
-	}
-
+	public String getDescription() { return parent.getDescription(); }
 	@Override
-	public String getDescription() {
-		return parent.getDescription();
-	}
-
+	public Collection<Person> getAuthors() { return parent.getAuthors(); }
 	@Override
-	public Collection<Person> getAuthors() {
-		return parent.getAuthors();
-	}
-
+	public Collection<Person> getContributors() { return parent.getContributors(); }
 	@Override
-	public Collection<Person> getContributors() {
-		return parent.getContributors();
-	}
-
+	public ContactInformation getContact() { return parent.getContact(); }
 	@Override
-	public ContactInformation getContact() {
-		return parent.getContact();
-	}
-
+	public Collection<String> getLicense() { return parent.getLicense(); }
 	@Override
-	public Collection<String> getLicense() {
-		return parent.getLicense();
-	}
-
+	public Optional<String> getIconPath(int size) { return parent.getIconPath(size); }
 	@Override
-	public Optional<String> getIconPath(int size) {
-		return parent.getIconPath(size);
-	}
-
+	public boolean containsCustomValue(String key) { return parent.containsCustomValue(key); }
 	@Override
-	public boolean containsCustomValue(String key) {
-		return parent.containsCustomValue(key);
-	}
-
+	public CustomValue getCustomValue(String key) { return parent.getCustomValue(key); }
 	@Override
-	public CustomValue getCustomValue(String key) {
-		return parent.getCustomValue(key);
-	}
-
+	public Map<String, CustomValue> getCustomValues() { return parent.getCustomValues(); }
 	@Override
-	public Map<String, CustomValue> getCustomValues() {
-		return parent.getCustomValues();
-	}
-
+	public int getSchemaVersion() { return Integer.MAX_VALUE; }
 	@Override
-	public int getSchemaVersion() {
-		return Integer.MAX_VALUE;
-	}
-
+	public Map<String, String> getLanguageAdapterDefinitions() { return Collections.emptyMap(); }
 	@Override
-	public Map<String, String> getLanguageAdapterDefinitions() {
-		return Collections.emptyMap();
-	}
-
-	@Override
-	public Collection<NestedJarEntry> getJars() {
-		return Collections.emptyList();
-	}
-
+	public Collection<NestedJarEntry> getJars() { return Collections.emptyList(); }
 	@Override
 	public Collection<String> getMixinConfigs(EnvType type) { return Collections.emptyList(); }
 	@Override

--- a/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
@@ -16,26 +16,16 @@
 
 package net.fabricmc.loader.discovery;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.logging.log4j.Logger;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-import net.fabricmc.loader.api.metadata.CustomValue;
-import net.fabricmc.loader.api.metadata.ModDependency;
-import net.fabricmc.loader.api.metadata.ModEnvironment;
-import net.fabricmc.loader.api.metadata.ModMetadata;
-import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.api.metadata.*;
 import net.fabricmc.loader.metadata.AbstractModMetadata;
 import net.fabricmc.loader.metadata.EntrypointMetadata;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.metadata.NestedJarEntry;
+import org.apache.logging.log4j.Logger;
+
+import java.util.*;
 
 class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMetadata {
 	private final ModMetadata parent;
@@ -45,49 +35,120 @@ class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMet
 	}
 
 	@Override
-	public String getType() { return parent.getType(); }
+	public String getType() {
+		return parent.getType();
+	}
+
 	@Override
-	public String getId() { return parent.getId(); }
+	public String getId() {
+		return parent.getId();
+	}
+
 	@Override
-	public Version getVersion() { return parent.getVersion(); }
+	public Collection<String> getAliases() {
+		return parent.getAliases();
+	}
+
 	@Override
-	public ModEnvironment getEnvironment() { return parent.getEnvironment(); }
+	public Version getVersion() {
+		return parent.getVersion();
+	}
+
 	@Override
-	public Collection<ModDependency> getDepends() { return parent.getDepends(); }
+	public ModEnvironment getEnvironment() {
+		return parent.getEnvironment();
+	}
+
 	@Override
-	public Collection<ModDependency> getRecommends() { return parent.getRecommends(); }
+	public Collection<ModDependency> getDepends() {
+		return parent.getDepends();
+	}
+
 	@Override
-	public Collection<ModDependency> getSuggests() { return parent.getSuggests(); }
+	public Collection<ModDependency> getRecommends() {
+		return parent.getRecommends();
+	}
+
 	@Override
-	public Collection<ModDependency> getConflicts() { return parent.getConflicts(); }
+	public Collection<ModDependency> getSuggests() {
+		return parent.getSuggests();
+	}
+
 	@Override
-	public Collection<ModDependency> getBreaks() { return parent.getBreaks(); }
+	public Collection<ModDependency> getConflicts() {
+		return parent.getConflicts();
+	}
+
 	@Override
-	public String getName() { return parent.getName(); }
+	public Collection<ModDependency> getBreaks() {
+		return parent.getBreaks();
+	}
+
 	@Override
-	public String getDescription() { return parent.getDescription(); }
+	public String getName() {
+		return parent.getName();
+	}
+
 	@Override
-	public Collection<Person> getAuthors() { return parent.getAuthors(); }
+	public String getDescription() {
+		return parent.getDescription();
+	}
+
 	@Override
-	public Collection<Person> getContributors() { return parent.getContributors(); }
+	public Collection<Person> getAuthors() {
+		return parent.getAuthors();
+	}
+
 	@Override
-	public ContactInformation getContact() { return parent.getContact(); }
+	public Collection<Person> getContributors() {
+		return parent.getContributors();
+	}
+
 	@Override
-	public Collection<String> getLicense() { return parent.getLicense(); }
+	public ContactInformation getContact() {
+		return parent.getContact();
+	}
+
 	@Override
-	public Optional<String> getIconPath(int size) { return parent.getIconPath(size); }
+	public Collection<String> getLicense() {
+		return parent.getLicense();
+	}
+
 	@Override
-	public boolean containsCustomValue(String key) { return parent.containsCustomValue(key); }
+	public Optional<String> getIconPath(int size) {
+		return parent.getIconPath(size);
+	}
+
 	@Override
-	public CustomValue getCustomValue(String key) { return parent.getCustomValue(key); }
+	public boolean containsCustomValue(String key) {
+		return parent.containsCustomValue(key);
+	}
+
 	@Override
-	public Map<String, CustomValue> getCustomValues() { return parent.getCustomValues(); }
+	public CustomValue getCustomValue(String key) {
+		return parent.getCustomValue(key);
+	}
+
 	@Override
-	public int getSchemaVersion() { return Integer.MAX_VALUE; }
+	public Map<String, CustomValue> getCustomValues() {
+		return parent.getCustomValues();
+	}
+
 	@Override
-	public Map<String, String> getLanguageAdapterDefinitions() { return Collections.emptyMap(); }
+	public int getSchemaVersion() {
+		return Integer.MAX_VALUE;
+	}
+
 	@Override
-	public Collection<NestedJarEntry> getJars() { return Collections.emptyList(); }
+	public Map<String, String> getLanguageAdapterDefinitions() {
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public Collection<NestedJarEntry> getJars() {
+		return Collections.emptyList();
+	}
+
 	@Override
 	public Collection<String> getMixinConfigs(EnvType type) { return Collections.emptyList(); }
 	@Override

--- a/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
@@ -17,7 +17,6 @@
 package net.fabricmc.loader.discovery;
 
 import net.fabricmc.loader.api.Version;
-
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 public class ModCandidateSet {
 	private final String modId;
-	private final List<String> modAliases = new ArrayList<>();
+	private final List<String> modProvides = new ArrayList<>();
 	private final Set<ModCandidate> depthZeroCandidates = new HashSet<>();
 	private final Map<String, ModCandidate> candidates = new HashMap<>();
 
@@ -46,8 +46,8 @@ public class ModCandidateSet {
 		return modId;
 	}
 
-	public List<String> getModAliases() {
-		return modAliases;
+	public List<String> getModProvides() {
+		return modProvides;
 	}
 
 	public boolean add(ModCandidate candidate) {
@@ -68,7 +68,7 @@ public class ModCandidateSet {
 		}
 
 		candidates.put(version, candidate);
-		modAliases.addAll(candidate.getInfo().getAliases());
+		modProvides.addAll(candidate.getInfo().getProvides());
 		if (candidate.getDepth() == 0) {
 			depthZeroCandidates.add(candidate);
 		}

--- a/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModCandidateSet.java
@@ -17,11 +17,13 @@
 package net.fabricmc.loader.discovery;
 
 import net.fabricmc.loader.api.Version;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class ModCandidateSet {
 	private final String modId;
+	private final List<String> modAliases = new ArrayList<>();
 	private final Set<ModCandidate> depthZeroCandidates = new HashSet<>();
 	private final Map<String, ModCandidate> candidates = new HashMap<>();
 
@@ -45,6 +47,10 @@ public class ModCandidateSet {
 		return modId;
 	}
 
+	public List<String> getModAliases() {
+		return modAliases;
+	}
+
 	public boolean add(ModCandidate candidate) {
 		String version = candidate.getInfo().getVersion().getFriendlyString();
 		ModCandidate oldCandidate = candidates.get(version);
@@ -63,6 +69,7 @@ public class ModCandidateSet {
 		}
 
 		candidates.put(version, candidate);
+		modAliases.addAll(candidate.getInfo().getAliases());
 		if (candidate.getDepth() == 0) {
 			depthZeroCandidates.add(candidate);
 		}

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -113,7 +113,9 @@ public class ModResolver {
 		if (!isAdvanced) {
 			result = new HashMap<>();
 			for (String s : modCandidateMap.keySet()) {
-				result.put(s, modCandidateMap.get(s).iterator().next());
+				ModCandidate candidate = modCandidateMap.get(s).iterator().next();
+				// if the candidate isn't actually just a alias, then put it on
+				if(!candidate.getInfo().getAliases().contains(s)) result.put(s, candidate);
 			}
 		} else {
 			// Inspired by http://0install.net/solver.html

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -342,7 +342,7 @@ public class ModResolver {
 		if(depCandidate == null) {
 			for (ModCandidate value : result.values()) {
 				if (value.getInfo().getAliases().contains(depModId)) {
-					logger.warn("Mod " + candidate.getInfo().getId() + " is using the alias " + depModId + " in place of the mod id " + value.getInfo().getId() + ".  Please use the mod id instead of a alias.");
+					if(FabricLoader.INSTANCE.isDevelopmentEnvironment()) logger.warn("Mod " + candidate.getInfo().getId() + " is using the alias " + depModId + " in place of the mod id " + value.getInfo().getId() + ".  Please use the mod id instead of a alias.");
 					depCandidate = value;
 					break;
 				}

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -338,6 +338,15 @@ public class ModResolver {
 		}
 
 		ModCandidate depCandidate = result.get(depModId);
+		// attempt searching aliases
+		if(depCandidate == null) {
+			for (ModCandidate value : result.values()) {
+				if (value.getInfo().getAliases().contains(depModId)) {
+					depCandidate = value;
+					break;
+				}
+			}
+		}
 		boolean isPresent = depCandidate != null && dependency.matches(depCandidate.getInfo().getVersion());
 
 		if (isPresent != cond) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -19,28 +19,23 @@ package net.fabricmc.loader.discovery;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.google.common.jimfs.PathType;
-
 import net.fabricmc.loader.FabricLoader;
+import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.game.GameProvider.BuiltinMod;
-import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.lib.gson.MalformedJsonException;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
-import net.fabricmc.loader.metadata.NestedJarEntry;
 import net.fabricmc.loader.metadata.ModMetadataParser;
+import net.fabricmc.loader.metadata.NestedJarEntry;
 import net.fabricmc.loader.metadata.ParseMetadataException;
 import net.fabricmc.loader.util.FileSystemUtil;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
 import net.fabricmc.loader.util.sat4j.core.VecInt;
 import net.fabricmc.loader.util.sat4j.minisat.SolverFactory;
-import net.fabricmc.loader.util.sat4j.specs.ContradictionException;
-import net.fabricmc.loader.util.sat4j.specs.IProblem;
-import net.fabricmc.loader.util.sat4j.specs.ISolver;
-import net.fabricmc.loader.util.sat4j.specs.IVecInt;
 import net.fabricmc.loader.util.sat4j.specs.TimeoutException;
-
+import net.fabricmc.loader.util.sat4j.specs.*;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
@@ -98,6 +93,9 @@ public class ModResolver {
 		for (ModCandidateSet mcs : modCandidateSetMap.values()) {
 			Collection<ModCandidate> s = mcs.toSortedSet();
 			modCandidateMap.put(mcs.getModId(), s);
+			for (String modAlias : mcs.getModAliases()) {
+				modCandidateMap.put(modAlias, s);
+			}
 			isAdvanced |= (s.size() > 1) || (s.iterator().next().getDepth() > 0);
 
 			if (mcs.isUserProvided()) {
@@ -250,7 +248,7 @@ public class ModResolver {
 		// verify result: all mandatory mods
 		Set<String> missingMods = new HashSet<>();
 		for (String m : mandatoryMods) {
-			if (!result.keySet().contains(m)) {
+			if (!result.containsKey(m)) {
 				missingMods.add(m);
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -98,8 +98,8 @@ public class ModResolver {
 		for (ModCandidateSet mcs : modCandidateSetMap.values()) {
 			Collection<ModCandidate> s = mcs.toSortedSet();
 			modCandidateMap.computeIfAbsent(mcs.getModId(), i -> new ArrayList<>()).addAll(s);
-			for (String modAlias : mcs.getModAliases()) {
-				modCandidateMap.computeIfAbsent(modAlias, i -> new ArrayList<>()).addAll(s);
+			for (String modProvide : mcs.getModProvides()) {
+				modCandidateMap.computeIfAbsent(modProvide, i -> new ArrayList<>()).addAll(s);
 			}
 			isAdvanced |= (s.size() > 1) || (s.iterator().next().getDepth() > 0);
 
@@ -114,8 +114,8 @@ public class ModResolver {
 			result = new HashMap<>();
 			for (String s : modCandidateMap.keySet()) {
 				ModCandidate candidate = modCandidateMap.get(s).iterator().next();
-				// if the candidate isn't actually just a alias, then put it on
-				if(!candidate.getInfo().getAliases().contains(s)) result.put(s, candidate);
+				// if the candidate isn't actually just a provided alias, then put it on
+				if(!candidate.getInfo().getProvides().contains(s)) result.put(s, candidate);
 			}
 		} else {
 			// Inspired by http://0install.net/solver.html
@@ -340,11 +340,11 @@ public class ModResolver {
 		}
 
 		ModCandidate depCandidate = result.get(depModId);
-		// attempt searching aliases
+		// attempt searching provides
 		if(depCandidate == null) {
 			for (ModCandidate value : result.values()) {
-				if (value.getInfo().getAliases().contains(depModId)) {
-					if(FabricLoader.INSTANCE.isDevelopmentEnvironment()) logger.warn("Mod " + candidate.getInfo().getId() + " is using the alias " + depModId + " in place of the mod id " + value.getInfo().getId() + ".  Please use the mod id instead of a alias.");
+				if (value.getInfo().getProvides().contains(depModId)) {
+					if(FabricLoader.INSTANCE.isDevelopmentEnvironment()) logger.warn("Mod " + candidate.getInfo().getId() + " is using the provided alias " + depModId + " in place of the real mod id " + value.getInfo().getId() + ".  Please use the mod id instead of a provided alias.");
 					depCandidate = value;
 					break;
 				}
@@ -646,12 +646,12 @@ public class ModResolver {
 					throw new RuntimeException(fullError.toString());
 				}
 
-				for(String alias : candidate.getInfo().getAliases()) {
-					if (!MOD_ID_PATTERN.matcher(alias).matches()) {
+				for(String provides : candidate.getInfo().getProvides()) {
+					if (!MOD_ID_PATTERN.matcher(provides).matches()) {
 						List<String> errorList = new ArrayList<>();
-						isModIdValid(alias, errorList);
-						StringBuilder fullError = new StringBuilder("Mod id alias `");
-						fullError.append(alias).append("` does not match the requirements because");
+						isModIdValid(provides, errorList);
+						StringBuilder fullError = new StringBuilder("Mod id provides `");
+						fullError.append(provides).append("` does not match the requirements because");
 
 						if (errorList.size() == 1) {
 							fullError.append(" it ").append(errorList.get(0));

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -646,6 +646,26 @@ public class ModResolver {
 					throw new RuntimeException(fullError.toString());
 				}
 
+				for(String alias : candidate.getInfo().getAliases()) {
+					if (!MOD_ID_PATTERN.matcher(alias).matches()) {
+						List<String> errorList = new ArrayList<>();
+						isModIdValid(alias, errorList);
+						StringBuilder fullError = new StringBuilder("Mod id alias `");
+						fullError.append(alias).append("` does not match the requirements because");
+
+						if (errorList.size() == 1) {
+							fullError.append(" it ").append(errorList.get(0));
+						} else {
+							fullError.append(":");
+							for (String error : errorList) {
+								fullError.append("\n  - It ").append(error);
+							}
+						}
+
+						throw new RuntimeException(fullError.toString());
+					}
+				}
+
 				added = candidatesById.computeIfAbsent(candidate.getInfo().getId(), ModCandidateSet::new).add(candidate);
 
 				if (!added) {

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -19,23 +19,28 @@ package net.fabricmc.loader.discovery;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.google.common.jimfs.PathType;
+
 import net.fabricmc.loader.FabricLoader;
-import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.game.GameProvider.BuiltinMod;
+import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.lib.gson.MalformedJsonException;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
-import net.fabricmc.loader.metadata.ModMetadataParser;
 import net.fabricmc.loader.metadata.NestedJarEntry;
+import net.fabricmc.loader.metadata.ModMetadataParser;
 import net.fabricmc.loader.metadata.ParseMetadataException;
 import net.fabricmc.loader.util.FileSystemUtil;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
 import net.fabricmc.loader.util.sat4j.core.VecInt;
 import net.fabricmc.loader.util.sat4j.minisat.SolverFactory;
+import net.fabricmc.loader.util.sat4j.specs.ContradictionException;
+import net.fabricmc.loader.util.sat4j.specs.IProblem;
+import net.fabricmc.loader.util.sat4j.specs.ISolver;
+import net.fabricmc.loader.util.sat4j.specs.IVecInt;
 import net.fabricmc.loader.util.sat4j.specs.TimeoutException;
-import net.fabricmc.loader.util.sat4j.specs.*;
+
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
@@ -248,7 +253,7 @@ public class ModResolver {
 		// verify result: all mandatory mods
 		Set<String> missingMods = new HashSet<>();
 		for (String m : mandatoryMods) {
-			if (!result.containsKey(m)) {
+			if (!result.keySet().contains(m)) {
 				missingMods.add(m);
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -267,19 +267,19 @@ public class ModResolver {
 			// verify result: dependencies
 			for (ModCandidate candidate : result.values()) {
 				for (ModDependency dependency : candidate.getInfo().getDepends()) {
-					addErrorToList(candidate, dependency, result, errorsHard, "requires", true);
+					addErrorToList(logger, candidate, dependency, result, errorsHard, "requires", true);
 				}
 
 				for (ModDependency dependency : candidate.getInfo().getRecommends()) {
-					addErrorToList(candidate, dependency, result, errorsSoft, "recommends", true);
+					addErrorToList(logger, candidate, dependency, result, errorsSoft, "recommends", true);
 				}
 
 				for (ModDependency dependency : candidate.getInfo().getBreaks()) {
-					addErrorToList(candidate, dependency, result, errorsHard, "is incompatible with", false);
+					addErrorToList(logger, candidate, dependency, result, errorsHard, "is incompatible with", false);
 				}
 
 				for (ModDependency dependency : candidate.getInfo().getConflicts()) {
-					addErrorToList(candidate, dependency, result, errorsSoft, "conflicts with", false);
+					addErrorToList(logger, candidate, dependency, result, errorsSoft, "conflicts with", false);
 				}
 
 				Version version = candidate.getInfo().getVersion();
@@ -321,7 +321,7 @@ public class ModResolver {
 		return result;
 	}
 
-	private void addErrorToList(ModCandidate candidate, ModDependency dependency, Map<String, ModCandidate> result, StringBuilder errors, String errorType, boolean cond) {
+	private void addErrorToList(Logger logger, ModCandidate candidate, ModDependency dependency, Map<String, ModCandidate> result, StringBuilder errors, String errorType, boolean cond) {
 		String depModId = dependency.getModId();
 
 		List<String> errorList = new ArrayList<>();
@@ -342,6 +342,7 @@ public class ModResolver {
 		if(depCandidate == null) {
 			for (ModCandidate value : result.values()) {
 				if (value.getInfo().getAliases().contains(depModId)) {
+					logger.warn("Mod " + candidate.getInfo().getId() + " is using the alias " + depModId + " in place of the mod id " + value.getInfo().getId() + ".  Please use the mod id instead of a alias.");
 					depCandidate = value;
 					break;
 				}

--- a/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
@@ -77,7 +77,7 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 	}
 
 	@Override
-	public Collection<String> getAliases() {
+	public Collection<String> getProvides() {
 		return Collections.emptyList();
 	}
 

--- a/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
@@ -16,13 +16,24 @@
 
 package net.fabricmc.loader.metadata;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
-import net.fabricmc.loader.api.metadata.*;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.Person;
 import net.fabricmc.loader.util.version.VersionDeserializer;
-
-import java.util.*;
-import java.util.Map.Entry;
 
 public final class BuiltinModMetadata extends AbstractModMetadata {
 	private final String id;

--- a/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/BuiltinModMetadata.java
@@ -16,24 +16,13 @@
 
 package net.fabricmc.loader.metadata;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.NavigableMap;
-import java.util.Optional;
-import java.util.TreeMap;
-
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-import net.fabricmc.loader.api.metadata.CustomValue;
-import net.fabricmc.loader.api.metadata.ModDependency;
-import net.fabricmc.loader.api.metadata.ModEnvironment;
-import net.fabricmc.loader.api.metadata.ModMetadata;
-import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.api.metadata.*;
 import net.fabricmc.loader.util.version.VersionDeserializer;
+
+import java.util.*;
+import java.util.Map.Entry;
 
 public final class BuiltinModMetadata extends AbstractModMetadata {
 	private final String id;
@@ -74,6 +63,11 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 	@Override
 	public String getId() {
 		return id;
+	}
+
+	@Override
+	public Collection<String> getAliases() {
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
@@ -103,7 +103,7 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	}
 
 	@Override
-	public Collection<String> getAliases() {
+	public Collection<String> getProvides() {
 		return Collections.emptyList();
 	}
 

--- a/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
@@ -16,12 +16,22 @@
 
 package net.fabricmc.loader.metadata;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.metadata.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
+import net.fabricmc.loader.api.metadata.Person;
 
 final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetadata {
 	private static final Mixins EMPTY_MIXINS = new Mixins(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());

--- a/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
@@ -16,22 +16,12 @@
 
 package net.fabricmc.loader.metadata;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.logging.log4j.Logger;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-import net.fabricmc.loader.api.metadata.CustomValue;
-import net.fabricmc.loader.api.metadata.ModDependency;
-import net.fabricmc.loader.api.metadata.ModEnvironment;
-import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.api.metadata.*;
+import org.apache.logging.log4j.Logger;
+
+import java.util.*;
 
 final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetadata {
 	private static final Mixins EMPTY_MIXINS = new Mixins(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
@@ -100,6 +90,11 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	@Override
 	public String getId() {
 		return this.id;
+	}
+
+	@Override
+	public Collection<String> getAliases() {
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -82,7 +82,7 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	V1ModMetadata(String id, Version version, Collection<String> aliases, ModEnvironment environment, Map<String, List<EntrypointMetadata>> entrypoints, Collection<NestedJarEntry> jars, Collection<MixinEntry> mixins, /* @Nullable */ String accessWidener, Map<String, ModDependency> depends, Map<String, ModDependency> recommends, Map<String, ModDependency> suggests, Map<String, ModDependency> conflicts, Map<String, ModDependency> breaks, Map<String, ModDependency> requires, /* @Nullable */ String name, /* @Nullable */String description, Collection<Person> authors, Collection<Person> contributors, /* @Nullable */ContactInformation contact, Collection<String> license, IconEntry icon, Map<String, String> languageAdapters, Map<String, CustomValue> customValues) {
 		this.id = id;
 		this.version = version;
-		this.aliases = aliases;
+		this.aliases = Collections.unmodifiableCollection(aliases);
 		this.environment = environment;
 		this.entrypoints = Collections.unmodifiableMap(entrypoints);
 		this.jars = Collections.unmodifiableCollection(jars);

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -16,23 +16,12 @@
 
 package net.fabricmc.loader.metadata;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.SortedMap;
-
-import org.apache.logging.log4j.Logger;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-import net.fabricmc.loader.api.metadata.CustomValue;
-import net.fabricmc.loader.api.metadata.ModDependency;
-import net.fabricmc.loader.api.metadata.ModEnvironment;
-import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.api.metadata.*;
+import org.apache.logging.log4j.Logger;
+
+import java.util.*;
 
 final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetadata {
 	static final IconEntry NO_ICON = size -> Optional.empty();
@@ -40,6 +29,9 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	// Required values
 	private final String id;
 	private final Version version;
+
+	// Optional (id aliases)
+	private final Collection<String> aliases;
 
 	// Optional (mod loading)
 	private final ModEnvironment environment;
@@ -76,9 +68,10 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	// Optional (custom values)
 	private final Map<String, CustomValue> customValues;
 
-	V1ModMetadata(String id, Version version, ModEnvironment environment, Map<String, List<EntrypointMetadata>> entrypoints, Collection<NestedJarEntry> jars, Collection<MixinEntry> mixins, /* @Nullable */ String accessWidener, Map<String, ModDependency> depends, Map<String, ModDependency> recommends, Map<String, ModDependency> suggests, Map<String, ModDependency> conflicts, Map<String, ModDependency> breaks, Map<String, ModDependency> requires, /* @Nullable */ String name, /* @Nullable */String description, Collection<Person> authors, Collection<Person> contributors, /* @Nullable */ContactInformation contact, Collection<String> license, IconEntry icon, Map<String, String> languageAdapters, Map<String, CustomValue> customValues) {
+	V1ModMetadata(String id, Version version, Collection<String> aliases, ModEnvironment environment, Map<String, List<EntrypointMetadata>> entrypoints, Collection<NestedJarEntry> jars, Collection<MixinEntry> mixins, /* @Nullable */ String accessWidener, Map<String, ModDependency> depends, Map<String, ModDependency> recommends, Map<String, ModDependency> suggests, Map<String, ModDependency> conflicts, Map<String, ModDependency> breaks, Map<String, ModDependency> requires, /* @Nullable */ String name, /* @Nullable */String description, Collection<Person> authors, Collection<Person> contributors, /* @Nullable */ContactInformation contact, Collection<String> license, IconEntry icon, Map<String, String> languageAdapters, Map<String, CustomValue> customValues) {
 		this.id = id;
 		this.version = version;
+		this.aliases = aliases;
 		this.environment = environment;
 		this.entrypoints = Collections.unmodifiableMap(entrypoints);
 		this.jars = Collections.unmodifiableCollection(jars);
@@ -133,6 +126,11 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	@Override
 	public String getId() {
 		return this.id;
+	}
+
+	@Override
+	public Collection<String> getAliases() {
+		return this.aliases;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -140,7 +140,7 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	}
 
 	@Override
-	public Collection<String> getAliases() {
+	public Collection<String> getProvides() {
 		return this.aliases;
 	}
 

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -16,12 +16,23 @@
 
 package net.fabricmc.loader.metadata;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.metadata.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
+import net.fabricmc.loader.api.metadata.Person;
 
 final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetadata {
 	static final IconEntry NO_ICON = size -> Optional.empty();

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -41,8 +41,8 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	private final String id;
 	private final Version version;
 
-	// Optional (id aliases)
-	private final Collection<String> aliases;
+	// Optional (id provides)
+	private final Collection<String> provides;
 
 	// Optional (mod loading)
 	private final ModEnvironment environment;
@@ -79,10 +79,10 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	// Optional (custom values)
 	private final Map<String, CustomValue> customValues;
 
-	V1ModMetadata(String id, Version version, Collection<String> aliases, ModEnvironment environment, Map<String, List<EntrypointMetadata>> entrypoints, Collection<NestedJarEntry> jars, Collection<MixinEntry> mixins, /* @Nullable */ String accessWidener, Map<String, ModDependency> depends, Map<String, ModDependency> recommends, Map<String, ModDependency> suggests, Map<String, ModDependency> conflicts, Map<String, ModDependency> breaks, Map<String, ModDependency> requires, /* @Nullable */ String name, /* @Nullable */String description, Collection<Person> authors, Collection<Person> contributors, /* @Nullable */ContactInformation contact, Collection<String> license, IconEntry icon, Map<String, String> languageAdapters, Map<String, CustomValue> customValues) {
+	V1ModMetadata(String id, Version version, Collection<String> provides, ModEnvironment environment, Map<String, List<EntrypointMetadata>> entrypoints, Collection<NestedJarEntry> jars, Collection<MixinEntry> mixins, /* @Nullable */ String accessWidener, Map<String, ModDependency> depends, Map<String, ModDependency> recommends, Map<String, ModDependency> suggests, Map<String, ModDependency> conflicts, Map<String, ModDependency> breaks, Map<String, ModDependency> requires, /* @Nullable */ String name, /* @Nullable */String description, Collection<Person> authors, Collection<Person> contributors, /* @Nullable */ContactInformation contact, Collection<String> license, IconEntry icon, Map<String, String> languageAdapters, Map<String, CustomValue> customValues) {
 		this.id = id;
 		this.version = version;
-		this.aliases = Collections.unmodifiableCollection(aliases);
+		this.provides = Collections.unmodifiableCollection(provides);
 		this.environment = environment;
 		this.entrypoints = Collections.unmodifiableMap(entrypoints);
 		this.jars = Collections.unmodifiableCollection(jars);
@@ -141,7 +141,7 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 
 	@Override
 	public Collection<String> getProvides() {
-		return this.aliases;
+		return this.provides;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
@@ -16,28 +16,16 @@
 
 package net.fabricmc.loader.metadata;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
-
-import org.apache.logging.log4j.Logger;
-
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-import net.fabricmc.loader.api.metadata.CustomValue;
-import net.fabricmc.loader.api.metadata.ModDependency;
-import net.fabricmc.loader.api.metadata.ModEnvironment;
-import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.api.metadata.*;
 import net.fabricmc.loader.lib.gson.JsonReader;
 import net.fabricmc.loader.lib.gson.JsonToken;
 import net.fabricmc.loader.util.version.VersionDeserializer;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.*;
 
 final class V1ModMetadataParser {
 	/**
@@ -55,6 +43,9 @@ final class V1ModMetadataParser {
 		// Required
 		String id = null;
 		Version version = null;
+
+		// Optional (id aliases)
+		List<String> aliases = new ArrayList<>();
 
 		// Optional (mod loading)
 		ModEnvironment environment = ModEnvironment.UNIVERSAL; // Default is always universal
@@ -107,63 +98,66 @@ final class V1ModMetadataParser {
 				}
 
 				break;
-			case "id":
-				if (reader.peek() != JsonToken.STRING) {
-					throw new ParseMetadataException("Mod id must be a non-empty string with a length of 3-64 characters.", reader);
-				}
+				case "id":
+					if (reader.peek() != JsonToken.STRING) {
+						throw new ParseMetadataException("Mod id must be a non-empty string with a length of 3-64 characters.", reader);
+					}
 
-				id = reader.nextString();
-				break;
-			case "version":
-				if (reader.peek() != JsonToken.STRING) {
-					throw new ParseMetadataException("Version must be a non-empty string", reader);
-				}
+					id = reader.nextString();
+					break;
+				case "aliases":
+					readAliases(reader, aliases);
+					break;
+				case "version":
+					if (reader.peek() != JsonToken.STRING) {
+						throw new ParseMetadataException("Version must be a non-empty string", reader);
+					}
 
-				try {
-					version = VersionDeserializer.deserialize(reader.nextString());
-				} catch (VersionParsingException e) {
-					throw new ParseMetadataException("Failed to parse version", e);
-				}
+					try {
+						version = VersionDeserializer.deserialize(reader.nextString());
+					} catch (VersionParsingException e) {
+						throw new ParseMetadataException("Failed to parse version", e);
+					}
 
-				break;
-			case "environment":
-				if (reader.peek() != JsonToken.STRING) {
-					throw new ParseMetadataException("Environment must be a string", reader);
-				}
+					break;
+				case "environment":
+					if (reader.peek() != JsonToken.STRING) {
+						throw new ParseMetadataException("Environment must be a string", reader);
+					}
 
-				environment = readEnvironment(reader);
-				break;
-			case "entrypoints":
-				readEntrypoints(warnings, reader, entrypoints);
-				break;
-			case "jars":
-				readNestedJarEntries(warnings, reader, jars);
-				break;
-			case "mixins":
-				readMixinConfigs(warnings, reader, mixins);
-				break;
-			case "accessWidener":
-				if (reader.peek() != JsonToken.STRING) {
-					throw new ParseMetadataException("Access Widener file must be a string", reader);
-				}
+					environment = readEnvironment(reader);
+					break;
+				case "entrypoints":
+					readEntrypoints(warnings, reader, entrypoints);
+					break;
+				case "jars":
+					readNestedJarEntries(warnings, reader, jars);
+					break;
+				case "mixins":
+					readMixinConfigs(warnings, reader, mixins);
+					break;
+				case "accessWidener":
+					if (reader.peek() != JsonToken.STRING) {
+						throw new ParseMetadataException("Access Widener file must be a string", reader);
+					}
 
-				accessWidener = reader.nextString();
-				break;
-			case "depends":
-				readDependenciesContainer(reader, depends);
-				break;
-			case "recommends":
-				readDependenciesContainer(reader, recommends);
-				break;
-			case "suggests":
-				readDependenciesContainer(reader, suggests);
-				break;
-			case "conflicts":
-				readDependenciesContainer(reader, conflicts);
-				break;
-			case "breaks":
-				readDependenciesContainer(reader, breaks);
-				break;
+					accessWidener = reader.nextString();
+					break;
+				case "depends":
+					readDependenciesContainer(reader, depends);
+					break;
+				case "recommends":
+					readDependenciesContainer(reader, recommends);
+					break;
+				case "suggests":
+					readDependenciesContainer(reader, suggests);
+					break;
+				case "conflicts":
+					readDependenciesContainer(reader, conflicts);
+					break;
+				case "breaks":
+					readDependenciesContainer(reader, breaks);
+					break;
 			case "requires":
 				readDependenciesContainer(reader, requires);
 				break;
@@ -220,7 +214,29 @@ final class V1ModMetadataParser {
 
 		ModMetadataParser.logWarningMessages(logger, id, warnings);
 
-		return new V1ModMetadata(id, version, environment, entrypoints, jars, mixins, accessWidener, depends, recommends, suggests, conflicts, breaks, requires, name, description, authors, contributors, contact, license, icon, languageAdapters, customValues);
+		return new V1ModMetadata(id, version, aliases, environment, entrypoints, jars, mixins, accessWidener, depends, recommends, suggests, conflicts, breaks, requires, name, description, authors, contributors, contact, license, icon, languageAdapters, customValues);
+	}
+
+	private static void readAliases(JsonReader reader, List<String> aliases) throws IOException, ParseMetadataException {
+		if (reader.peek() != JsonToken.BEGIN_ARRAY) {
+			throw new ParseMetadataException("Aliases must be in an array");
+		}
+
+		reader.beginArray();
+
+		while (reader.hasNext()) {
+			String alias;
+
+			if (reader.peek() == JsonToken.STRING) {
+				alias = reader.nextString();
+			} else {
+				throw new ParseMetadataException("Aliases must be a string", reader);
+			}
+
+			aliases.add(alias);
+		}
+
+		reader.endArray();
 	}
 
 	private static ModEnvironment readEnvironment(JsonReader reader) throws ParseMetadataException, IOException {

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
@@ -237,15 +237,11 @@ final class V1ModMetadataParser {
 		reader.beginArray();
 
 		while (reader.hasNext()) {
-			String alias;
-
 			if (reader.peek() != JsonToken.STRING) {
 				throw new ParseMetadataException("Aliases must be a string", reader);
 			}
 
-			alias = reader.nextString();
-
-			aliases.add(alias);
+			aliases.add(reader.nextString());
 		}
 
 		reader.endArray();

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
@@ -16,16 +16,28 @@
 
 package net.fabricmc.loader.metadata;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
-import net.fabricmc.loader.api.metadata.*;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
+import net.fabricmc.loader.api.metadata.Person;
 import net.fabricmc.loader.lib.gson.JsonReader;
 import net.fabricmc.loader.lib.gson.JsonToken;
 import net.fabricmc.loader.util.version.VersionDeserializer;
-import org.apache.logging.log4j.Logger;
-
-import java.io.IOException;
-import java.util.*;
 
 final class V1ModMetadataParser {
 	/**
@@ -98,66 +110,66 @@ final class V1ModMetadataParser {
 				}
 
 				break;
-				case "id":
-					if (reader.peek() != JsonToken.STRING) {
-						throw new ParseMetadataException("Mod id must be a non-empty string with a length of 3-64 characters.", reader);
-					}
+			case "id":
+				if (reader.peek() != JsonToken.STRING) {
+					throw new ParseMetadataException("Mod id must be a non-empty string with a length of 3-64 characters.", reader);
+				}
 
-					id = reader.nextString();
-					break;
-				case "aliases":
-					readAliases(reader, aliases);
-					break;
-				case "version":
-					if (reader.peek() != JsonToken.STRING) {
-						throw new ParseMetadataException("Version must be a non-empty string", reader);
-					}
+				id = reader.nextString();
+				break;
+			case "version":
+				if (reader.peek() != JsonToken.STRING) {
+					throw new ParseMetadataException("Version must be a non-empty string", reader);
+				}
 
-					try {
-						version = VersionDeserializer.deserialize(reader.nextString());
-					} catch (VersionParsingException e) {
-						throw new ParseMetadataException("Failed to parse version", e);
-					}
+				try {
+					version = VersionDeserializer.deserialize(reader.nextString());
+				} catch (VersionParsingException e) {
+					throw new ParseMetadataException("Failed to parse version", e);
+				}
 
-					break;
-				case "environment":
-					if (reader.peek() != JsonToken.STRING) {
-						throw new ParseMetadataException("Environment must be a string", reader);
-					}
+				break;
+			case "aliases":
+				readAliases(reader, aliases);
+				break;
+			case "environment":
+				if (reader.peek() != JsonToken.STRING) {
+					throw new ParseMetadataException("Environment must be a string", reader);
+				}
 
-					environment = readEnvironment(reader);
-					break;
-				case "entrypoints":
-					readEntrypoints(warnings, reader, entrypoints);
-					break;
-				case "jars":
-					readNestedJarEntries(warnings, reader, jars);
-					break;
-				case "mixins":
-					readMixinConfigs(warnings, reader, mixins);
-					break;
-				case "accessWidener":
-					if (reader.peek() != JsonToken.STRING) {
-						throw new ParseMetadataException("Access Widener file must be a string", reader);
-					}
+				environment = readEnvironment(reader);
+				break;
+			case "entrypoints":
+				readEntrypoints(warnings, reader, entrypoints);
+				break;
+			case "jars":
+				readNestedJarEntries(warnings, reader, jars);
+				break;
+			case "mixins":
+				readMixinConfigs(warnings, reader, mixins);
+				break;
+			case "accessWidener":
+				if (reader.peek() != JsonToken.STRING) {
+					throw new ParseMetadataException("Access Widener file must be a string", reader);
+				}
 
-					accessWidener = reader.nextString();
-					break;
-				case "depends":
-					readDependenciesContainer(reader, depends);
-					break;
-				case "recommends":
-					readDependenciesContainer(reader, recommends);
-					break;
-				case "suggests":
-					readDependenciesContainer(reader, suggests);
-					break;
-				case "conflicts":
-					readDependenciesContainer(reader, conflicts);
-					break;
-				case "breaks":
-					readDependenciesContainer(reader, breaks);
-					break;
+				accessWidener = reader.nextString();
+				break;
+			case "depends":
+				readDependenciesContainer(reader, depends);
+				break;
+			case "recommends":
+				readDependenciesContainer(reader, recommends);
+				break;
+			case "suggests":
+				readDependenciesContainer(reader, suggests);
+				break;
+			case "conflicts":
+				readDependenciesContainer(reader, conflicts);
+				break;
+			case "breaks":
+				readDependenciesContainer(reader, breaks);
+				break;
 			case "requires":
 				readDependenciesContainer(reader, requires);
 				break;

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
@@ -239,11 +239,11 @@ final class V1ModMetadataParser {
 		while (reader.hasNext()) {
 			String alias;
 
-			if (reader.peek() == JsonToken.STRING) {
-				alias = reader.nextString();
-			} else {
+			if (reader.peek() != JsonToken.STRING) {
 				throw new ParseMetadataException("Aliases must be a string", reader);
 			}
+
+			alias = reader.nextString();
 
 			aliases.add(alias);
 		}

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
@@ -56,8 +56,8 @@ final class V1ModMetadataParser {
 		String id = null;
 		Version version = null;
 
-		// Optional (id aliases)
-		List<String> aliases = new ArrayList<>();
+		// Optional (id provides)
+		List<String> provides = new ArrayList<>();
 
 		// Optional (mod loading)
 		ModEnvironment environment = ModEnvironment.UNIVERSAL; // Default is always universal
@@ -129,8 +129,8 @@ final class V1ModMetadataParser {
 				}
 
 				break;
-			case "aliases":
-				readAliases(reader, aliases);
+			case "provides":
+				readProvides(reader, provides);
 				break;
 			case "environment":
 				if (reader.peek() != JsonToken.STRING) {
@@ -226,22 +226,22 @@ final class V1ModMetadataParser {
 
 		ModMetadataParser.logWarningMessages(logger, id, warnings);
 
-		return new V1ModMetadata(id, version, aliases, environment, entrypoints, jars, mixins, accessWidener, depends, recommends, suggests, conflicts, breaks, requires, name, description, authors, contributors, contact, license, icon, languageAdapters, customValues);
+		return new V1ModMetadata(id, version, provides, environment, entrypoints, jars, mixins, accessWidener, depends, recommends, suggests, conflicts, breaks, requires, name, description, authors, contributors, contact, license, icon, languageAdapters, customValues);
 	}
 
-	private static void readAliases(JsonReader reader, List<String> aliases) throws IOException, ParseMetadataException {
+	private static void readProvides(JsonReader reader, List<String> provides) throws IOException, ParseMetadataException {
 		if (reader.peek() != JsonToken.BEGIN_ARRAY) {
-			throw new ParseMetadataException("Aliases must be in an array");
+			throw new ParseMetadataException("Provides must be an array");
 		}
 
 		reader.beginArray();
 
 		while (reader.hasNext()) {
 			if (reader.peek() != JsonToken.STRING) {
-				throw new ParseMetadataException("Alias must be a string", reader);
+				throw new ParseMetadataException("Provided id must be a string", reader);
 			}
 
-			aliases.add(reader.nextString());
+			provides.add(reader.nextString());
 		}
 
 		reader.endArray();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,9 +1,6 @@
 {
   "schemaVersion": 1,
   "id": "fabricloader",
-  "aliases": [
-    "testmod"
-  ],
   "name": "Fabric Loader",
   "version": "${version}",
   "environment": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,6 +1,9 @@
 {
   "schemaVersion": 1,
   "id": "fabricloader",
+  "aliases": [
+    "testmod"
+  ],
   "name": "Fabric Loader",
   "version": "${version}",
   "environment": "*",


### PR DESCRIPTION
This PR does 1 thing:
- Adds aliases to dependency handling, so mods can depend on a mod's alias instead of its mod id.

Please review, there are some changes that I made that I wasn't sure of the standard of.