### PR TITLE
Add --fabric.addMods / -Dfabric.addMods for adding extra path separator separated mods, list file if prefixed with @

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -43,6 +43,7 @@ import net.fabricmc.loader.api.LanguageAdapter;
 import net.fabricmc.loader.api.MappingResolver;
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+import net.fabricmc.loader.impl.discovery.ArgumentModCandidateFinder;
 import net.fabricmc.loader.impl.discovery.ClasspathModCandidateFinder;
 import net.fabricmc.loader.impl.discovery.DirectoryModCandidateFinder;
 import net.fabricmc.loader.impl.discovery.ModCandidate;
@@ -179,9 +180,11 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 	}
 
 	private void setup() throws ModResolutionException {
+		boolean remapRegularMods = isDevelopmentEnvironment();
 		ModDiscoverer discoverer = new ModDiscoverer();
 		discoverer.addCandidateFinder(new ClasspathModCandidateFinder());
-		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(gameDir.resolve("mods"), isDevelopmentEnvironment()));
+		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(gameDir.resolve("mods"), remapRegularMods));
+		discoverer.addCandidateFinder(new ArgumentModCandidateFinder(remapRegularMods));
 
 		List<ModCandidate> mods = ModResolver.resolve(discoverer.discoverMods(this));
 
@@ -201,7 +204,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		// runtime mod remapping
 
