### PR TITLE
Throw an error when a mod alias is same with another mod's id

### DIFF
--- a/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/discovery/ModResolver.java
@@ -157,6 +157,14 @@ public class ModResolver {
 				for (ModCandidate mod : candidateIntMap.keySet()) {
 					int modClauseId = candidateIntMap.get(mod);
 
+					// When a mod provides an alias id, another mod with same id as the alias must NOT be present.
+
+					for (String provided : mod.getInfo().getProvides()) {
+						if (mandatoryMods.contains(provided)) {
+							throw new ModResolutionException("Found conflicting mods: " + mod.getInfo().getId() + " provides " + provided + " but it's already present");
+						}
+					}
+
 					// Each mod's requirements must be satisfied, if it is to be present.
 					// mod => ((a or b) AND (d or e))
 					// \> not mod OR ((a or b) AND (d or e))


### PR DESCRIPTION
When someone has a mod that provides alias `tater`, and an actual mod with that id, it'll result in a `Missing mods` error:
```
 net.fabricmc.loader.discovery.ModResolutionException: Errors were found!
 - Missing mods: tater
	at net.fabricmc.loader.discovery.ModResolver.findCompatibleSet(ModResolver.java:322) ~[main/:?]
	at net.fabricmc.loader.discovery.ModResolver.resolve(ModResolver.java:787) ~[main/:?]
	at net.fabricmc.loader.FabricLoader.setup(FabricLoader.java:211) ~[main/:?]
	at net.fabricmc.loader.FabricLoader.load(FabricLoader.java:201) [main/:?]
	at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:126) [main/:?]
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:27) [main/:?]
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86) [dev-launch-injector-0.2.1+build.8.jar:?]
```
This PR makes it more clear that you shouldn't have both of them in the first place.