### PR TITLE
Add a method for mod dependent mixins

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/BuiltinMetadataWrapper.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.api.metadata.CustomValue;
@@ -138,7 +139,7 @@ class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMet
 	}
 
 	@Override
-	public Collection<String> getMixinConfigs(EnvType type) {
+	public Collection<String> getMixinConfigs(EnvType type, FabricLoader loader) {
 		return Collections.emptyList();
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricMixinBootstrap.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricMixinBootstrap.java
@@ -80,7 +80,7 @@ public final class FabricMixinBootstrap {
 		Map<String, ModContainerImpl> configToModMap = new HashMap<>();
 
 		for (ModContainerImpl mod : loader.getModsInternal()) {
-			for (String config : mod.getMetadata().getMixinConfigs(side)) {
+			for (String config : mod.getMetadata().getMixinConfigs(side, loader)) {
 				ModContainerImpl prev = configToModMap.putIfAbsent(config, mod);
 				if (prev != null) throw new RuntimeException(String.format("Non-unique mixin config name %s used by %s and %s", config, prev.getMetadata().getId(), mod.getMetadata().getId()));
 

--- a/src/main/java/net/fabricmc/loader/impl/metadata/LoaderModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/LoaderModMetadata.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
 
 /**
  * Internal variant of the ModMetadata interface.
@@ -35,7 +36,7 @@ public interface LoaderModMetadata extends net.fabricmc.loader.metadata.LoaderMo
 
 	Map<String, String> getLanguageAdapterDefinitions();
 	Collection<NestedJarEntry> getJars();
-	Collection<String> getMixinConfigs(EnvType type);
+	Collection<String> getMixinConfigs(EnvType type, FabricLoader loader);
 	/* @Nullable */
 	String getAccessWidener();
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/metadata/V0ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/V0ModMetadata.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.api.metadata.CustomValue;
@@ -221,7 +222,7 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	public void emitFormatWarnings() { }
 
 	@Override
-	public Collection<String> getMixinConfigs(EnvType type) {
+	public Collection<String> getMixinConfigs(EnvType type, FabricLoader loader) {
 		List<String> mixinConfigs = new ArrayList<>(this.mixins.common);
 
 		switch (type) {


### PR DESCRIPTION
Related to #68

Just an idea to save people needing mixin plugins for mixins that depend on other mods in a way that doesn't need changes within Mixin itself. Not the prettiest passing `FabricLoader` in, but it was the best I could come up with (given it's an internal interface anyway). Did consider allowing full dependency ranges rather than just "is the mod present" but didn't want to over invest time in something that might not be what we want anyway.