### PR TITLE
Version specific mods folder.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -190,8 +190,11 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		boolean remapRegularMods = isDevelopmentEnvironment();
 		ModDiscoverer discoverer = new ModDiscoverer();
 		discoverer.addCandidateFinder(new ClasspathModCandidateFinder());
-		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(gameDir.resolve("mods"), remapRegularMods));
 		discoverer.addCandidateFinder(new ArgumentModCandidateFinder(remapRegularMods));
+
+		Path modsFolder = gameDir.resolve("mods");
+		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(modsFolder, remapRegularMods, true));
+		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(modsFolder.resolve(getGameProvider().getNormalizedGameVersion()), remapRegularMods, false));
 
 		modCandidates = discoverer.discoverMods(this);
 		modCandidates = ModResolver.resolve(modCandidates);

--- a/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
@@ -31,15 +31,21 @@ import net.fabricmc.loader.impl.util.log.LogCategory;
 public class DirectoryModCandidateFinder implements ModCandidateFinder {
 	private final Path path;
 	private final boolean requiresRemap;
+	private final boolean shouldCreateFolder;
 
 	public DirectoryModCandidateFinder(Path path, boolean requiresRemap) {
+		this(path, requiresRemap, true);
+	}
+
+	public DirectoryModCandidateFinder(Path path, boolean requiresRemap, boolean shouldCreateFolder) {
 		this.path = path;
 		this.requiresRemap = requiresRemap;
+		this.shouldCreateFolder = shouldCreateFolder;
 	}
 
 	@Override
 	public void findCandidates(ModCandidateConsumer out) {
-		if (!Files.exists(path)) {
+		if (shouldCreateFolder && !Files.exists(path)) {
 			try {
 				Files.createDirectory(path);
 			} catch (IOException e) {

--- a/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
@@ -53,6 +53,11 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 			}
 		}
 
+		// If the folder does not exist at this point it shouldn't be searched for mods
+		if (!Files.exists(path)) {
+			return;
+		}
+
 		if (!Files.isDirectory(path)) {
 			throw new RuntimeException(path + " is not a directory!");
 		}


### PR DESCRIPTION
I would like to have support for version specific mods subfolders inside the main mods folder.

E.g. a Folder "1.17.1" inside the mods folder with mods that are only loaded when a fabric 1.17.1 client is started.