### PR TITLE
Dependency Overrides

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import net.fabricmc.loader.discovery.RuntimeModRemapper;
+import net.fabricmc.loader.metadata.DependencyOverrides;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -225,6 +226,10 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		LOGGER.info("[" + getClass().getSimpleName() + "] " + modText, candidateMap.values().size(), candidateMap.values().stream()
 			.map(info -> String.format("%s@%s", info.getInfo().getId(), info.getInfo().getVersion().getFriendlyString()))
 			.collect(Collectors.joining(", ")));
+
+		if (DependencyOverrides.INSTANCE.getDependencyOverrides().size() > 0) {
+			LOGGER.info(String.format("Dependencies overridden for \"%s\"", String.join(", ", DependencyOverrides.INSTANCE.getDependencyOverrides().keySet())));
+		}
 
 		boolean runtimeModRemapping = isDevelopmentEnvironment();
 

--- a/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
+++ b/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
@@ -178,4 +178,8 @@ public final class DependencyOverrides {
 
 		return Collections.unmodifiableMap(override);
 	}
+
+	public Map<String, Map<String, Map<String, ModDependency>>> getDependencyOverrides() {
+		return Collections.unmodifiableMap(dependencyOverrides);
+	}
 }

--- a/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
+++ b/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
@@ -180,6 +180,6 @@ public final class DependencyOverrides {
 	}
 
 	public Map<String, Map<String, Map<String, ModDependency>>> getDependencyOverrides() {
-		return Collections.unmodifiableMap(dependencyOverrides);
+		return dependencyOverrides;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
+++ b/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
@@ -92,6 +92,7 @@ public final class DependencyOverrides {
 			}
 		}
 
+		reader.endObject();
 		return dependencyOverrides;
 	}
 

