### PR TITLE
Add helper methods to CustomValue and its implementations

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
@@ -72,6 +72,23 @@ public interface CustomValue {
 	boolean getAsBoolean();
 
 	/**
+	 * Compares this custom value with another and returns whether they are equal.
+	 *
+	 * @param another The custom value to compare to.
+	 */
+	boolean equals(Object another);
+
+	/**
+	 * Returns the hash code for this custom value.
+	 */
+	int hashCode();
+
+	/**
+	 * Returns the value of this custom value as json.
+	 */
+	String toString();
+
+	/**
 	 * Represents an {@link CvType#OBJECT} value.
 	 */
 	interface CvObject extends CustomValue, Iterable<Map.Entry<String, CustomValue>> {

--- a/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
@@ -17,6 +17,10 @@
 package net.fabricmc.loader.api.metadata;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Represents a custom value in the {@code fabric.mod.json}.
@@ -91,6 +95,20 @@ public interface CustomValue {
 		 * @return the value associated, or {@code null} if no such value is present
 		 */
 		CustomValue get(String key);
+
+		/**
+		 * Returns a sequential {@link Stream} with this iterable as its source.
+		 */
+		default Stream<Map.Entry<String, CustomValue>> stream() {
+			return StreamSupport.stream(this.spliterator(), false);
+		}
+
+		/**
+		 * Returns the set of keys in this custom value.
+		 */
+		default Set<String> keys() {
+			return this.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
+		}
 	}
 
 	/**
@@ -110,6 +128,13 @@ public interface CustomValue {
 		 * @throws IndexOutOfBoundsException if the index is not within {{@link #size()}}
 		 */
 		CustomValue get(int index);
+
+		/**
+		 * Returns a sequential {@link Stream} with this iterable as its source.
+		 */
+		default Stream<CustomValue> stream() {
+			return StreamSupport.stream(this.spliterator(), false);
+		}
 	}
 
 	/**

--- a/src/main/java/net/fabricmc/loader/metadata/CustomValueImpl.java
+++ b/src/main/java/net/fabricmc/loader/metadata/CustomValueImpl.java
@@ -157,6 +157,45 @@ abstract class CustomValueImpl implements CustomValue {
 		public Iterator<Entry<String, CustomValue>> iterator() {
 			return entries.entrySet().iterator();
 		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else if (!(o instanceof ObjectImpl)) {
+				return false;
+			}
+
+			ObjectImpl object = (ObjectImpl) o;
+			return Objects.equals(this.entries, object.entries);
+		}
+
+		@Override
+		public int hashCode() {
+			return this.entries.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("{");
+			Iterator<String> itr = this.keys().iterator();
+
+			while (itr.hasNext()) {
+				String key = itr.next();
+				// Key
+				sb.append("\"").append(key).append("\"").append(":");
+				// Value
+				sb.append(this.get(key).toString());
+
+				if (itr.hasNext()) {
+					sb.append(",");
+				}
+			}
+
+			sb.append("}");
+			return sb.toString();
+		}
 	}
 
 	private static final class ArrayImpl extends CustomValueImpl implements CvArray {
@@ -185,6 +224,51 @@ abstract class CustomValueImpl implements CustomValue {
 		public Iterator<CustomValue> iterator() {
 			return entries.iterator();
 		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else if (!(o instanceof ArrayImpl)) {
+				return false;
+			}
+
+			ArrayImpl that = (ArrayImpl) o;
+			return this.entries.equals(that.entries);
+		}
+
+		@Override
+		public int hashCode() {
+			return this.entries.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("[");
+			Iterator<CustomValue> itr = this.iterator();
+
+			while (itr.hasNext()) {
+				CustomValue value = itr.next();
+
+				if (value.getType() == CvType.STRING) {
+					sb.append("\"");
+				}
+
+				sb.append(value.toString());
+
+				if (value.getType() == CvType.STRING) {
+					sb.append("\"");
+				}
+
+				if (itr.hasNext()) {
+					sb.append(",");
+				}
+			}
+
+			sb.append("]");
+			return sb.toString();
+		}
 	}
 
 	private static final class StringImpl extends CustomValueImpl {
@@ -197,6 +281,28 @@ abstract class CustomValueImpl implements CustomValue {
 		@Override
 		public CvType getType() {
 			return CvType.STRING;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else if (!(o instanceof StringImpl)) {
+				return false;
+			}
+
+			StringImpl string = (StringImpl) o;
+			return this.value.equals(string.value);
+		}
+
+		@Override
+		public int hashCode() {
+			return this.value.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
 		}
 	}
 
@@ -211,6 +317,28 @@ abstract class CustomValueImpl implements CustomValue {
 		public CvType getType() {
 			return CvType.NUMBER;
 		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else if (!(o instanceof NumberImpl)) {
+				return false;
+			}
+
+			NumberImpl number = (NumberImpl) o;
+			return this.value.equals(number.value);
+		}
+
+		@Override
+		public int hashCode() {
+			return this.value.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return String.valueOf(this.value);
+		}
 	}
 
 	private static final class BooleanImpl extends CustomValueImpl {
@@ -224,12 +352,49 @@ abstract class CustomValueImpl implements CustomValue {
 		public CvType getType() {
 			return CvType.BOOLEAN;
 		}
+
+		@Override
+		public int hashCode() {
+			return Boolean.hashCode(this.value);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else if (!(o instanceof BooleanImpl)) {
+				return false;
+			}
+
+			BooleanImpl aBoolean = (BooleanImpl) o;
+			return this.value == aBoolean.value;
+		}
+
+		@Override
+		public String toString() {
+			return String.valueOf(this.value);
+		}
 	}
 
 	private static final class NullImpl extends CustomValueImpl {
 		@Override
 		public CvType getType() {
 			return CvType.NULL;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return this == NULL;
+		}
+
+		@Override
+		public int hashCode() {
+			return System.identityHashCode(null);
+		}
+
+		@Override
+		public String toString() {
+			return "null";
 		}
 	}
 }


### PR DESCRIPTION
`CustomValue`'s implementations do not implement `equals` or `hashCode`. This causes issues when storing them in lists and maps, where it is impossible to remove `CustomValue`s from a list, or get the value associated with a `CustomValue` key from a map. 
This also affects any `DynamicOps` relying on `CustomValue`s as `FieldDecoder`s get returned `null` when reading a CustomValue keyed map.

This makes `CustomValue`'s implementations implement `equals`, `hashCode` and `toString`.
This also adds a `stream` method to CvObject and CvArray, and a `keys` method to `CvObject` for convenience.
