### PR TITLE
Implement on-mixin entrypoints.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/entrypoint/MixinLoadingEntrypoint.java
+++ b/src/main/java/net/fabricmc/loader/impl/entrypoint/MixinLoadingEntrypoint.java
@@ -1,0 +1,6 @@
+package net.fabricmc.loader.impl.entrypoint;
+
+@FunctionalInterface
+public interface MixinLoadingEntrypoint {
+	void onMixinLoading();
+}

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -38,6 +38,8 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import net.fabricmc.loader.impl.entrypoint.MixinLoadingEntrypoint;
+
 import org.spongepowered.asm.launch.MixinBootstrap;
 
 import net.fabricmc.api.EnvType;
@@ -128,8 +130,10 @@ public final class Knot extends FabricLauncherBase {
 		loader.setGameProvider(provider);
 		loader.load();
 		loader.freeze();
+		loader.loadAccessWideners();
 
-		FabricLoaderImpl.INSTANCE.loadAccessWideners();
+		// Some mods has any API required for mixins. But they most-likely load it remotely, since its unused in any other place.
+		EntrypointUtils.invoke("onMixinLoading", MixinLoadingEntrypoint.class, MixinLoadingEntrypoint::onMixinLoading);
 
 		MixinBootstrap.init();
 		FabricMixinBootstrap.init(getEnvironmentType(), loader);


### PR DESCRIPTION
**Why**
There are many reasons. Some mods would like to load mixin-related API, which is unused in any other classes except mixins,
so they would like to load them remotely.

There are some mods that would like to create like a beta version with auto-update, and they need to load the classes remotely.

If someone will also wanna say something, you are allowed :D

**Ask any questions, I'll answer.**