--- a/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
+++ b/src/main/java/net/fabricmc/loader/metadata/DependencyOverrides.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.metadata;
+
+import net.fabricmc.loader.FabricLoader;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.lib.gson.JsonReader;
+import net.fabricmc.loader.lib.gson.JsonToken;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public final class DependencyOverrides {
+	private static final Collection<String> ALLOWED_KEYS = new HashSet<>(Arrays.asList("depends", "recommends", "suggests", "conflicts", "breaks"));
+	public static final DependencyOverrides INSTANCE = new DependencyOverrides();
+
+	private final boolean exists;
+	private final Map<String, Map<String, Map<String, ModDependency>>> dependencyOverrides;
+
+	private DependencyOverrides() {
+		Path path = FabricLoader.INSTANCE.getConfigDir().resolve("fabric_loader_dependencies.json");
+		exists = Files.exists(path);
+
+		if (!exists) {
+			dependencyOverrides = Collections.emptyMap();
+			return;
+		}
+
+		try (JsonReader reader = new JsonReader(new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8))) {
+			dependencyOverrides = parse(reader);
+		} catch (IOException | ParseMetadataException e) {
+			throw new RuntimeException("Failed to parse " + path.toString(), e);
+		}
+	}
+
+	private static Map<String, Map<String, Map<String, ModDependency>>> parse(JsonReader reader) throws ParseMetadataException, IOException {
+		if (reader.peek() != JsonToken.BEGIN_OBJECT) {
+			throw new ParseMetadataException("Root must be an object", reader);
+		}
+
+		Map<String, Map<String, Map<String, ModDependency>>> dependencyOverrides = new HashMap<>();
+		reader.beginObject();
+
+		if (!reader.nextName().equals("version")) {
+			throw new ParseMetadataException("First key must be \"version\"", reader);
+		}
+
+		if (reader.peek() != JsonToken.NUMBER || reader.nextInt() != 1) {
+			throw new ParseMetadataException("Unsupported \"version\", must be 1", reader);
+		}
+
+		while (reader.hasNext()) {
+			String key = reader.nextName();
+
+			if ("overrides".equals(key)) {
+				reader.beginObject();
+
+				while (reader.hasNext()) {
+					String modId = reader.nextName();
+
+					dependencyOverrides.put(modId, readKeys(reader));
+				}
+
+				reader.endObject();
+			} else {
+				throw new ParseMetadataException("Unsupported root key: " + key, reader);
+			}
+		}
+
+		return dependencyOverrides;
+	}
+
+	private static Map<String, Map<String, ModDependency>> readKeys(JsonReader reader) throws IOException, ParseMetadataException {
+		if (reader.peek() != JsonToken.BEGIN_OBJECT) {
+			throw new ParseMetadataException("Dependency container must be an object!", reader);
+		}
+
+		Map<String, Map<String, ModDependency>> containersMap = new HashMap<>();
+		reader.beginObject();
+
+		while (reader.hasNext()) {
+			String key = reader.nextName();
+
+			if (!ALLOWED_KEYS.contains(key)) {
+				throw new ParseMetadataException(key + " is not an allowed dependency key, must be one of: " + String.join(", ", ALLOWED_KEYS), reader);
+			}
+
+			containersMap.put(key, readDependenciesContainer(reader));
+		}
+
+		reader.endObject();
+		return containersMap;
+	}
+
+	private static Map<String, ModDependency> readDependenciesContainer(JsonReader reader) throws IOException, ParseMetadataException {
+		if (reader.peek() != JsonToken.BEGIN_OBJECT) {
+			throw new ParseMetadataException("Dependency container must be an object!", reader);
+		}
+
+		Map<String, ModDependency> modDependencyMap = new HashMap<>();
+		reader.beginObject();
+
+		while (reader.hasNext()) {
+			final String modId = reader.nextName();
+			final List<String> matcherStringList = new ArrayList<>();
+
+			switch (reader.peek()) {
+				case STRING:
+					matcherStringList.add(reader.nextString());
+					break;
+				case BEGIN_ARRAY:
+					reader.beginArray();
+
+					while (reader.hasNext()) {
+						if (reader.peek() != JsonToken.STRING) {
+							throw new ParseMetadataException("Dependency version range array must only contain string values", reader);
+						}
+
+						matcherStringList.add(reader.nextString());
+					}
+
+					reader.endArray();
+					break;
+				default:
+					throw new ParseMetadataException("Dependency version range must be a string or string array!", reader);
+			}
+
+			modDependencyMap.put(modId, new ModDependencyImpl(modId, matcherStringList));
+		}
+
+		reader.endObject();
+		return modDependencyMap;
+	}
+
+	public Map<String, ModDependency> getActiveDependencyMap(String key, String modId, Map<String, ModDependency> defaultMap) {
+		if(!exists) {
+			return defaultMap;
+		}
+
+		Map<String, Map<String, ModDependency>> modOverrides = dependencyOverrides.get(modId);
+
+		if (modOverrides == null) {
+			// No overrides return the default
+			return defaultMap;
+		}
+
+		Map<String, ModDependency> override = modOverrides.get(key);
+
+		if (override == null) {
+			return defaultMap;
+		}
+
+		return Collections.unmodifiableMap(override);
+	}
+}

--- a/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V0ModMetadata.java
@@ -41,7 +41,9 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 
 	// Optional (Environment)
 	private final Map<String, ModDependency> requires;
+	private final Map<String, ModDependency> suggests;
 	private final Map<String, ModDependency> conflicts;
+	private final Map<String, ModDependency> breaks;
 	private final String languageAdapter = "net.fabricmc.loader.language.JavaLanguageAdapter"; // TODO: Constants class?
 	private final Mixins mixins;
 	private final ModEnvironment environment; // REMOVEME: Replacing Side in old metadata with this
