### PR TITLE
Add `loader` and `loaderVersion` fields to fabric-installer.json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,10 @@ processResources {
 	filesMatching("fabric.mod.json") {
 		expand "version": project.version
 	}
+
+	filesMatching("fabric-installer.json") {
+		expand "group": project.group, "artifact": project.modid, "version": project.version
+	}
 }
 
 java {

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -1,5 +1,10 @@
 {
   "version": 1,
+  "loaderVersion": "${version}",
+  "loader": {
+    "name": "${group}:${artifact}:${version}",
+    "url": "https://maven.fabricmc.net/${group.replace('.', '/')}/${artifact}/${version}/${artifact}-${version}.jar"
+  },
   "libraries": {
     "client": [
 


### PR DESCRIPTION
Add `loader` and `loaderVersion` fields to fabric-installer.json, example below

```json
  "loaderVersion": "0.10.8",
  "loader": {
    "name": "net.fabricmc:fabric-loader:0.10.8",
    "url": "https://maven.fabricmc.net/net/fabricmc/fabric-loader/0.10.8/fabric-loader-0.10.8.jar"
  },
```

This is useful for consumers of this file since the loader itself is (rightfully) not present in the library list already in this file; `loader` is a valid Minecraft-style library definition and thus can easily be added to existing library lists where required.