### PR TITLE
Migrate from reflection to method handles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,12 @@ jar {
 	}
 }
 
+// useful for creating test mod jar
+task testJar(type: Jar) {
+	archiveClassifier = "test"
+	from sourceSets.test.output
+}
+
 task copyJson(type: Copy, dependsOn: ["remapJar"]) {
 	from('src/main/resources/fabric-installer.json') {
 		rename { "${archivesBaseName}-${version}.json" }

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -88,6 +88,19 @@ public interface FabricLoader {
 	 * where the {@code default} adapter is the {@linkplain LanguageAdapter adapter}
 	 * offered by Fabric Loader. </p>
 	 *
+	 * <p>The language adapter from fabric loader supports these notations:
+	 * <ul><li>A class name in binary ({@code .}) format</li>
+	 * <li>A class name in binary format concatenated with {@code ::} to a field or
+	 * method name</li></ul>
+	 * When only a class name is provided, the default adapter will try to instantiate
+	 * the class thorough its public no-argument constructor and cast it to the type
+	 * of entrypoint. When there is a field name, the field must be public and static;
+	 * the adapter will retrieve the field's value and cast it to the type of entrypoint.
+	 * When there is a method name, the adapter will create a proxy where <b>any call to
+	 * any method</b> except Object methods will be delegated to that method, which must be
+	 * public and can be static or instance. If it's an instance method, an instance of
+	 * the class will be created first.
+	 *
 	 * @param key  the key in entrypoint declaration in {@code fabric.mod.json}
 	 * @param type the type of entrypoints
 	 * @param <T>  the type of entrypoints

--- a/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
+++ b/src/main/java/net/fabricmc/loader/game/MinecraftGameProvider.java
@@ -29,7 +29,8 @@ import net.fabricmc.loader.util.Arguments;
 import net.fabricmc.loader.util.SystemProperties;
 
 import java.io.File;
-import java.lang.reflect.Method;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -221,10 +222,10 @@ public class MinecraftGameProvider implements GameProvider {
 		}
 
 		try {
-			Class<?> c = loader.loadClass(targetClass);
-			Method m = c.getMethod("main", String[].class);
-			m.invoke(null, (Object) arguments.toArray());
-		} catch (Exception e) {
+			MethodHandles.lookup()
+					.findStatic(loader.loadClass(targetClass), "main", MethodType.methodType(Void.TYPE, String[].class))
+					.invokeExact((String[]) arguments.toArray()); // ignore ide warning here
+		} catch (Throwable e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/launch/server/FabricServerLauncher.java
+++ b/src/main/java/net/fabricmc/loader/launch/server/FabricServerLauncher.java
@@ -20,6 +20,8 @@ import net.fabricmc.loader.util.SystemProperties;
 import net.fabricmc.loader.util.UrlUtil;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
@@ -58,9 +60,10 @@ public class FabricServerLauncher {
 
 	private static void launch(String mainClass, ClassLoader loader, String[] args) {
 		try {
-			Class<?> c = loader.loadClass(mainClass);
-			c.getMethod("main", String[].class).invoke(null, (Object) args);
-		} catch (Exception e) {
+			MethodHandles.lookup()
+					.findStatic(loader.loadClass(mainClass), "main", MethodType.methodType(Void.TYPE, String[].class))
+					.invokeExact((String[]) args); // ignore ide warning
+		} catch (Throwable e) {
 			throw new RuntimeException("An exception occurred when launching the server!", e);
 		}
 	}

--- a/src/test/java/net/fabricmc/test/EntrypointTest.java
+++ b/src/test/java/net/fabricmc/test/EntrypointTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.test;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.fabricmc.api.ModInitializer;
+
+public final class EntrypointTest {
+
+	private static final Logger LOGGER = LogManager.getLogger();
+	public static final ModInitializer FIELD_ENTRY = EntrypointTest::fieldEntry;
+
+	public static void staticEntry() {
+		LOGGER.info("Static entry called");
+	}
+
+	public EntrypointTest() {
+		LOGGER.info("EntrypointTest instance created");
+	}
+
+	public void instanceEntry() {
+		LOGGER.info("Instance entry called");
+	}
+
+	public static void fieldEntry() {
+		LOGGER.info("Field entry called");
+	}
+}

--- a/src/test/java/net/fabricmc/test/TestMod.java
+++ b/src/test/java/net/fabricmc/test/TestMod.java
@@ -16,7 +16,11 @@
 
 package net.fabricmc.test;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.launch.common.FabricLauncherBase;
 
@@ -51,6 +55,10 @@ public class TestMod implements PreLaunchEntrypoint, ModInitializer {
 		LOGGER.info("**************************");
 		LOGGER.info("Hello from Fabric");
 		LOGGER.info("**************************");
+
+		Set<ModInitializer> testingInits = new LinkedHashSet<>(FabricLoader.getInstance().getEntrypoints("test:testing", ModInitializer.class));
+		LOGGER.info("Found %d testing inits", testingInits.size());
+		testingInits.forEach(ModInitializer::onInitialize);
 	}
 
 }

--- a/src/test/resources/fabric.mod.json
+++ b/src/test/resources/fabric.mod.json
@@ -16,6 +16,11 @@
     ],
     "main": [
       "net.fabricmc.test.TestMod"
+    ],
+    "test:testing": [
+      "net.fabricmc.test.EntrypointTest::instanceEntry",
+      "net.fabricmc.test.EntrypointTest::staticEntry",
+      "net.fabricmc.test.EntrypointTest::FIELD_ENTRY"
     ]
   }
 }


### PR DESCRIPTION
Except one place where mixin bootstrap methods are not accessible
Fixed #377, the test mod has test case (adding to linked hash set)

In general, in modern java, method handles are significantly faster than reflection because of vm optimizations (especially when always calling with `invokeExact`).