### PR TITLE
Fix deprecations, remove JCenter, update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
 		transitive = false
 	}
 	implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
+	
+	testImplementation 'org.jetbrains:annotations:20.1.0'
 
 	// Unit testing for mod metadata
 	testImplementation('org.junit.jupiter:junit-jupiter:5.7.1')

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ dependencies {
 		transitive = false
 	}
 	implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
-	
 	testImplementation 'org.jetbrains:annotations:20.1.0'
 
 	// Unit testing for mod metadata

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	}
 	implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
 
-	testCompileClasspath 'org.jetbrains:annotations:20.1.0'
+	testImplementation 'org.jetbrains:annotations:20.1.0'
 
 	// Unit testing for mod metadata
 	testImplementation('org.junit.jupiter:junit-jupiter:5.7.1')

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'eclipse'
 	id 'maven-publish'
 	id("org.cadixdev.licenser") version "0.5.0"
-	id("fabric-loom") version "0.5-SNAPSHOT"
+	id("fabric-loom") version "0.6-SNAPSHOT"
 }
 
 sourceCompatibility = 1.8
@@ -64,7 +64,7 @@ dependencies {
 	}
 	implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
 
-	testCompileOnly 'org.jetbrains:annotations:19.0.0'
+	testCompileClasspath 'org.jetbrains:annotations:19.0.0'
 
 	// Unit testing for mod metadata
 	testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,6 @@ dependencies {
 	}
 	implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
 
-	testImplementation 'org.jetbrains:annotations:20.1.0'
-
 	// Unit testing for mod metadata
 	testImplementation('org.junit.jupiter:junit-jupiter:5.7.1')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ version = version + (ENV.GITHUB_ACTIONS ? "" : "+local")
 
 repositories {
 	mavenCentral()
-	jcenter()
 	maven {
 		name = 'Fabric'
 		url = 'https://maven.fabricmc.net/'
@@ -30,8 +29,8 @@ repositories {
 }
 
 dependencies {
-	minecraft "com.mojang:minecraft:1.16.4"
-	mappings "net.fabricmc:yarn:1.16.4+build.9:v2"
+	minecraft "com.mojang:minecraft:1.16.5"
+	mappings "net.fabricmc:yarn:1.16.5+build.6:v2"
 
 	// fabric-loader dependencies
 	implementation "org.ow2.asm:asm:${project.asm_version}"
@@ -51,9 +50,9 @@ dependencies {
 		exclude module: 'launchwrapper'
 		exclude module: 'guava'
 	}
-	implementation 'net.fabricmc:tiny-mappings-parser:0.2.2.14'
-	implementation 'net.fabricmc:tiny-remapper:0.3.0.70'
-	implementation 'net.fabricmc:access-widener:1.0.0'
+	implementation 'net.fabricmc:tiny-mappings-parser:0.3.0+build.17'
+	implementation 'net.fabricmc:tiny-remapper:0.3.2'
+	implementation 'net.fabricmc:access-widener:1.0.2'
 
 	implementation 'com.google.jimfs:jimfs:1.2-fabric'
 	implementation 'net.fabricmc:fabric-loader-sat4j:2.3.5.4'
@@ -64,10 +63,10 @@ dependencies {
 	}
 	implementation 'net.sf.jopt-simple:jopt-simple:5.0.3'
 
-	testCompileClasspath 'org.jetbrains:annotations:19.0.0'
+	testCompileClasspath 'org.jetbrains:annotations:20.1.0'
 
 	// Unit testing for mod metadata
-	testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
+	testImplementation('org.junit.jupiter:junit-jupiter:5.7.1')
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ repositories {
 }
 
 dependencies {
-	minecraft "com.mojang:minecraft:1.16.5"
-	mappings "net.fabricmc:yarn:1.16.5+build.6:v2"
+	minecraft "com.mojang:minecraft:1.16.4"
+	mappings "net.fabricmc:yarn:1.16.4+build.9:v2"
 
 	// fabric-loader dependencies
 	implementation "org.ow2.asm:asm:${project.asm_version}"

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -6,7 +6,7 @@
     ],
     "common": [
       {
-        "name": "net.fabricmc:tiny-mappings-parser:0.2.2.14",
+        "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
         "url": "https://maven.fabricmc.net/"
       },
       {
@@ -14,11 +14,11 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:tiny-remapper:0.3.0.70",
+        "name": "net.fabricmc:tiny-remapper:0.3.2",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:access-widener:1.0.0",
+        "name": "net.fabricmc:access-widener:1.0.2",
         "url": "https://maven.fabricmc.net/"
       },
       {

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -9,7 +9,7 @@
         "name": "net.minecraft:launchwrapper:1.12"
       },
       {
-        "name": "net.fabricmc:tiny-mappings-parser:0.2.2.14",
+        "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
         "url": "https://maven.fabricmc.net/"
       },
       {
@@ -17,11 +17,11 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:tiny-remapper:0.3.0.70",
+        "name": "net.fabricmc:tiny-remapper:0.3.2",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:access-widener:1.0.0",
+        "name": "net.fabricmc:access-widener:1.0.2",
         "url": "https://maven.fabricmc.net/"
       },
       {


### PR DESCRIPTION
`testCompileOnly` fails in Gradle 7.0, this PR changes it to `testImplementation` for it to function with 7.0 once updated.