### PR TITLE
Fix manifests when doing runtime mod remapping

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/RuntimeModRemapper.java
+++ b/src/main/java/net/fabricmc/loader/discovery/RuntimeModRemapper.java
@@ -31,6 +31,7 @@ import net.fabricmc.loader.util.UrlConversionException;
 import net.fabricmc.loader.util.UrlUtil;
 import net.fabricmc.loader.util.mappings.TinyRemapperMappingsHelper;
 import net.fabricmc.tinyremapper.InputTag;
+import net.fabricmc.tinyremapper.NonClassCopyMode;
 import net.fabricmc.tinyremapper.OutputConsumerPath;
 import net.fabricmc.tinyremapper.TinyRemapper;
 
@@ -112,7 +113,7 @@ public final class RuntimeModRemapper {
 				}
 
 				Path inputJar = delegate.get().getRootDirectories().iterator().next();
-				outputConsumer.addNonClassFiles(inputJar);
+				outputConsumer.addNonClassFiles(inputJar, NonClassCopyMode.FIX_META_INF, remapper);
 
 				info.outputConsumerPath = outputConsumer;
 


### PR DESCRIPTION
The old behaviour of passing manifests through unmodified would break
signed jars, whose class signatures would be invalidated because of
remapping.