### PR TITLE
Add a more specific error message when finding positive (but unsupported) schema versions.

### DIFF
--- a/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModMetadataParser.java
@@ -112,6 +112,10 @@ public final class ModMetadataParser {
 		case 0:
 			return V0ModMetadataParser.parse(logger, reader);
 		default:
+			if (schemaVersion > 0) {
+				throw new ParseMetadataException(String.format("This version of fabric-loader doesn't support the newer schema version of \"%s\""
+					+ "\nPlease update fabric-loader to be able to read this.", schemaVersion));
+			}
 			throw new ParseMetadataException(String.format("Invalid/Unsupported schema version \"%s\" was found", schemaVersion));
 		}
 	}


### PR DESCRIPTION
...which informs the user that they need to update fabric-loader.

This assumes that modders never create fabric.mod.json files with a schemaVersion newer than what a released version of fabric-loader supports, as then the error message wouldn't be very useful.

I'm primarily opening this so that users will be greeted with a better error message if they install a version of fabric-loader after this PR is merged, but before PRs like #334 is merged (at least, assuming you want to bump the schemaVersion to 2 for that PR - if you don't then this is just useful for when you do want to bump the version).

This results in a screen like this:
![Screenshot from 2020-12-03 23-33-28](https://user-images.githubusercontent.com/3751138/101103475-21629080-35c1-11eb-89bc-2d6dee151ca8.png)
This doesn't affect the error message for versions less than 0 (which I assume is fine as we're unlikely to *decrease* the schema version in a normal build).