### PR TITLE
Treat unexpanded Gradle version property as satisfied dependency

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModResolver.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModResolver.java
@@ -150,7 +150,13 @@ public class ModResolver {
 					for (ModDependency dep : mod.getInfo().getDepends()) {
 						int[] matchingCandidates = modCandidateMap.getOrDefault(dep.getModId(), Collections.emptyList())
 								.stream()
-								.filter((c) -> dep.matches(c.getInfo().getVersion()))
+								.filter((c) -> {
+									Version version = c.getInfo().getVersion();
+									if (version.toString() == "${version}" || version.toString() == "$version") {
+										return true;
+									}
+									return dep.matches(version);
+								})
 								.mapToInt(candidateIntMap::get)
 								.toArray();
 


### PR DESCRIPTION
This helps when testing mod compatibility with mods that have a dependency on the mod that is being developed.