### PR TITLE
Add warning when loading a mod in the wrong environment

### DIFF
--- a/src/main/java/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/FabricLoader.java
@@ -332,6 +332,7 @@ public class FabricLoader implements net.fabricmc.loader.api.FabricLoader {
 		}
 
 		if (!info.loadsInEnvironment(getEnvironmentType())) {
+			LOGGER.warn("Attempted to load mod {} in environment {}, it can only be loaded in environment type {}", info.getId(), getEnvironmentType(), info.getEnvironment());
 			return;
 		}
 


### PR DESCRIPTION
Adds a warning when a user attempts to load a mod that should not be loaded in their current environment, but does not throw an exception.