### PR TITLE
Update to use stitch annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	minecraft "com.mojang:minecraft:1.16.3"
 	mappings "net.fabricmc:yarn:1.16.3+build.47:v2"
 
+	implementation "net.fabricmc:stitch-annotations:0.5.1+local"
+
 	// fabric-loader dependencies
 	implementation "org.ow2.asm:asm:${project.asm_version}"
 	implementation "org.ow2.asm:asm-analysis:${project.asm_version}"

--- a/src/main/java/net/fabricmc/api/ClientModInitializer.java
+++ b/src/main/java/net/fabricmc/api/ClientModInitializer.java
@@ -17,7 +17,7 @@
 package net.fabricmc.api;
 
 /**
- * A mod initializer ran only on {@link EnvType#CLIENT}.
+ * A mod initializer ran only on {@link net.fabricmc.stitch.annotation.EnvType#CLIENT}.
  *
  * <p>This entrypoint is suitable for setting up client-specific logic, such as rendering
  * or integrated server tweaks.</p>

--- a/src/main/java/net/fabricmc/api/DedicatedServerModInitializer.java
+++ b/src/main/java/net/fabricmc/api/DedicatedServerModInitializer.java
@@ -17,7 +17,7 @@
 package net.fabricmc.api;
 
 /**
- * A mod initializer ran only on {@link EnvType#SERVER}.
+ * A mod initializer ran only on {@link net.fabricmc.stitch.annotation.EnvType#SERVER}.
  *
  * <p>In {@code fabric.mod.json}, the entrypoint is defined with {@code server} key.</p>
  *

--- a/src/main/java/net/fabricmc/api/EnvType.java
+++ b/src/main/java/net/fabricmc/api/EnvType.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.api;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 /**
  * Represents a type of environment.
  *
@@ -34,7 +37,7 @@ public enum EnvType {
 	 * server logic), the data generator logic, and dedicated server logic. It encompasses
 	 * everything that is available on the {@linkplain #SERVER server environment type}.</p>
 	 */
-	CLIENT,
+	CLIENT(net.fabricmc.stitch.annotation.EnvType.CLIENT),
 	/**
 	 * Represents the server environment type, in which the {@code server.jar} for a
 	 * <i>Minecraft</i> version is the main game jar.
@@ -44,5 +47,41 @@ public enum EnvType {
 	 * However, the server environment type has its libraries embedded compared to the
 	 * client.</p>
 	 */
-	SERVER
+	SERVER(net.fabricmc.stitch.annotation.EnvType.SERVER);
+
+	private static final Map<net.fabricmc.stitch.annotation.EnvType, EnvType> FROM_STITCH =
+			new EnumMap<>(net.fabricmc.stitch.annotation.EnvType.class);
+	private final net.fabricmc.stitch.annotation.EnvType stitchType;
+
+	EnvType(final net.fabricmc.stitch.annotation.EnvType stitchType) {
+		this.stitchType = stitchType;
+	}
+
+	/**
+	 * Get the equivalent environment type in stitch-annotations.
+	 *
+	 * @return the equivalent type
+	 * @deprecated to be used for transitional purposes only
+	 */
+	@Deprecated
+	public net.fabricmc.stitch.annotation.EnvType getStitchEquivalent() {
+		return this.stitchType;
+	}
+
+	/**
+	 * Get an {@link EnvType} from the stitch equivalent.
+	 *
+	 * @return the equivalent type
+	 * @deprecated to be used for transitional purposes only
+	 */
+	@Deprecated
+	public static EnvType fromStitch(final net.fabricmc.stitch.annotation.EnvType envType) {
+		return FROM_STITCH.get(envType);
+	}
+
+	static {
+		for (final EnvType existing : EnvType.values()) {
+			FROM_STITCH.put(existing.stitchType, existing);
+		}
+	}
 }

--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -35,10 +35,10 @@ import java.util.stream.Stream;
 
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import net.fabricmc.loader.discovery.RuntimeModRemapper;
+import net.fabricmc.stitch.annotation.EnvType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.LanguageAdapter;
 import net.fabricmc.loader.api.MappingResolver;
 import net.fabricmc.loader.api.SemanticVersion;
@@ -129,7 +129,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	}
 
 	@Override
-	public EnvType getEnvironmentType() {
+	public EnvType getEnvironment() {
 		return FabricLauncherBase.getLauncher().getEnvironmentType();
 	}
 
@@ -326,7 +326,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 			throw new ModResolutionException("Duplicate mod ID: " + info.getId() + "! (" + modMap.get(info.getId()).getOriginUrl().getFile() + ", " + originUrl.getFile() + ")");
 		}
 
