### PR TITLE
Add a GUI for when the game crashes early

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -278,11 +278,19 @@ public class MinecraftGameProvider implements GameProvider {
 			Method m = c.getMethod("main", String[].class);
 			m.invoke(null, (Object) arguments.toArray());
 		} catch (InvocationTargetException e) {
-			FabricGuiEntry.displayError("Minecraft has crashed!", e.getCause(), false);
-			throw new RuntimeException("Minecraft has crashed", e.getCause()); // Pass it on
+			if (!onCrash(e.getCause(), "Minecraft has crashed!")) {
+				throw new RuntimeException("Minecraft has crashed", e.getCause()); // Pass it on
+			}
 		} catch (ReflectiveOperationException e) {
-			FabricGuiEntry.displayError("Failed to start Minecraft!", e, false);
-			throw new RuntimeException("Failed to start Minecraft", e);
+			if (!onCrash(e, "Failed to start Minecraft!")) {
+				throw new RuntimeException("Failed to start Minecraft", e);
+			}
 		}
+	}
+
+	@Override
+	public boolean onCrash(Throwable exception, String context) {
+		FabricGuiEntry.displayError(context, exception, false);
+		return false; // Allow the crash to propagate
 	}
 }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -17,6 +17,7 @@
 package net.fabricmc.loader.impl.game.minecraft;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ import net.fabricmc.loader.impl.game.minecraft.patch.BrandingPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatchFML125;
 import net.fabricmc.loader.impl.game.patch.GameTransformer;
+import net.fabricmc.loader.impl.gui.FabricGuiEntry;
 import net.fabricmc.loader.impl.metadata.BuiltinModMetadata;
 import net.fabricmc.loader.impl.metadata.ModDependencyImpl;
 import net.fabricmc.loader.impl.util.Arguments;
@@ -275,8 +277,11 @@ public class MinecraftGameProvider implements GameProvider {
 			Class<?> c = loader.loadClass(targetClass);
 			Method m = c.getMethod("main", String[].class);
 			m.invoke(null, (Object) arguments.toArray());
-		} catch (Exception e) {
-			throw new RuntimeException(e);
+		} catch (InvocationTargetException e) {
+			FabricGuiEntry.displayError("Minecraft has crashed!", e.getCause(), false);
+			throw new RuntimeException("Minecraft has crashed", e.getCause()); // Pass it on
+		} catch (ReflectiveOperationException e) {
+			throw new RuntimeException("Failed to start Minecraft", e);
 		}
 	}
 }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -281,6 +281,7 @@ public class MinecraftGameProvider implements GameProvider {
 			FabricGuiEntry.displayError("Minecraft has crashed!", e.getCause(), false);
 			throw new RuntimeException("Minecraft has crashed", e.getCause()); // Pass it on
 		} catch (ReflectiveOperationException e) {
+			FabricGuiEntry.displayError("Failed to start Minecraft!", e, false);
 			throw new RuntimeException("Failed to start Minecraft", e);
 		}
 	}

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -48,7 +48,6 @@ import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.entrypoint.EntrypointUtils;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider;
-import net.fabricmc.loader.impl.gui.FabricGuiEntry;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.FabricMixinBootstrap;
 import net.fabricmc.loader.impl.util.Arguments;
@@ -162,8 +161,9 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		try {
 			EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
 		} catch (RuntimeException e) {
-			FabricGuiEntry.displayError("Failed preparing to start", e, false);
-			throw e;
+			if (!provider.onCrash(e, "A mod crashed on startup")) {
+				throw e;
+			}
 		}
 	}
 

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -48,6 +48,7 @@ import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.entrypoint.EntrypointUtils;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider;
+import net.fabricmc.loader.impl.gui.FabricGuiEntry;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.FabricMixinBootstrap;
 import net.fabricmc.loader.impl.util.Arguments;
@@ -158,7 +159,12 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		FabricMixinBootstrap.init(getEnvironmentType(), FabricLoaderImpl.INSTANCE);
 		MixinEnvironment.getDefaultEnvironment().setSide(getEnvironmentType() == EnvType.CLIENT ? MixinEnvironment.Side.CLIENT : MixinEnvironment.Side.SERVER);
 
