### PR TITLE
Fix RuntimeModRemapper

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidate.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidate.java
@@ -22,6 +22,7 @@ import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -247,7 +248,7 @@ public final class ModCandidate implements DomainObject.Mod {
 			ByteBuffer data = dataRef.get();
 
 			if (data != null) {
-				Files.copy(new ByteArrayInputStream(data.array(), data.arrayOffset() + data.position(), data.arrayOffset() + data.limit()), out);
+				Files.copy(new ByteArrayInputStream(data.array(), data.arrayOffset() + data.position(), data.arrayOffset() + data.limit()), out, StandardCopyOption.REPLACE_EXISTING);
 				return;
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
@@ -158,6 +158,10 @@ public final class RuntimeModRemapper {
 			remapper.finish();
 
 			for (RemapInfo info : infoMap.values()) {
+				if (info.outputPath == null) {
+					continue;
+				}
+
 				try {
 					Files.deleteIfExists(info.outputPath);
 				} catch (IOException e) {


### PR DESCRIPTION
Allow ModCandidate.copyToFile to replace existing files, needed becuase the RMR creates an empty temp file.

Fix RuntimeModRemapper error handling, outputPath can be null if it throws before the output path has been set, as seen with the above issue.