### PR TITLE
Fix lazy loading (#313) breaking legacy entry points

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointContainerImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointContainerImpl.java
@@ -26,10 +26,23 @@ public final class EntrypointContainerImpl<T> implements EntrypointContainer<T> 
 	private final EntrypointStorage.Entry entry;
 	private T instance;
 
+	/**
+	 * Create EntrypointContainer with lazy init.
+	 */
 	public EntrypointContainerImpl(String key, Class<T> type, EntrypointStorage.Entry entry) {
 		this.key = key;
 		this.type = type;
 		this.entry = entry;
+	}
+
+	/**
+	 * Create EntrypointContainer without lazy init.
+	 */
+	public EntrypointContainerImpl(EntrypointStorage.Entry entry, T instance) {
+		this.key = null;
+		this.type = null;
+		this.entry = entry;
+		this.instance = instance;
 	}
 
 	@SuppressWarnings("deprecation")
@@ -38,6 +51,7 @@ public final class EntrypointContainerImpl<T> implements EntrypointContainer<T> 
 		if (instance == null) {
 			try {
 				instance = entry.getOrCreate(type);
+				assert instance != null;
 			} catch (Exception ex) {
 				throw new EntrypointException(key, getProvider().getMetadata().getId(), ex);
 			}


### PR DESCRIPTION
This disables lazy loading where it isn't possible due to the entry point potentially needing actual type based filtering.