### PR TITLE
Ignore $schema in v1 fabric.mod.json files instead of warning

### DIFF
--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadataParser.java
@@ -208,6 +208,9 @@ final class V1ModMetadataParser {
 			case "custom":
 				readCustomValues(reader, customValues);
 				break;
+			case "$schema":
+				reader.skipValue();
+				break;
 			default:
 				warnings.add(new ParseWarning(reader.getLineNumber(), reader.getColumn(), key, "Unsupported root entry"));
 				reader.skipValue();


### PR DESCRIPTION
[JSON Schema](https://json-schema.org) specifies that the `$schema` key is used to set the JSON schema used for the file.
By ignoring this key instead of printing a warning, it becomes possible to specify such a schema for the editor support _without_ causing warnings on every load of the mod.
