### PR TITLE
Fix incorrect template in V1ModMetadata's 'requires' warning

### DIFF
--- a/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/metadata/V1ModMetadata.java
@@ -289,7 +289,7 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	@Override
 	public void emitFormatWarnings(Logger logger) {
 		if (!this.requires.isEmpty()) {
-			logger.warn("Mod `{}` ({}) uses 'requires' key in fabric.mod.json, which is not supported - use 'depends'", this.id, this.version);
+			logger.warn("Mod `%s` (%s) uses 'requires' key in fabric.mod.json, which is not supported - use 'depends'", this.id, this.version);
 		}
 	}
 


### PR DESCRIPTION
This is a backported fix from 0.12, but since 0.11 is still widely used, it might be good to have this in there as well.