### PR TITLE
Add reason and environment fields to mod dependencies

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/metadata/ModDependency.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModDependency.java
@@ -32,7 +32,7 @@ public interface ModDependency {
 	String getModId();
 
 	/**
-	 * @return the reason for the mod dependency
+	 * @return the reason for the mod dependency.
 	 */
 	Optional<String> getReason();
 

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModDependency.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModDependency.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.loader.api.metadata;
 
+import java.util.Optional;
 import java.util.Set;
 
 import net.fabricmc.loader.api.Version;
@@ -29,6 +30,16 @@ public interface ModDependency {
 	 * Returns the ID of the mod to check.
 	 */
 	String getModId();
+
+	/**
+	 * @return the reason for the mod dependency
+	 */
+	Optional<String> getReason();
+
+	/**
+	 * @return the mod environment in which this dependency applies.
+	 */
+	ModEnvironment getEnvironment();
 
 	/**
 	 * Returns if the version fulfills this dependency's version requirement.

--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -440,7 +440,7 @@ public class ModResolver {
 					.append(depCandidateVer)
 					.append(" of ")
 					.append(getCandidateName(depCandidate))
-					.append(" may breaks in the presence of ")
+					.append(" may break in the presence of ")
 					.append(getCandidateName(candidate))
 					.append(":\n")
 					.append(reason);

--- a/src/main/java/net/fabricmc/loader/metadata/ModDependencyImpl.java
+++ b/src/main/java/net/fabricmc/loader/metadata/ModDependencyImpl.java
@@ -17,27 +17,45 @@
 package net.fabricmc.loader.metadata;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+
+import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.VersionPredicate;
 import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
 import net.fabricmc.loader.util.version.VersionPredicateParser;
 
 final class ModDependencyImpl implements ModDependency {
 	private final String modId;
+	private final ModEnvironment environment;
+	private final String reason;
 	private final List<String> matcherStringList;
 	private Set<VersionPredicate> ranges;
 
-	ModDependencyImpl(String modId, List<String> matcherStringList) {
+	ModDependencyImpl(String modId, ModEnvironment environment, @Nullable String reason, List<String> matcherStringList) {
 		this.modId = modId;
+		this.environment = environment;
+		this.reason = reason;
 		this.matcherStringList = matcherStringList;
 	}
 
 	@Override
 	public String getModId() {
 		return this.modId;
+	}
+
+	@Override
+	public Optional<String> getReason() {
+		return Optional.ofNullable(this.reason);
+	}
+
+	@Override
+	public ModEnvironment getEnvironment() {
+		return this.environment;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/metadata/V0ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V0ModMetadataParser.java
@@ -371,7 +371,8 @@ final class V0ModMetadataParser {
 				throw new ParseMetadataException("Expected version to be a string or array", reader);
 			}
 
-			dependencies.put(modId, new ModDependencyImpl(modId, versionMatchers));
+			// V0 does not support environment dependencies or dependency reasons
+			dependencies.put(modId, new ModDependencyImpl(modId, ModEnvironment.UNIVERSAL, null, versionMatchers));
 		}
 
 		reader.endObject();

--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
@@ -46,7 +46,7 @@ final class V1ModMetadataParser {
 	 * @param logger the logger to print warnings to
 	 * @param reader the json reader to read the file with
 	 * @return the metadata of this file, null if the file could not be parsed
-	 * @throws IOException         if there was any issue reading the file
+	 * @throws IOException if there was any issue reading the file
 	 */
 	static LoaderModMetadata parse(Logger logger, JsonReader reader) throws IOException, ParseMetadataException {
 		List<ParseWarning> warnings = new ArrayList<>();
@@ -434,7 +434,7 @@ final class V1ModMetadataParser {
 		reader.endArray();
 	}
 
-	private static void readDependenciesContainer(JsonReader reader, Map<String, ModDependency> modDependencies) throws IOException, ParseMetadataException {
+	static void readDependenciesContainer(JsonReader reader, Map<String, ModDependency> modDependencies) throws IOException, ParseMetadataException {
 		if (reader.peek() != JsonToken.BEGIN_OBJECT) {
 			throw new ParseMetadataException("Dependency container must be an object!", reader);
 		}
@@ -444,7 +444,8 @@ final class V1ModMetadataParser {
 		while (reader.hasNext()) {
 			final String modId = reader.nextName();
 			final List<String> matcherStringList = new ArrayList<>();
-			/* @Nullable */ String reason = null;
+			/* @Nullable */
+			String reason = null;
 			ModEnvironment environment = ModEnvironment.UNIVERSAL;
 
 			switch (reader.peek()) {


### PR DESCRIPTION
This pull request allows for two new things:

Yes I need to go test this first - just readying this for feedback.

Dependencies may apply in certain environments - a mod which only depends on `a` on the client will launch without `a` being installed on the dedicated server.

Adds a reason field to a mod dependency, explaining why a mod may conflict, is depended on or breaks in the presence of another mod.

This pull request also makes the version parsing logic between dependency overrides and the v1 dependency parsing in the same method for easier maintenance of these facilities.

The `environment` and `reason` fields are optional in the new additional syntax for a dependency.

Example:
```json
{
    "depends": {
        "foo": {
            "versions": ">=1.0", // This may be an array for multiple version ranges like the current array syntax.
            "reason": "bar",
            "environment": "client"
        }
    }
}
```