### PR TITLE
Initialize mods' root path lazily.

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -410,8 +410,6 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 	private void setupMods() {
 		for (ModContainer mod : mods) {
 			try {
-				mod.setupRootPath();
-
 				for (String in : mod.getInfo().getOldInitializers()) {
 					String adapter = mod.getInfo().getOldStyleLanguageAdapter();
 					entrypointStorage.addDeprecated(mod, adapter, in);


### PR DESCRIPTION
This is a partial workaround for issue #152 where MC unconditionally
creates a file system for its Jar that conflicted with loader doing the
same earlier. A complete fix that also works if a mod happens to access
ModContainer.getRootPath for MC needs to prevent MC from creating the
already existing FileSystem and closing it.

Co-authored-by: shedaniel

This replaces https://github.com/FabricMC/fabric-loader/pull/291