@@ -60,8 +62,11 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	V0ModMetadata(String id, Version version, Map<String, ModDependency> requires, Map<String, ModDependency> conflicts, Mixins mixins, ModEnvironment environment, String initializer, Collection<String> initializers, String name, String description, Map<String, ModDependency> recommends, Collection<Person> authors, Collection<Person> contributors, ContactInformation links, String license) {
 		this.id = id;
 		this.version = version;
-		this.requires = Collections.unmodifiableMap(requires);
-		this.conflicts = Collections.unmodifiableMap(conflicts);
+		this.requires = DependencyOverrides.INSTANCE.getActiveDependencyMap("depends", id, Collections.unmodifiableMap(requires));
+		this.recommends = DependencyOverrides.INSTANCE.getActiveDependencyMap("recommends", id, Collections.emptyMap());
+		this.suggests = DependencyOverrides.INSTANCE.getActiveDependencyMap("suggests", id, Collections.unmodifiableMap(recommends));
+		this.conflicts = DependencyOverrides.INSTANCE.getActiveDependencyMap("conflicts", id, Collections.emptyMap());
+		this.breaks = DependencyOverrides.INSTANCE.getActiveDependencyMap("breaks", id, Collections.unmodifiableMap(conflicts));
 
 		if (mixins == null) {
 			this.mixins = V0ModMetadata.EMPTY_MIXINS;
@@ -80,7 +85,6 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 			this.description = description;
 		}
 
-		this.recommends = Collections.unmodifiableMap(recommends);
 		this.authors = Collections.unmodifiableCollection(authors);
 		this.contributors = contributors;
 		this.links = links;
@@ -129,22 +133,22 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 
 	@Override
 	public Collection<ModDependency> getRecommends() {
-		return Collections.emptyList();
-	}
-
-	@Override
-	public Collection<ModDependency> getSuggests() {
 		return this.recommends.values();
 	}
 
 	@Override
+	public Collection<ModDependency> getSuggests() {
+		return this.suggests.values();
+	}
+
+	@Override
 	public Collection<ModDependency> getConflicts() {
-		return Collections.emptyList();
+		return this.conflicts.values();
 	}
 
 	@Override
 	public Collection<ModDependency> getBreaks() {
-		return this.conflicts.values();
+		return this.breaks.values();
 	}
 
 	// General metadata

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -88,11 +88,11 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 		this.jars = Collections.unmodifiableCollection(jars);
 		this.mixins = Collections.unmodifiableCollection(mixins);
 		this.accessWidener = accessWidener;
-		this.depends = Collections.unmodifiableMap(depends);
-		this.recommends = Collections.unmodifiableMap(recommends);
-		this.suggests = Collections.unmodifiableMap(suggests);
-		this.conflicts = Collections.unmodifiableMap(conflicts);
-		this.breaks = Collections.unmodifiableMap(breaks);
+		this.depends = DependencyOverrides.INSTANCE.getActiveDependencyMap("depends", id, Collections.unmodifiableMap(depends));
+		this.recommends = DependencyOverrides.INSTANCE.getActiveDependencyMap("recommends", id, Collections.unmodifiableMap(recommends));
+		this.suggests = DependencyOverrides.INSTANCE.getActiveDependencyMap("suggests", id, Collections.unmodifiableMap(suggests));
+		this.conflicts = DependencyOverrides.INSTANCE.getActiveDependencyMap("conflicts", id, Collections.unmodifiableMap(conflicts));
+		this.breaks = DependencyOverrides.INSTANCE.getActiveDependencyMap("breaks", id, Collections.unmodifiableMap(breaks));
 		this.requires = Collections.unmodifiableMap(requires);
 		this.name = name;
 


### PR DESCRIPTION
This PR is designed to give modpack developers more control over mod dependenies. It starts by looking for (but not creating) a `config/fabric_loader_dependencies.json` file with the following format:

```json
{
  "version": 1,
  "overrides": {
    "oldermod": {
      "depends": {}
    },
    "fragilemod": {
      "breaks": {
          "hackymod": "*"
      }
    }
  }
}
```

If present this file will be used to replce the entire `depends` block of  `oldermod` with no dependencies, this is useful if a mod dpends on a specific version of minecraft, but works on another version without changes.

Secondly this can be used to add extra dependencies such as noting that `hackymod` breaks with `fragilemod`. This can be useful if a pack developer knows a specific mod that is added casuses common issues.

This can of course be used by any one, but its not something that should be encoraged due to it possibly leading to unexpected crashes. The format isnt very giving so wont be ideal for end users in that regard. (I do plan to add the overriden deps to the crash report via fabric api)

Thanks to player for providing some ideas and inputing on the design.

_V0 mod support should act the same as before, its a little tricky to apply the v1 support ontop of it, but I think its correct._