### PR TITLE
Improve error screen on MacOS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ indent_style = tab
 
 [*.java]
 indent_style = tab
+ij_continuation_indent_size = 8
+ij_java_imports_layout = $*,|,java.**,|,javax.**,|,*,|,net.fabricmc.**
+ij_java_class_count_to_use_import_on_demand = 999

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 
 	manifest {
 		attributes (
-				'Main-Class': 'net.fabricmc.loader.impl.launch.server.FabricServerLauncher'
+			'Main-Class': 'net.fabricmc.loader.impl.launch.server.FabricServerLauncher'
 		)
 	}
 
@@ -150,6 +150,8 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 	exclude 'about.html'
 	exclude 'sat4j.version'
 	exclude 'META-INF/maven/org.ow2.sat4j/*/**'
+
+	outputs.upToDateWhen { false }
 }
 
 File proguardFile = file("build/libs/fabric-loader-${version}.jar")

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -89,6 +89,7 @@ public final class FabricGuiEntry {
 	public static void main(String[] args) throws Exception {
 		FabricStatusTree tree = new FabricStatusTree(new DataInputStream(System.in));
 		FabricMainWindow.open(tree, true);
+		System.exit(-1);
 	}
 
 	/** @param exitAfter If true then this will call {@link System#exit(int)} after showing the gui, otherwise this will

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -89,7 +89,7 @@ public final class FabricGuiEntry {
 	public static void main(String[] args) throws Exception {
 		FabricStatusTree tree = new FabricStatusTree(new DataInputStream(System.in));
 		FabricMainWindow.open(tree, true);
-		System.exit(-1);
+		System.exit(0);
 	}
 
 	/** @param exitAfter If true then this will call {@link System#exit(int)} after showing the gui, otherwise this will


### PR DESCRIPTION
Fixes most of : #489 

- Title bar respects system dark mode settings
- Menu bar title fixed
- Dock icon fixed (Java 9+ only)
- Fixed closing (I think there is a thread still around, hard to debug I can look into more if wanted)

Not fixed the dock title, not sure of a way to resolve that.

<img width="645" alt="Screenshot 2021-08-04 at 19 52 12" src="https://user-images.githubusercontent.com/4324090/128241622-62915f71-f979-4fec-a85c-35e4a99b8274.png">
<img width="125" alt="Screenshot 2021-08-04 at 19 59 57" src="https://user-images.githubusercontent.com/4324090/128241631-7d86f011-b742-4571-af68-d58f0ac1ec90.png">
