### PR TITLE
Allow classpath isolation of Minecraft

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -167,13 +167,16 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 	}
 
 	@Override
-	public void addToClassPath(Path path) {
+	public void addToClassPath(Path path, boolean restricted) {
 		try {
 			launchClassLoader.addURL(UrlUtil.asUrl(path));
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}
 	}
+
+	@Override
+	public void releaseClassPathRestriction() { }
 
 	@Override
 	public Collection<URL> getLoadTimeDependencies() {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -149,6 +149,8 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 			}
 		}
 
+		FabricLauncherBase.getLauncher().releaseClassPathRestriction();
+
 		FabricLoaderImpl.INSTANCE.loadAccessWideners();
 
 		MinecraftGameProvider.TRANSFORMER.locateEntrypoints(this);

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/ModClassLoader_125_FML.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/ModClassLoader_125_FML.java
@@ -43,7 +43,7 @@ public class ModClassLoader_125_FML extends URLClassLoader {
 	@Override
 	protected void addURL(URL url) {
 		try {
-			FabricLauncherBase.getLauncher().addToClassPath(UrlUtil.asPath(url));
+			FabricLauncherBase.getLauncher().addToClassPath(UrlUtil.asPath(url), false);
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -263,7 +263,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		// TODO: This can probably be made safer, but that's a long-term goal
 		for (ModContainerImpl mod : mods) {
 			if (!mod.getInfo().getId().equals(MOD_ID) && !mod.getInfo().getType().equals("builtin")) {
-				FabricLauncherBase.getLauncher().addToClassPath(mod.getOriginPath());
+				FabricLauncherBase.getLauncher().addToClassPath(mod.getOriginPath(), false);
 			}
 		}
 
@@ -289,7 +289,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 				Path path = Paths.get(pathName).toAbsolutePath().normalize();
 
 				if (Files.isDirectory(path) && knownModPaths.add(path)) {
-					FabricLauncherBase.getLauncher().addToClassPath(path);
+					FabricLauncherBase.getLauncher().addToClassPath(path, false);
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
@@ -27,7 +27,14 @@ import net.fabricmc.api.EnvType;
 public interface FabricLauncher {
 	MappingConfiguration getMappingConfiguration();
 
-	void addToClassPath(Path path);
+	@Deprecated
+	default void addToClassPath(Path path) {
+		this.addToClassPath(path, false);
+	}
+
+	void addToClassPath(Path path, boolean restricted);
+
+	void releaseClassPathRestriction();
 
 	EnvType getEnvironmentType();
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
@@ -117,7 +117,7 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 			jarFile = deobfJarFile;
 		}
 
-		launcher.addToClassPath(jarFile);
+		launcher.addToClassPath(jarFile, true);
 
 		if (minecraftJar == null) {
 			minecraftJar = jarFile;

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -265,14 +265,19 @@ public final class Knot extends FabricLauncherBase {
 	}
 
 	@Override
-	public void addToClassPath(Path path) {
-		Log.debug(LogCategory.KNOT, "Adding " + path + " to classpath.");
+	public void addToClassPath(Path path, boolean restricted) {
+		Log.debug(LogCategory.KNOT, "Adding " + path + " to classpath. restricted = " + restricted);
 
 		try {
-			classLoader.addURL(UrlUtil.asUrl(path));
+			classLoader.addURL(UrlUtil.asUrl(path), restricted);
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@Override
+	public void releaseClassPathRestriction() {
+		classLoader.releaseRestriction();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -128,6 +128,8 @@ public final class Knot extends FabricLauncherBase {
 		loader.load();
 		loader.freeze();
 
+		FabricLauncherBase.getLauncher().releaseClassPathRestriction();
+
 		FabricLoaderImpl.INSTANCE.loadAccessWideners();
 
 		MixinBootstrap.init();

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -117,23 +117,18 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 	}
 
 	@Override
-	public void addURL(URL url) {
-		urlLoader.addURL(url);
-	}
-
-	@Override
 	public void addURL(URL url, boolean restricted) {
 		if (restricted) {
 			this.restrictedUrl.add(url);
 		} else {
-			this.addURL(url);
+			this.urlLoader.addURL(url);
 		}
 	}
 
 	@Override
 	public void releaseRestriction() {
 		for (URL url : restrictedUrl) {
-			this.addURL(url);
+			this.urlLoader.addURL(url);
 		}
 
 		restrictedUrl.clear();

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.SecureClassLoader;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Enumeration;
 
 import net.fabricmc.api.EnvType;
@@ -44,6 +46,7 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 
 	private final DynamicURLClassLoader urlLoader;
 	private final KnotClassDelegate delegate;
+	private final Collection<URL> restrictedUrl;
 
 	static {
 		registerAsParallelCapable();
@@ -53,6 +56,7 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 		super(KnotClassLoader.class.getClassLoader());
 		this.urlLoader = new DynamicURLClassLoader(new URL[0]);
 		this.delegate = new KnotClassDelegate(isDevelopment, envType, this, provider);
+		this.restrictedUrl = new ArrayList<>();
 	}
 
 	@Override
@@ -115,6 +119,20 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 	@Override
 	public void addURL(URL url) {
 		urlLoader.addURL(url);
+	}
+
+	@Override
+	public void addRestrictedUrl(URL url) {
+		this.restrictedUrl.add(url);
+	}
+
+	@Override
+	public void releaseRestriction() {
+		for (URL url : restrictedUrl) {
+			this.addURL(url);
+		}
+
+		restrictedUrl.clear();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -122,8 +122,12 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 	}
 
 	@Override
-	public void addRestrictedUrl(URL url) {
-		this.restrictedUrl.add(url);
+	public void addURL(URL url, boolean restricted) {
+		if (restricted) {
+			this.restrictedUrl.add(url);
+		} else {
+			this.addURL(url);
+		}
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -23,12 +23,6 @@ import java.net.URL;
 interface KnotClassLoaderInterface {
 	KnotClassDelegate getDelegate();
 	boolean isClassLoaded(String name);
-
-	@Deprecated
-	default void addURL(URL url) {
-		this.addURL(url, false);
-	}
-
 	void addURL(URL url, boolean restricted);
 	InputStream getResourceAsStream(String filename, boolean skipOriginalLoader) throws IOException;
 	void releaseRestriction();

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -25,4 +25,6 @@ interface KnotClassLoaderInterface {
 	boolean isClassLoaded(String name);
 	void addURL(URL url);
 	InputStream getResourceAsStream(String filename, boolean skipOriginalLoader) throws IOException;
+	void addRestrictedUrl(URL url);
+	void releaseRestriction();
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -23,8 +23,13 @@ import java.net.URL;
 interface KnotClassLoaderInterface {
 	KnotClassDelegate getDelegate();
 	boolean isClassLoaded(String name);
-	void addURL(URL url);
+
+	@Deprecated
+	default void addURL(URL url) {
+		this.addURL(url, false);
+	}
+
+	void addURL(URL url, boolean restricted);
 	InputStream getResourceAsStream(String filename, boolean skipOriginalLoader) throws IOException;
-	void addRestrictedUrl(URL url);
 	void releaseRestriction();
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
@@ -77,10 +77,12 @@ class KnotCompatibilityClassLoader extends URLClassLoader implements KnotClassLo
 		super.addURL(url);
 	}
 
+	@Override
 	public void addRestrictedUrl(URL url) {
 		this.restrictedUrl.add(url);
 	}
 
+	@Override
 	public void releaseRestriction() {
 		for (URL url : restrictedUrl) {
 			this.addURL(url);

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
@@ -78,8 +78,12 @@ class KnotCompatibilityClassLoader extends URLClassLoader implements KnotClassLo
 	}
 
 	@Override
-	public void addRestrictedUrl(URL url) {
-		this.restrictedUrl.add(url);
+	public void addURL(URL url, boolean restricted) {
+		if (restricted) {
+			this.restrictedUrl.add(url);
+		} else {
+			this.addURL(url);
+		}
 	}
 
 	@Override

--- a/src/main/legacyJava/net/fabricmc/loader/launch/common/FabricLauncherBase.java
+++ b/src/main/legacyJava/net/fabricmc/loader/launch/common/FabricLauncherBase.java
@@ -49,7 +49,7 @@ public class FabricLauncherBase implements FabricLauncher {
 	@Override
 	public void propose(URL url) {
 		try {
-			parent.addToClassPath(UrlUtil.asPath(url));
+			parent.addToClassPath(UrlUtil.asPath(url), false);
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
This isolates the Minecraft from the classpath until right before applying mixin.

Also, re-work class loader a little to avoid any potential class double defining.