### PR TITLE
Add support for specifying the game version via program argument.

### DIFF
--- a/src/main/java/net/fabricmc/loader/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/GameProvider.java
@@ -38,8 +38,7 @@ public interface GameProvider {
 	boolean requiresUrlClassLoader();
 	List<Path> getGameContextJars();
 
-	boolean locateGame(EnvType envType, ClassLoader loader);
-	void acceptArguments(String... arguments);
+	boolean locateGame(EnvType envType, String[] args, ClassLoader loader);
 	EntrypointTransformer getEntrypointTransformer();
 	void launch(ClassLoader loader);
 

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -26,6 +26,8 @@ import net.fabricmc.loader.metadata.BuiltinModMetadata;
 import net.fabricmc.loader.minecraft.McVersionLookup;
 import net.fabricmc.loader.minecraft.McVersionLookup.McVersion;
 import net.fabricmc.loader.util.Arguments;
+import net.fabricmc.loader.util.SystemProperties;
+
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -153,6 +155,7 @@ public class MinecraftGameProvider implements GameProvider {
 		hasModLoader = GameProviderHelper.getSource(loader, "ModLoader.class").isPresent();
 
 		String version = arguments.remove(Arguments.GAME_VERSION);
+		if (version == null) version = System.getProperty(SystemProperties.GAME_VERSION);
 		versionData = version != null ? McVersionLookup.getVersion(version) : McVersionLookup.getVersion(gameJar);
 
 		FabricLauncherBase.processArgumentMap(arguments, envType);

--- a/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/launch/FabricTweaker.java
@@ -111,10 +111,9 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 		GameProvider provider = new MinecraftGameProvider();
 
-		if (!provider.locateGame(getEnvironmentType(), launchClassLoader)) {
+		if (!provider.locateGame(getEnvironmentType(), arguments.toArray(), launchClassLoader)) {
 			throw new RuntimeException("Could not locate Minecraft: provider locate failed");
 		}
-		provider.acceptArguments(arguments.toArray());
 
 		@SuppressWarnings("deprecation")
 		FabricLoader loader = FabricLoader.INSTANCE;
@@ -227,7 +226,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		}
 
 		try (FileInputStream jarFileStream = new FileInputStream(remappedJarFile.toFile());
-			 JarInputStream jarStream = new JarInputStream(jarFileStream)) {
+				JarInputStream jarStream = new JarInputStream(jarFileStream)) {
 			JarEntry entry;
 
 			while ((entry = jarStream.getNextJarEntry()) != null) {

--- a/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/Knot.java
@@ -62,14 +62,14 @@ public final class Knot extends FabricLauncherBase {
 			}
 
 			switch (side.toLowerCase(Locale.ROOT)) {
-				case "client":
-					envType = EnvType.CLIENT;
-					break;
-				case "server":
-					envType = EnvType.SERVER;
-					break;
-				default:
-					throw new RuntimeException("Invalid side provided: must be \"client\" or \"server\"!");
+			case "client":
+				envType = EnvType.CLIENT;
+				break;
+			case "server":
+				envType = EnvType.SERVER;
+				break;
+			default:
+				throw new RuntimeException("Invalid side provided: must be \"client\" or \"server\"!");
 			}
 		}
 
@@ -80,7 +80,7 @@ public final class Knot extends FabricLauncherBase {
 		provider = null;
 
 		for (GameProvider p : providers) {
-			if (p.locateGame(envType, this.getClass().getClassLoader())) {
+			if (p.locateGame(envType, args, this.getClass().getClassLoader())) {
 				provider = p;
 				break;
 			}
@@ -96,8 +96,6 @@ public final class Knot extends FabricLauncherBase {
 			throw new RuntimeException("Could not find valid game provider!");
 		}
 
-		provider.acceptArguments(args);
-
 		isDevelopment = Boolean.parseBoolean(System.getProperty(SystemProperties.DEVELOPMENT, "false"));
 
 		// Setup classloader
@@ -109,11 +107,11 @@ public final class Knot extends FabricLauncherBase {
 		if (provider.isObfuscated()) {
 			for (Path path : provider.getGameContextJars()) {
 				FabricLauncherBase.deobfuscate(
-					provider.getGameId(), provider.getNormalizedGameVersion(),
-					provider.getLaunchDirectory(),
-					path,
-					this
-				);
+						provider.getGameId(), provider.getNormalizedGameVersion(),
+						provider.getLaunchDirectory(),
+						path,
+						this
+						);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loader/minecraft/McVersionLookup.java
+++ b/src/main/java/net/fabricmc/loader/minecraft/McVersionLookup.java
@@ -64,6 +64,10 @@ public final class McVersionLookup {
 	private static final Pattern INDEV_PATTERN = Pattern.compile("(?:inf-|Inf?dev )(?:0\\.31 )?(\\d+(-\\d+)?)");
 	private static final String STRING_DESC = "Ljava/lang/String;";
 
+	public static McVersion getVersion(String version) {
+		return new McVersion(version, getRelease(version));
+	}
+
 	public static McVersion getVersion(Path gameJar) {
 		McVersion ret;
 
@@ -519,10 +523,10 @@ public final class McVersionLookup {
 				@Override
 				public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean itf) {
 					if (result == null
-						&& lastLdc != null
-						&& owner.equals(methodOwner)
-						&& name.equals(methodName)
-						&& descriptor.startsWith("(" + STRING_DESC + ")")) {
+							&& lastLdc != null
+							&& owner.equals(methodOwner)
+							&& name.equals(methodName)
+							&& descriptor.startsWith("(" + STRING_DESC + ")")) {
 						result = lastLdc;
 					}
 
@@ -718,6 +722,11 @@ public final class McVersionLookup {
 		private McVersion(String name, String release) {
 			this.raw = name;
 			this.normalized = normalizeVersion(name, release);
+		}
+
+		@Override
+		public String toString() {
+			return String.format("%s/%s", raw, normalized);
 		}
 
 		public final String raw; // raw version, e.g. 18w12a

--- a/src/main/java/net/fabricmc/loader/util/Arguments.java
+++ b/src/main/java/net/fabricmc/loader/util/Arguments.java
@@ -19,7 +19,7 @@ package net.fabricmc.loader.util;
 import java.util.*;
 
 public final class Arguments {
-	public static final String GAME_VERSION = "fabric.game.version";
+	public static final String GAME_VERSION = "fabric.gameVersion";
 
 	private final Map<String, String> values;
 	private final List<String> extraArgs;

--- a/src/main/java/net/fabricmc/loader/util/Arguments.java
+++ b/src/main/java/net/fabricmc/loader/util/Arguments.java
@@ -19,6 +19,8 @@ package net.fabricmc.loader.util;
 import java.util.*;
 
 public final class Arguments {
+	public static final String GAME_VERSION = "fabric.game.version";
+
 	private final Map<String, String> values;
 	private final List<String> extraArgs;
 

--- a/src/main/java/net/fabricmc/loader/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/util/SystemProperties.java
@@ -20,6 +20,7 @@ public final class SystemProperties {
 	public static final String DEVELOPMENT = "fabric.development";
 	public static final String SIDE = "fabric.side";
 	public static final String GAME_JAR_PATH = "fabric.gameJarPath";
+	public static final String GAME_VERSION = "fabric.gameVersion";
 	public static final String REMAP_CLASSPATH_FILE = "fabric.remapClasspathFile";
 
 	private SystemProperties() {


### PR DESCRIPTION
Some MC builds, e.g. infdev, don't know about their version, so the only way to determine it is through external input. System properties aren't particularly launcher friendly, so this uses a normal program arg. The GameProvider interface has been tweaked such that it can leverage args to do its initial setup tasks.