### PR TITLE
Re-add legacy FabricServerLauncher.main, just in case something depends on it

### DIFF
--- a/src/main/legacyJava/net/fabricmc/loader/launch/server/FabricServerLauncher.java
+++ b/src/main/legacyJava/net/fabricmc/loader/launch/server/FabricServerLauncher.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.launch.server;
+
+/**
+ * @deprecated Use {@link net.fabricmc.loader.impl.launch.server.FabricServerLauncher} instead
+ */
+@Deprecated
+public final class FabricServerLauncher {
+	public static void main(String[] args) {
+		net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(args);
+	}
+}


### PR DESCRIPTION
I am unable to determine whether anyone relies on this entry point, so better to keep it working.