-		if (isDevelopmentEnvironment()) {
+		if (remapRegularMods) {
 			if (System.getProperty(SystemProperties.REMAP_CLASSPATH_FILE) == null) {
 				Log.warn(LogCategory.MOD_REMAP, "Runtime mod remapping disabled due to no fabric.remapClasspathFile being specified. You may need to update loom.");
 			} else {

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ArgumentModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ArgumentModCandidateFinder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.discovery;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import net.fabricmc.loader.impl.FabricLoaderImpl;
+import net.fabricmc.loader.impl.util.Arguments;
+import net.fabricmc.loader.impl.util.SystemProperties;
+import net.fabricmc.loader.impl.util.log.Log;
+import net.fabricmc.loader.impl.util.log.LogCategory;
+
+public class ArgumentModCandidateFinder implements ModCandidateFinder {
+	private final boolean requiresRemap;
+
+	public ArgumentModCandidateFinder(boolean requiresRemap) {
+		this.requiresRemap = requiresRemap;
+	}
+
+	@Override
+	public void findCandidates(ModCandidateConsumer out) {
+		String list = System.getProperty(SystemProperties.ADD_MODS);
+		if (list != null) addMods(list, "system property", out);
+
+		list = FabricLoaderImpl.INSTANCE.getGameProvider().getArguments().remove(Arguments.ADD_MODS);
+		if (list != null) addMods(list, "argument", out);
+	}
+
+	private void addMods(String list, String source, ModCandidateConsumer out) {
+		for (String pathStr : list.split(File.pathSeparator)) {
+			if (pathStr.isEmpty()) continue;
+
+			if (pathStr.startsWith("@")) {
+				Path path = Paths.get(pathStr.substring(1));
+
+				if (!Files.isRegularFile(path)) {
+					Log.warn(LogCategory.DISCOVERY, "Missing/invalid %s provided mod list file %s", source, path);
+					continue;
+				}
+
+				try (BufferedReader reader = Files.newBufferedReader(path)) {
+					String fileSource = String.format("%s file %s", source, path);
+					String line;
+
+					while ((line = reader.readLine()) != null) {
+						line = line.trim();
+						if (line.isEmpty()) continue;
+
+						addMod(pathStr, fileSource, out);
+					}
+				} catch (IOException e) {
+					throw new RuntimeException(String.format("Error reading %s provided mod list file %s", source, path), e);
+				}
+			} else {
+				addMod(pathStr, source, out);
+			}
+		}
+	}
+
+	private void addMod(String pathStr, String source, ModCandidateConsumer out) {
+		Path path = Paths.get(pathStr);
+		boolean isDir;
+
+		if (!Files.exists(path)) {
+			Log.warn(LogCategory.DISCOVERY, "Missing %s provided mod path %s", source, path);
+		} else if ((isDir = Files.isDirectory(path)) && !Files.isRegularFile(path.resolve("fabric.mod.json"))
+				|| !isDir && !DirectoryModCandidateFinder.isValidFile(path)) {
+			Log.warn(LogCategory.DISCOVERY, "Incompatible path in %s provided mod path %s (must be a directory with a fabric.mod.json or a non-hidden jar file", source, path);
+		} else {
+			out.accept(path, requiresRemap);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ArgumentModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ArgumentModCandidateFinder.java
@@ -65,7 +65,7 @@ public class ArgumentModCandidateFinder implements ModCandidateFinder {
 						line = line.trim();
 						if (line.isEmpty()) continue;
 
-						addMod(pathStr, fileSource, out);
+						addMod(line, fileSource, out);
 					}
 				} catch (IOException e) {
 					throw new RuntimeException(String.format("Error reading %s provided mod list file %s", source, path), e);

--- a/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
@@ -25,6 +25,9 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.EnumSet;
 
+import net.fabricmc.loader.impl.util.log.Log;
+import net.fabricmc.loader.impl.util.log.LogCategory;
+
 public class DirectoryModCandidateFinder implements ModCandidateFinder {
 	private final Path path;
 	private final boolean requiresRemap;
@@ -52,18 +55,7 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 			Files.walkFileTree(this.path, EnumSet.of(FileVisitOption.FOLLOW_LINKS), 1, new SimpleFileVisitor<Path>() {
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-					/*
-					 * We only propose a file as a possible mod in the following scenarios:
-					 * General: Must be a jar file
-					 *
-					 * Some OSes Generate metadata so consider the following because of OSes:
-					 * UNIX: Exclude if file is hidden; this occurs when starting a file name with `.`
-					 * MacOS: Exclude hidden + startsWith "." since Mac OS names their metadata files in the form of `.mod.jar`
-					 */
-
-					String fileName = file.getFileName().toString();
-
-					if (fileName.endsWith(".jar") && !fileName.startsWith(".") && !Files.isHidden(file)) {
+					if (isValidFile(file)) {
 						out.accept(file, requiresRemap);
 					}
 
@@ -73,5 +65,29 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 		} catch (IOException e) {
 			throw new RuntimeException("Exception while searching for mods in '" + path + "'!", e);
 		}
+	}
+
+	static boolean isValidFile(Path path) {
+		/*
+		 * We only propose a file as a possible mod in the following scenarios:
+		 * General: Must be a jar file
+		 *
+		 * Some OSes Generate metadata so consider the following because of OSes:
+		 * UNIX: Exclude if file is hidden; this occurs when starting a file name with `.`
+		 * MacOS: Exclude hidden + startsWith "." since Mac OS names their metadata files in the form of `.mod.jar`
+		 */
+
+		if (!Files.isRegularFile(path)) return false;
+
+		try {
+			if (Files.isHidden(path)) return false;
+		} catch (IOException e) {
+			Log.warn(LogCategory.DISCOVERY, "Error checking if file %s is hidden", path, e);
+			return false;
+		}
+
+		String fileName = path.getFileName().toString();
+
+		return fileName.endsWith(".jar") && !fileName.startsWith(".");
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
@@ -69,10 +69,15 @@ public final class ModDiscoverer {
 	public Collection<ModCandidate> discoverMods(FabricLoaderImpl loader) throws ModResolutionException {
 		long startTime = System.nanoTime();
 		ForkJoinPool pool = new ForkJoinPool();
+		Set<Path> paths = new HashSet<>(); // suppresses duplicate paths
 		List<Future<ModCandidate>> futures = new ArrayList<>();
 
 		ModCandidateConsumer taskSubmitter = (path, requiresRemap) -> {
-			futures.add(pool.submit(new ModScanTask(path, requiresRemap)));
+			path = path.toAbsolutePath().normalize();
+
+			if (paths.add(path)) {
+				futures.add(pool.submit(new ModScanTask(path, requiresRemap)));
+			}
 		};
 
 		for (ModCandidateFinder finder : candidateFinders) {

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.impl.game.patch.GameTransformer;
+import net.fabricmc.loader.impl.util.Arguments;
 
 public interface GameProvider {
 	String getGameId();
@@ -42,6 +43,7 @@ public interface GameProvider {
 	GameTransformer getEntrypointTransformer();
 	void launch(ClassLoader loader);
 
+	Arguments getArguments();
 	String[] getLaunchArguments(boolean sanitize);
 
 	default boolean canOpenErrorGui() {

--- a/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -88,8 +88,6 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		if (getEnvironmentType() == EnvType.CLIENT && !arguments.containsKey("assetsDir") && assetsDir != null) {
 			arguments.put("assetsDir", assetsDir.getAbsolutePath());
 		}
-
-		FabricLauncherBase.processArgumentMap(arguments, getEnvironmentType());
 	}
 
 	@Override
@@ -118,6 +116,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 			throw new RuntimeException("Could not locate Minecraft: provider locate failed");
 		}
 
+		arguments = null;
 		FabricLoaderImpl loader = FabricLoaderImpl.INSTANCE;
 		loader.setGameProvider(provider);
 		loader.load();
@@ -127,7 +126,6 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 		if (!isDevelopment) {
 			// Obfuscated environment
-			Launch.blackboard.put(SystemProperties.DEVELOPMENT, false);
 
 			try {
 				String target = getLaunchTarget();
@@ -164,7 +162,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public String[] getLaunchArguments() {
-		return isPrimaryTweaker ? arguments.toArray() : new String[0];
+		return isPrimaryTweaker ? FabricLoaderImpl.INSTANCE.getGameProvider().getLaunchArguments(false) : new String[0];
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.impl.launch;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -32,9 +31,7 @@ import java.util.jar.JarFile;
 
 import org.spongepowered.asm.mixin.MixinEnvironment;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
-import net.fabricmc.loader.impl.util.Arguments;
 import net.fabricmc.loader.impl.util.UrlUtil;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
@@ -53,10 +50,6 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 
 	protected FabricLauncherBase() {
 		setLauncher(this);
-	}
-
-	public static File getLaunchDirectory(Arguments argMap) {
-		return new File(argMap.getOrDefault("gameDir", "."));
 	}
 
 	public static Class<?> getClass(String className) throws ClassNotFoundException {
@@ -216,38 +209,6 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 
 		if (!Files.exists(deobfJarFile)) {
 			throw new RuntimeException("Remapped .JAR file does not exist after remapping! Cannot continue!");
-		}
-	}
-
-	public static void processArgumentMap(Arguments argMap, EnvType envType) {
-		switch (envType) {
-		case CLIENT:
-			if (!argMap.containsKey("accessToken")) {
-				argMap.put("accessToken", "FabricMC");
-			}
-
-			if (!argMap.containsKey("version")) {
-				argMap.put("version", "Fabric");
-			}
-
-			String versionType = "";
-
-			if (argMap.containsKey("versionType") && !argMap.get("versionType").equalsIgnoreCase("release")) {
-				versionType = argMap.get("versionType") + "/";
-			}
-
-			argMap.put("versionType", versionType + "Fabric");
-
-			if (!argMap.containsKey("gameDir")) {
-				argMap.put("gameDir", getLaunchDirectory(argMap).getAbsolutePath());
-			}
-
-			break;
-		case SERVER:
-			argMap.remove("version");
-			argMap.remove("gameDir");
-			argMap.remove("assetsDir");
-			break;
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/util/Arguments.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/Arguments.java
@@ -25,7 +25,10 @@ import java.util.List;
 import java.util.Map;
 
 public final class Arguments {
+	// set the game version for the builtin game mod/dependencies, bypassing auto-detection
 	public static final String GAME_VERSION = "fabric.gameVersion";
+	// additional mods to load (path separator separated paths, @ prefix for meta-file with each line referencing an actual file)
+	public static final String ADD_MODS = "fabric.addMods";
 
 	private final Map<String, String> values;
 	private final List<String> extraArgs;

--- a/src/main/java/net/fabricmc/loader/impl/util/Arguments.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/Arguments.java
@@ -26,9 +26,9 @@ import java.util.Map;
 
 public final class Arguments {
 	// set the game version for the builtin game mod/dependencies, bypassing auto-detection
-	public static final String GAME_VERSION = "fabric.gameVersion";
+	public static final String GAME_VERSION = SystemProperties.GAME_VERSION;
 	// additional mods to load (path separator separated paths, @ prefix for meta-file with each line referencing an actual file)
-	public static final String ADD_MODS = "fabric.addMods";
+	public static final String ADD_MODS = SystemProperties.ADD_MODS;
 
 	private final Map<String, String> values;
 	private final List<String> extraArgs;

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -17,14 +17,18 @@
 package net.fabricmc.loader.impl.util;
 
 public final class SystemProperties {
+	// whether fabric loader is running in a development environment / mode, affects class path mod discovery, remapping, logging, ...
 	public static final String DEVELOPMENT = "fabric.development";
 	public static final String SIDE = "fabric.side";
 	public static final String GAME_JAR_PATH = "fabric.gameJarPath";
+	// set the game version for the builtin game mod/dependencies, bypassing auto-detection
 	public static final String GAME_VERSION = "fabric.gameVersion";
 	// fallback log file for the builtin log handler (dumped on exit if not replaced with another handler)
 	public static final String LOG_FILE = "fabric.log.file";
 	// minimum log level for builtin log handler
 	public static final String LOG_LEVEL = "fabric.log.level";
+	// additional mods to load (path separator separated paths, @ prefix for meta-file with each line referencing an actual file)
+	public static final String ADD_MODS = "fabric.addMods";
 	// file containing the class path for in-dev runtime mod remapping
 	public static final String REMAP_CLASSPATH_FILE = "fabric.remapClasspathFile";
 	// throw exceptions from entrypoints, discovery etc. directly instead of gathering and attaching as suppressed
@@ -33,7 +37,4 @@ public final class SystemProperties {
 	public static final String DEBUG_DISABLE_MOD_SHUFFLE = "fabric.debug.disableModShuffle";
 	// workaround for bad load order dependencies
 	public static final String DEBUG_LOAD_LATE = "fabric.debug.loadLate";
-
-	private SystemProperties() {
-	}
 }


### PR DESCRIPTION
This allows to specify extra mods with
- the --fabric.addMods program argument
- the -Dfabric.addMods jvm argument

Each takes a path separated list similar to the class path, e.g. `--fabric.addMods=path/modA.jar:/some/path/modB.jar` on Linux/MacOS or `--fabric.addMods=path/modA.jar;/some/path/modB.jar`on Windows

Valid entries for this list are:
- mod jars
- unpackaged mod directories (as used in-dev)
- \@-prefixed mod list files with one of the above in each line, similar to java/javac command line argument files

A mod list reference like `-Dfabric.addMods=@/some/modList.txt` expects modList.txt to contain e.g.
```
path/modA.jar
/some/path/modB.jar
```


This PR touches argument handling to ensure correct behavior with Launchwrapper and move some MC specific code where it belongs.


resolves https://github.com/FabricMC/fabric-loader/issues/282 - the launcher has to translate to plain paths though