-		if (!info.loadsInEnvironment(getEnvironmentType())) {
+		if (!info.loadsInEnvironment(getEnvironment())) {
 			return;
 		}
 
@@ -499,7 +499,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	 */
 	@Deprecated
 	public void setGameInstance(Object gameInstance) {
-		if (this.getEnvironmentType() != EnvType.SERVER) {
+		if (this.getEnvironment() != EnvType.SERVER) {
 			throw new UnsupportedOperationException("Cannot set game instance on a client!");
 		}
 

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -22,8 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+import net.fabricmc.stitch.annotation.EnvType;
 
 /**
  * The public-facing FabricLoader instance.
@@ -147,8 +147,19 @@ public interface FabricLoader {
 	 * Get the current environment type.
 	 *
 	 * @return the current environment type
+	 * @deprecated for removal, use {@link #getEnvironment()} instead.
 	 */
-	EnvType getEnvironmentType();
+	@Deprecated
+	default net.fabricmc.api.EnvType getEnvironmentType() {
+		return net.fabricmc.api.EnvType.fromStitch(getEnvironment());
+	}
+
+	/**
+	 * Get the current environment type.
+	 *
+	 * @return the active environment
+	 */
+	EnvType getEnvironment();
 
 	/**
 	 * Get the current game instance. Can represent a game client or

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModEnvironment.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModEnvironment.java
@@ -16,12 +16,17 @@
 
 package net.fabricmc.loader.api.metadata;
 
-import net.fabricmc.api.EnvType;
+import net.fabricmc.stitch.annotation.EnvType;
 
 public enum ModEnvironment {
 	CLIENT,
 	SERVER,
 	UNIVERSAL;
+
+	@Deprecated
+	public boolean matches(net.fabricmc.api.EnvType type) {
+		return matches(type.getStitchEquivalent());
+	}
 
 	public boolean matches(EnvType type) {
 		switch (this) {

--- a/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/discovery/BuiltinMetadataWrapper.java
@@ -22,9 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import net.fabricmc.stitch.annotation.EnvType;
 import org.apache.logging.log4j.Logger;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.api.metadata.CustomValue;

--- a/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
+++ b/src/main/java/net/fabricmc/loader/entrypoint/minecraft/EntrypointPatchHook.java
@@ -16,10 +16,10 @@
 
 package net.fabricmc.loader.entrypoint.minecraft;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.entrypoint.EntrypointPatch;
 import net.fabricmc.loader.entrypoint.EntrypointTransformer;
 import net.fabricmc.loader.launch.common.FabricLauncher;
+import net.fabricmc.stitch.annotation.EnvType;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;

--- a/src/main/java/net/fabricmc/loader/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/GameProvider.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.loader.game;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.entrypoint.EntrypointTransformer;
+import net.fabricmc.stitch.annotation.EnvType;
 
 import java.net.URL;
 import java.nio.file.Path;
@@ -37,6 +37,11 @@ public interface GameProvider {
 	boolean isObfuscated();
 	boolean requiresUrlClassLoader();
 	List<Path> getGameContextJars();
+
+	@Deprecated
+	default boolean locateGame(net.fabricmc.api.EnvType env, ClassLoader loader) {
+		return locateGame(env.getStitchEquivalent(), loader);
+	}
 
 	boolean locateGame(EnvType envType, ClassLoader loader);
 	void acceptArguments(String... arguments);

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.game;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.entrypoint.EntrypointTransformer;
 import net.fabricmc.loader.entrypoint.minecraft.EntrypointPatchBranding;
 import net.fabricmc.loader.entrypoint.minecraft.EntrypointPatchFML125;
@@ -26,6 +25,8 @@ import net.fabricmc.loader.metadata.BuiltinModMetadata;
 import net.fabricmc.loader.minecraft.McVersionLookup;
 import net.fabricmc.loader.minecraft.McVersionLookup.McVersion;
 import net.fabricmc.loader.util.Arguments;
+import net.fabricmc.stitch.annotation.EnvType;
+
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;

--- a/src/main/java/net/fabricmc/loader/language/JavaLanguageAdapter.java
+++ b/src/main/java/net/fabricmc/loader/language/JavaLanguageAdapter.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.loader.language;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
+import net.fabricmc.stitch.annotation.EnvType;
 import org.objectweb.asm.ClassReader;
 
 import java.io.IOException;
@@ -34,12 +34,12 @@ public class JavaLanguageAdapter implements LanguageAdapter {
 		// TODO: Be a bit more involved
 		switch (itfString) {
 			case "net/fabricmc/api/ClientModInitializer":
-				if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
+				if (FabricLoader.getInstance().getEnvironment() == EnvType.SERVER) {
 					return false;
 				}
 				break;
 			case "net/fabricmc/api/DedicatedServerModInitializer":
-				if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
+				if (FabricLoader.getInstance().getEnvironment() == EnvType.CLIENT) {
 					return false;
 				}
 		}

--- a/src/main/java/net/fabricmc/loader/launch/FabricClientTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricClientTweaker.java
@@ -16,7 +16,8 @@
 
 package net.fabricmc.loader.launch;
 
-import net.fabricmc.api.EnvType;
+
+import net.fabricmc.stitch.annotation.EnvType;
 
 public final class FabricClientTweaker extends FabricTweaker {
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/FabricServerTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricServerTweaker.java
@@ -16,7 +16,7 @@
 
 package net.fabricmc.loader.launch;
 
-import net.fabricmc.api.EnvType;
+import net.fabricmc.stitch.annotation.EnvType;
 
 public final class FabricServerTweaker extends FabricTweaker {
 	@Override

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.launch;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils;
@@ -28,6 +27,7 @@ import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.loader.util.SystemProperties;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
+import net.fabricmc.stitch.annotation.EnvType;
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.launchwrapper.ITweaker;
 import net.minecraft.launchwrapper.Launch;

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncher.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncher.java
@@ -16,7 +16,7 @@
 
 package net.fabricmc.loader.launch.common;
 
-import net.fabricmc.api.EnvType;
+import net.fabricmc.stitch.annotation.EnvType;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricLauncherBase.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.loader.launch.common;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.util.mappings.TinyRemapperMappingsHelper;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
 import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.mapping.tree.TinyTree;
+import net.fabricmc.stitch.annotation.EnvType;
 import net.fabricmc.tinyremapper.OutputConsumerPath;
 import net.fabricmc.tinyremapper.TinyRemapper;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
@@ -16,12 +16,12 @@
 
 package net.fabricmc.loader.launch.common;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
 import net.fabricmc.loader.util.mappings.MixinIntermediaryDevRemapper;
 import net.fabricmc.mapping.tree.TinyTree;
+import net.fabricmc.stitch.annotation.EnvType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.launch.MixinBootstrap;

--- a/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.launch.knot;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils;
@@ -27,6 +26,7 @@ import net.fabricmc.loader.launch.common.FabricMixinBootstrap;
 import net.fabricmc.loader.util.SystemProperties;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
+import net.fabricmc.stitch.annotation.EnvType;
 import org.spongepowered.asm.launch.MixinBootstrap;
 
 import java.io.File;

--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotClassDelegate.java
@@ -16,13 +16,13 @@
 
 package net.fabricmc.loader.launch.knot;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.game.GameProvider;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 import net.fabricmc.loader.transformer.FabricTransformer;
 import net.fabricmc.loader.util.FileSystemUtil;
 import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
+import net.fabricmc.stitch.annotation.EnvType;
 import org.spongepowered.asm.mixin.transformer.FabricMixinTransformerProxy;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotClassLoader.java
@@ -16,8 +16,8 @@
 
 package net.fabricmc.loader.launch.knot;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.game.GameProvider;
+import net.fabricmc.stitch.annotation.EnvType;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotClient.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotClient.java
@@ -16,8 +16,8 @@
 
 package net.fabricmc.loader.launch.knot;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.util.SystemProperties;
+import net.fabricmc.stitch.annotation.EnvType;
 
 import java.io.File;
 

--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotCompatibilityClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotCompatibilityClassLoader.java
@@ -16,8 +16,8 @@
 
 package net.fabricmc.loader.launch.knot;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.game.GameProvider;
+import net.fabricmc.stitch.annotation.EnvType;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/net/fabricmc/loader/launch/knot/KnotServer.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/KnotServer.java
@@ -16,8 +16,8 @@
 
 package net.fabricmc.loader.launch.knot;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.util.SystemProperties;
+import net.fabricmc.stitch.annotation.EnvType;
 
 import java.io.File;
 

--- a/src/main/java/net/fabricmc/loader/metadata/LoaderModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/LoaderModMetadata.java
@@ -16,9 +16,9 @@
 
 package net.fabricmc.loader.metadata;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 
+import net.fabricmc.stitch.annotation.EnvType;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;

--- a/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import net.fabricmc.stitch.annotation.EnvType;
 import org.apache.logging.log4j.Logger;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.api.metadata.CustomValue;

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -24,9 +24,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 
+import net.fabricmc.stitch.annotation.EnvType;
 import org.apache.logging.log4j.Logger;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.api.metadata.CustomValue;

--- a/src/main/java/net/fabricmc/loader/transformer/EnvironmentStrippingData.java
+++ b/src/main/java/net/fabricmc/loader/transformer/EnvironmentStrippingData.java
@@ -16,21 +16,29 @@
 
 package net.fabricmc.loader.transformer;
 
-import net.fabricmc.api.Environment;
-import net.fabricmc.api.EnvironmentInterface;
-import net.fabricmc.api.EnvironmentInterfaces;
+import com.google.common.collect.ImmutableSet;
+import net.fabricmc.stitch.annotation.Environment;
+import net.fabricmc.stitch.annotation.EnvironmentInterface;
+import net.fabricmc.stitch.annotation.EnvironmentInterfaces;
 import org.objectweb.asm.*;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Scans a class for Environment and EnvironmentInterface annotations to figure out what needs to be stripped.
  */
 public class EnvironmentStrippingData extends ClassVisitor {
-	private static final String ENVIRONMENT_DESCRIPTOR = Type.getDescriptor(Environment.class);
-	private static final String ENVIRONMENT_INTERFACE_DESCRIPTOR = Type.getDescriptor(EnvironmentInterface.class);
-	private static final String ENVIRONMENT_INTERFACES_DESCRIPTOR = Type.getDescriptor(EnvironmentInterfaces.class);
+	private static final Set<String> ENVIRONMENT_DESCRIPTORS = ImmutableSet.of(
+			Type.getDescriptor(Environment.class),
+			Type.getDescriptor(net.fabricmc.api.Environment.class));
+	private static final Set<String> ENVIRONMENT_INTERFACE_DESCRIPTORS = ImmutableSet.of(
+			Type.getDescriptor(EnvironmentInterface.class),
+			Type.getDescriptor(net.fabricmc.api.EnvironmentInterface.class));
+	private static final Set<String> ENVIRONMENT_INTERFACES_DESCRIPTORS = ImmutableSet.of(
+			Type.getDescriptor(EnvironmentInterfaces.class),
+			Type.getDescriptor(net.fabricmc.api.EnvironmentInterfaces.class));
 
 	private final String envType;
 
@@ -86,7 +94,7 @@ public class EnvironmentStrippingData extends ClassVisitor {
 	}
 
 	private AnnotationVisitor visitMemberAnnotation(String descriptor, boolean visible, Runnable onEnvMismatch) {
-		if (ENVIRONMENT_DESCRIPTOR.equals(descriptor)) {
+		if (ENVIRONMENT_DESCRIPTORS.contains(descriptor)) {
 			return new EnvironmentAnnotationVisitor(api, onEnvMismatch);
 		}
 		return null;
@@ -99,11 +107,11 @@ public class EnvironmentStrippingData extends ClassVisitor {
 
 	@Override
 	public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-		if (ENVIRONMENT_DESCRIPTOR.equals(descriptor)) {
+		if (ENVIRONMENT_DESCRIPTORS.contains(descriptor)) {
 			return new EnvironmentAnnotationVisitor(api, () -> stripEntireClass = true);
-		} else if (ENVIRONMENT_INTERFACE_DESCRIPTOR.equals(descriptor)) {
+		} else if (ENVIRONMENT_INTERFACE_DESCRIPTORS.contains(descriptor)) {
 			return new EnvironmentInterfaceAnnotationVisitor(api);
-		} else if (ENVIRONMENT_INTERFACES_DESCRIPTOR.equals(descriptor)) {
+		} else if (ENVIRONMENT_INTERFACES_DESCRIPTORS.contains(descriptor)) {
 			return new AnnotationVisitor(api) {
 				@Override
 				public AnnotationVisitor visitArray(String name) {

--- a/src/main/java/net/fabricmc/loader/transformer/FabricTransformer.java
+++ b/src/main/java/net/fabricmc/loader/transformer/FabricTransformer.java
@@ -17,10 +17,10 @@
 package net.fabricmc.loader.transformer;
 
 import net.fabricmc.accesswidener.AccessWidenerVisitor;
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.FabricLoader;
 import net.fabricmc.loader.game.MinecraftGameProvider;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
+import net.fabricmc.stitch.annotation.EnvType;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -26,6 +26,10 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
+        "name": "net.fabricmc:stitch-annotations:0.5.1",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
         "name": "com.google.jimfs:jimfs:1.2-fabric",
         "url": "https://maven.fabricmc.net/"
       },

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -29,6 +29,10 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
+        "name": "net.fabricmc:stitch-annotations:0.5.1",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
         "name": "com.google.jimfs:jimfs:1.2-fabric",
         "url": "https://maven.fabricmc.net/"
       },


### PR DESCRIPTION
[Stitch](https://github.com/FabricMC/stitch/pull/36) | **Loader** | [Loom](https://github.com/FabricMC/fabric-loom/pull/316)

Sided stripping supports both old and new annotations.

See the stitch PR for more details on the change. This PR does not deprecate the existing annotations -- that allows for a more graceful migration.

This depends on the stitch PR, and will need to have its `stitch-annotations` version updated once that PR is merged.