### PR TITLE
Update mixin and asm to support newer java versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	annotationProcessor "org.ow2.asm:asm-tree:${project.asm_version}"
 	annotationProcessor "org.ow2.asm:asm-util:${project.asm_version}"
 
-	implementation('net.fabricmc:sponge-mixin:0.8.2+build.24') {
+	implementation('net.fabricmc:sponge-mixin:0.9.2+mixin.0.8.2') {
 		exclude module: 'launchwrapper'
 		exclude module: 'guava'
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
 version = 0.11.1
-asm_version = 9.0
+asm_version = 9.1

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -10,7 +10,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:sponge-mixin:0.8.2+build.24",
+        "name": "net.fabricmc:sponge-mixin:0.9.2+mixin.0.8.2",
         "url": "https://maven.fabricmc.net/"
       },
       {
@@ -30,23 +30,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:9.0",
+        "name": "org.ow2.asm:asm:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:9.0",
+        "name": "org.ow2.asm:asm-analysis:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:9.0",
+        "name": "org.ow2.asm:asm-commons:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:9.0",
+        "name": "org.ow2.asm:asm-tree:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:9.0",
+        "name": "org.ow2.asm:asm-util:9.1",
         "url": "https://maven.fabricmc.net/"
       }
     ],

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -13,7 +13,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:sponge-mixin:0.8.2+build.24",
+        "name": "net.fabricmc:sponge-mixin:0.9.2+mixin.0.8.2",
         "url": "https://maven.fabricmc.net/"
       },
       {
@@ -33,23 +33,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:9.0",
+        "name": "org.ow2.asm:asm:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:9.0",
+        "name": "org.ow2.asm:asm-analysis:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:9.0",
+        "name": "org.ow2.asm:asm-commons:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:9.0",
+        "name": "org.ow2.asm:asm-tree:9.1",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:9.0",
+        "name": "org.ow2.asm:asm-util:9.1",
         "url": "https://maven.fabricmc.net/"
       }
     ],


### PR DESCRIPTION
Not a lot of notable changes, the main concern with this update is the new mixin version number and the changes I made to mixin's build script. This leads the way to allow other changes to mixin down the line.

This still needs special testing on 0.5 loom.