### PR TITLE
Fix MC version typo

### DIFF
--- a/src/main/java/net/fabricmc/loader/minecraft/McVersionLookup.java
+++ b/src/main/java/net/fabricmc/loader/minecraft/McVersionLookup.java
@@ -211,7 +211,7 @@ public final class McVersionLookup {
 
 			if (name != null && release != null) {
 				builder.setName(name);
-				builder.setName(release);
+				builder.setRelease(release);
 
 				return true;
 			}


### PR DESCRIPTION
This has been broken since 0.11.4 but will only make a difference for pre-releases and release candidates