-		EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
+		try {
+			EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
+		} catch (RuntimeException e) {
+			FabricGuiEntry.displayError("Failed preparing to start", e, false);
+			throw e;
+		}
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -44,6 +44,7 @@ public interface GameProvider { // name directly referenced in net.fabricmc.load
 	boolean locateGame(EnvType envType, String[] args, ClassLoader loader);
 	GameTransformer getEntrypointTransformer();
 	void launch(ClassLoader loader);
+	boolean onCrash(Throwable exception, String context);
 
 	Arguments getArguments();
 	String[] getLaunchArguments(boolean sanitize);

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -25,8 +25,6 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import net.fabricmc.loader.api.ModContainer;
@@ -35,7 +33,6 @@ import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.discovery.ClasspathModCandidateFinder;
 import net.fabricmc.loader.impl.discovery.ModCandidate;
 import net.fabricmc.loader.impl.game.GameProvider;
-import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricStatusNode;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricStatusTab;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.log.Log;
@@ -127,7 +124,7 @@ public final class FabricGuiEntry {
 			FabricStatusTree tree = new FabricStatusTree(title, mainText);
 			FabricStatusTab crashTab = tree.addTab("Crash");
 
-			addThrowable(crashTab.node, exception, new HashSet<>());
+			crashTab.node.addCleanedException(exception);
 
 			// Maybe add an "open mods folder" button?
 			// or should that be part of the main tree's right-click menu?
@@ -158,43 +155,5 @@ public final class FabricGuiEntry {
 		if (candidate != null) return candidate.getVersion();
 
 		return null;
-	}
-
-	private static void addThrowable(FabricStatusNode node, Throwable e, Set<Throwable> seen) {
-		if (!seen.add(e)) {
-			return;
-		}
-
-		// Remove some self-repeating exception traces from the tree
-		// (for example the RuntimeException that is is created unnecessarily by ForkJoinTask)
-		Throwable cause;
-
-		while ((cause = e.getCause()) != null) {
-			if (e.getSuppressed().length > 0) {
-				break;
-			}
-
-			String msg = e.getMessage();
-
-			if (msg == null) {
-				msg = e.getClass().getName();
-			}
-
-			if (!msg.equals(cause.getMessage()) && !msg.equals(cause.toString())) {
-				break;
-			}
-
-			e = cause;
-		}
-
-		FabricStatusNode sub = node.addException(e);
-
-		if (e.getCause() != null) {
-			addThrowable(sub, e.getCause(), seen);
-		}
-
-		for (Throwable t : e.getSuppressed()) {
-			addThrowable(sub, t, seen);
-		}
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -33,6 +33,7 @@ import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.discovery.ClasspathModCandidateFinder;
 import net.fabricmc.loader.impl.discovery.ModCandidate;
 import net.fabricmc.loader.impl.game.GameProvider;
+import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricBasicButtonType;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricStatusTab;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.log.Log;
@@ -104,7 +105,7 @@ public final class FabricGuiEntry {
 		displayError(mainText, exception, tree -> {
 			StringWriter error = new StringWriter();
 			exception.printStackTrace(new PrintWriter(error));
-			tree.addButton("Copy stacktrace").makeReusable().withClipboard(error.toString());
+			tree.addButton("Copy stacktrace", FabricBasicButtonType.CLICK_MANY).withClipboard(error.toString());
 		}, exitAfter);
 	}
 
@@ -128,7 +129,7 @@ public final class FabricGuiEntry {
 
 			// Maybe add an "open mods folder" button?
 			// or should that be part of the main tree's right-click menu?
-			tree.addButton("Exit").makeClose();
+			tree.addButton("Exit", FabricBasicButtonType.CLICK_ONCE).makeClose();
 			treeCustomiser.accept(tree);
 
 			try {

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -97,6 +97,10 @@ public final class FabricGuiEntry {
 	public static void displayCriticalError(Throwable exception, boolean exitAfter) {
 		Log.error(LogCategory.GENERAL, "A critical error occurred", exception);
 
+		displayError("Failed to launch!", exception, exitAfter);
+	}
+
+	public static void displayError(String mainText, Throwable exception, boolean exitAfter) {
 		GameProvider provider = FabricLoaderImpl.INSTANCE.getGameProvider();
 
 		if (!GraphicsEnvironment.isHeadless() && (provider == null || provider.canOpenErrorGui())) {
@@ -109,7 +113,7 @@ public final class FabricGuiEntry {
 				title = "Fabric Loader " + loaderVersion.getFriendlyString();
 			}
 
-			FabricStatusTree tree = new FabricStatusTree(title, "Failed to launch!");
+			FabricStatusTree tree = new FabricStatusTree(title, mainText);
 			FabricStatusTab crashTab = tree.addTab("Crash");
 
 			addThrowable(crashTab.node, exception, new HashSet<>());

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -20,11 +20,14 @@ import java.awt.GraphicsEnvironment;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.Version;
@@ -101,6 +104,14 @@ public final class FabricGuiEntry {
 	}
 
 	public static void displayError(String mainText, Throwable exception, boolean exitAfter) {
+		displayError(mainText, exception, tree -> {
+			StringWriter error = new StringWriter();
+			exception.printStackTrace(new PrintWriter(error));
+			tree.addButton("Copy stacktrace").makeReusable().withClipboard(error.toString());
+		}, exitAfter);
+	}
+
+	public static void displayError(String mainText, Throwable exception, Consumer<FabricStatusTree> treeCustomiser, boolean exitAfter) {
 		GameProvider provider = FabricLoaderImpl.INSTANCE.getGameProvider();
 
 		if (!GraphicsEnvironment.isHeadless() && (provider == null || provider.canOpenErrorGui())) {
@@ -121,6 +132,7 @@ public final class FabricGuiEntry {
 			// Maybe add an "open mods folder" button?
 			// or should that be part of the main tree's right-click menu?
 			tree.addButton("Exit").makeClose();
+			treeCustomiser.accept(tree);
 
 			try {
 				open(tree);

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
@@ -201,7 +201,7 @@ class FabricMainWindow {
 
 			CustomTreeNode node = ((CustomTreeNode) tree.getPathForRow(row).getLastPathComponent());
 
-			if (node.node.expandByDefault || node.node.getMaximumWarningLevel().isAtLeast(FabricTreeWarningLevel.WARN)) {
+			if (node.node.expandByDefault) {
 				tree.expandRow(row);
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
@@ -64,6 +64,7 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 
+import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricBasicButtonType;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricStatusButton;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricStatusNode;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricStatusTab;
@@ -157,7 +158,7 @@ class FabricMainWindow {
 				JButton btn = new JButton(button.text);
 				buttons.add(btn);
 				btn.addActionListener(event -> {
-					if (!button.isReusable) btn.setEnabled(false);
+					if (button.type == FabricBasicButtonType.CLICK_ONCE) btn.setEnabled(false);
 
 					if (button.clipboard != null) {
 						try {

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
@@ -26,6 +26,8 @@ import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.awt.Image;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
@@ -154,8 +156,17 @@ class FabricMainWindow {
 			for (FabricStatusButton button : tree.buttons) {
 				JButton btn = new JButton(button.text);
 				buttons.add(btn);
-				btn.addActionListener(e -> {
-					btn.setEnabled(false);
+				btn.addActionListener(event -> {
+					if (!button.isReusable) btn.setEnabled(false);
+
+					if (button.clipboard != null) {
+						try {
+							StringSelection clipboard = new StringSelection(button.clipboard);
+							Toolkit.getDefaultToolkit().getSystemClipboard().setContents(clipboard, clipboard);
+						} catch (IllegalStateException e) {
+							//Clipboard unavailable?
+						}
+					}
 
 					if (button.shouldClose) {
 						window.dispose();

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricMainWindow.java
@@ -193,6 +193,7 @@ class FabricMainWindow {
 		DefaultTreeModel model = new DefaultTreeModel(treeNode);
 		JTree tree = new JTree(model);
 		tree.setRootVisible(false);
+		tree.setRowHeight(0); // Allow rows to be multiple lines tall
 
 		for (int row = 0; row < tree.getRowCount(); row++) {
 			if (!tree.isVisible(tree.getPathForRow(row))) {
@@ -415,6 +416,7 @@ class FabricMainWindow {
 
 		private CustomTreeCellRenderer(IconSet icons) {
 			this.iconSet = icons;
+			//setVerticalTextPosition(TOP); // Move icons to top rather than centre
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
@@ -291,6 +291,7 @@ public final class FabricStatusTree {
 				}
 
 				this.warningLevel = level;
+				expandByDefault |= level.isAtLeast(FabricTreeWarningLevel.WARN);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
@@ -56,7 +56,7 @@ public final class FabricStatusTree {
 	public enum FabricBasicButtonType {
 		/** Sends the status message to the main application, then disables itself. */
 		CLICK_ONCE,
-		/** Sends the status message to the main application, remains enabled */
+		/** Sends the status message to the main application, remains enabled. */
 		CLICK_MANY;
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
@@ -137,7 +137,8 @@ public final class FabricStatusTree {
 
 	public static final class FabricStatusButton {
 		public final String text;
-		public boolean shouldClose, shouldContinue;
+		public String clipboard;
+		public boolean shouldClose, shouldContinue, isReusable;
 
 		public FabricStatusButton(String text) {
 			Objects.requireNonNull(text, "null text");
@@ -149,12 +150,23 @@ public final class FabricStatusTree {
 			text = is.readUTF();
 			shouldClose = is.readBoolean();
 			shouldContinue = is.readBoolean();
+			isReusable = is.readBoolean();
+
+			if (is.readBoolean()) clipboard = is.readUTF();
 		}
 
 		public void writeTo(DataOutputStream os) throws IOException {
 			os.writeUTF(text);
 			os.writeBoolean(shouldClose);
 			os.writeBoolean(shouldContinue);
+			os.writeBoolean(isReusable);
+
+			if (clipboard != null) {
+				os.writeBoolean(true);
+				os.writeUTF(clipboard);
+			} else {
+				os.writeBoolean(false);
+			}
 		}
 
 		public FabricStatusButton makeClose() {
@@ -164,6 +176,16 @@ public final class FabricStatusTree {
 
 		public FabricStatusButton makeContinue() {
 			this.shouldContinue = true;
+			return this;
+		}
+
+		public FabricStatusButton makeReusable() {
+			isReusable = true;
+			return this;
+		}
+
+		public FabricStatusButton withClipboard(String clipboard) {
+			this.clipboard = clipboard;
 			return this;
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.function.UnaryOperator;
 
 public final class FabricStatusTree {
@@ -411,15 +412,18 @@ public final class FabricStatusTree {
 				uniqueFrames--;
 			}
 
-			for (int i = 0; i <= uniqueFrames; i++) {
-				sub.addChild("at " + trace[i]).iconType = ICON_TYPE_JAVA_CLASS;
-			}
-
+			StringJoiner frames = new StringJoiner("<br/>", "<html>", "</html>");
 			int inheritedFrames = trace.length - 1 - uniqueFrames;
 
-			if (inheritedFrames > 0) {
-				sub.addChild("... " + inheritedFrames + " more").iconType = ICON_TYPE_JAVA_CLASS;
+			for (int i = 0; i <= uniqueFrames; i++) {
+				frames.add("at " + trace[i]);
 			}
+
+			if (inheritedFrames > 0) {
+				frames.add("... " + inheritedFrames + " more");
+			}
+
+			sub.addChild(frames.toString()).iconType = ICON_TYPE_JAVA_CLASS;
 
 			StringWriter sw = new StringWriter();
 			exception.printStackTrace(new PrintWriter(sw));

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
@@ -55,7 +55,9 @@ public final class FabricStatusTree {
 
 	public enum FabricBasicButtonType {
 		/** Sends the status message to the main application, then disables itself. */
-		CLICK_ONCE;
+		CLICK_ONCE,
+		/** Sends the status message to the main application, remains enabled */
+		CLICK_MANY;
 	}
 
 	/** No icon is displayed. */
@@ -134,37 +136,39 @@ public final class FabricStatusTree {
 		return tab;
 	}
 
-	public FabricStatusButton addButton(String text) {
-		FabricStatusButton button = new FabricStatusButton(text);
+	public FabricStatusButton addButton(String text, FabricBasicButtonType type) {
+		FabricStatusButton button = new FabricStatusButton(text, type);
 		buttons.add(button);
 		return button;
 	}
 
 	public static final class FabricStatusButton {
 		public final String text;
+		public final FabricBasicButtonType type;
 		public String clipboard;
-		public boolean shouldClose, shouldContinue, isReusable;
+		public boolean shouldClose, shouldContinue;
 
-		public FabricStatusButton(String text) {
+		public FabricStatusButton(String text, FabricBasicButtonType type) {
 			Objects.requireNonNull(text, "null text");
 
 			this.text = text;
+			this.type = type;
 		}
 
 		public FabricStatusButton(DataInputStream is) throws IOException {
 			text = is.readUTF();
+			type = FabricBasicButtonType.valueOf(is.readUTF());
 			shouldClose = is.readBoolean();
 			shouldContinue = is.readBoolean();
-			isReusable = is.readBoolean();
 
 			if (is.readBoolean()) clipboard = is.readUTF();
 		}
 
 		public void writeTo(DataOutputStream os) throws IOException {
 			os.writeUTF(text);
+			os.writeUTF(type.name());
 			os.writeBoolean(shouldClose);
 			os.writeBoolean(shouldContinue);
-			os.writeBoolean(isReusable);
 
 			if (clipboard != null) {
 				os.writeBoolean(true);
@@ -181,11 +185,6 @@ public final class FabricStatusTree {
 
 		public FabricStatusButton makeContinue() {
 			this.shouldContinue = true;
-			return this;
-		}
-
-		public FabricStatusButton makeReusable() {
-			isReusable = true;
 			return this;
 		}
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -44,6 +44,7 @@ import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.entrypoint.EntrypointUtils;
 import net.fabricmc.loader.impl.game.GameProvider;
+import net.fabricmc.loader.impl.gui.FabricGuiEntry;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.FabricMixinBootstrap;
 import net.fabricmc.loader.impl.util.SystemProperties;
@@ -136,7 +137,12 @@ public final class Knot extends FabricLauncherBase {
 
 		classLoader.getDelegate().initializeTransformers();
 
-		EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
+		try {
+			EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
+		} catch (RuntimeException e) {
+			FabricGuiEntry.displayError("Failed preparing to start", e, false);
+			throw e;
+		}
 
 		return cl;
 	}

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -44,7 +44,6 @@ import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.entrypoint.EntrypointUtils;
 import net.fabricmc.loader.impl.game.GameProvider;
-import net.fabricmc.loader.impl.gui.FabricGuiEntry;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.FabricMixinBootstrap;
 import net.fabricmc.loader.impl.util.SystemProperties;
@@ -140,8 +139,9 @@ public final class Knot extends FabricLauncherBase {
 		try {
 			EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
 		} catch (RuntimeException e) {
-			FabricGuiEntry.displayError("Failed preparing to start", e, false);
-			throw e;
+			if (!provider.onCrash(e, "A mod crashed on startup")) {
+				throw e;
+			}
 		}
 
 		return cl;


### PR DESCRIPTION
Minecraft doesn't set up crash handling immediately; so for pre-launch entrypoints or Mixins to early loaded classes, exceptions will not produce crash reports. This can cause launchers (especially the vanilla one) to unhelpfully just report the game closing with an error code and nothing else. The crash will be in the logs, but this isn't always immediately obvious for a user to go check.

This PR recycles the dependency error/warning screen to show these early crashes visibly to the user so they at least have something to immediately report beyond just it closes upon start. The existing code only prints the messages for each `Throwable` so there's a copy stacktrace button to easily allow getting all the information there is.

![crash](https://user-images.githubusercontent.com/4021725/130338718-9a73def1-bfab-42ec-8622-f78b4d64e2fc.PNG)
