### PR TITLE
Try normalize special Minecraft versions

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
@@ -339,7 +339,8 @@ public final class McVersionLookup {
 	 */
 	protected static String normalizeVersion(String name, String release) {
 		if (release == null || name.equals(release)) {
-			return normalizeVersion(name);
+			String ret = normalizeSpecialVersion(name);
+			return ret != null ? ret : normalizeVersion(name);
 		}
 
 		Matcher matcher;
@@ -375,11 +376,18 @@ public final class McVersionLookup {
 					} else {
 						name = String.format("beta.%s", matcher.group(1));
 					}
+				} else {
+					String ret = normalizeSpecialVersion(name);
+					if (ret != null) return ret;
 				}
 			}
 		} else if ((matcher = SNAPSHOT_PATTERN.matcher(name)).matches()) {
 			name = String.format("alpha.%s.%s.%s", matcher.group(1), matcher.group(2), matcher.group(3));
 		} else {
+			// Try short-circuiting special versions which are complete on their own
+			String ret = normalizeSpecialVersion(name);
+			if (ret != null) return ret;
+
 			name = normalizeVersion(name);
 		}
 
@@ -453,6 +461,91 @@ public final class McVersionLookup {
 		while (end > start && ret.charAt(end - 1) == '.') end--;
 
 		return ret.substring(start, end);
+	}
+
+	private static String normalizeSpecialVersion(String version ) {
+		switch (version) {
+		case "13w12~":
+			// A pair of debug snapshots immediately before 1.5.1-pre
+			return "1.5.1-alpha.13.12.~";
+
+		case "15w14a":
+			// The Love and Hugs Update, forked from 1.8.3
+			return "1.8.4-alpha.1";
+
+		case "1.RV-Pre1":
+			// The Trendy Update, probably forked from 1.9.2 (although the protocol/data versions immediately follow 1.9.1-pre3)
+			return "1.9.2-alpha.1";
+
+		case "3D Shareware v1.34":
+			// Minecraft 3D, forked from 19w13b
+			return "1.14-alpha.19.13.shareware";
+
+		case "20w14~":
+			// The Ultimate Content update, forked from 20w13b
+			return "1.16-alpha.20.13.inf"; // Not to be confused with the actual 20w14a
+
+		case "1.14.3 - Combat Test":
+			// The first Combat Test, forked from 1.14.3 Pre-Release 4
+			return "1.14.3-rc.5";
+
+		case "Combat Test 2":
+			// The second Combat Test, forked from 1.14.4
+			return "1.14.5-alpha.1";
+
+		case "Combat Test 3":
+			// The third Combat Test, forked from 1.14.4
+			return "1.14.5-alpha.2";
+
+		case "Combat Test 4":
+			// The fourth Combat Test, forked from 1.15 Pre-release 3
+			return "1.15-rc.3.9"; // Not to be confused with 1.15 Pre-release 4
+
+		case "Combat Test 5":
+			// The fifth Combat Test, forked from 1.15.2 Pre-release 2
+			return "1.15.2-rc.3";
+
+		case "Combat Test 6":
+			// The sixth Combat Test, forked from 1.16.2 Pre-release 3
+			return "1.16.2-beta.4";
+
+		case "Combat Test 7":
+			// Private testing Combat Test 7, forked from 1.16.2
+			return "1.16.3-alpha.1";
+
+		case "1.16_combat-2":
+			// Private testing Combat Test 7b, forked from 1.16.2
+			return "1.16.3-alpha.2";
+
+		case "1.16_combat-3":
+			// The seventh Combat Test 7c, forked from 1.16.2
+			return "1.16.3-alpha.3";
+
+		case "1.16_combat-4":
+			// Private testing Combat Test 8(a?), forked from 1.16.2
+			return "1.16.3-alpha.4";
+
+		case "1.16_combat-5":
+			// The eighth Combat Test 8b, forked from 1.16.2
+			return "1.16.3-alpha.5";
+
+		case "1.16_combat-6":
+			// The ninth Combat Test 8c, forked from 1.16.2
+			return "1.16.3-alpha.6";
+
+		case "1.18 Experimental Snapshot 1":
+		case "1.18 experimental snapshot 2":
+		case "1.18 experimental snapshot 3":
+		case "1.18 experimental snapshot 4":
+		case "1.18 experimental snapshot 5":
+		case "1.18 experimental snapshot 6":
+		case "1.18 experimental snapshot 7":
+			// Pre-snapshot snapshots for 1.18 before the first (21w37a)
+			return "1.18-alpha.".concat(version.substring(27));
+
+		default:
+			return null; //Don't recognise the version
+		}
 	}
 
 	private interface Analyzer {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
@@ -467,15 +467,15 @@ public final class McVersionLookup {
 		switch (version) {
 		case "13w12~":
 			// A pair of debug snapshots immediately before 1.5.1-pre
-			return "1.5.1-alpha.13.12.~";
+			return "1.5.1-alpha.13.12.a";
 
 		case "15w14a":
 			// The Love and Hugs Update, forked from 1.8.3
-			return "1.8.4-alpha.1";
+			return "1.8.4-alpha.15.14.a+loveandhugs";
 
 		case "1.RV-Pre1":
 			// The Trendy Update, probably forked from 1.9.2 (although the protocol/data versions immediately follow 1.9.1-pre3)
-			return "1.9.2-alpha.1";
+			return "1.9.2-rv+trendy";
 
 		case "3D Shareware v1.34":
 			// Minecraft 3D, forked from 19w13b
@@ -487,51 +487,51 @@ public final class McVersionLookup {
 
 		case "1.14.3 - Combat Test":
 			// The first Combat Test, forked from 1.14.3 Pre-Release 4
-			return "1.14.3-rc.5";
+			return "1.14.3-rc.4.combat.1";
 
 		case "Combat Test 2":
 			// The second Combat Test, forked from 1.14.4
-			return "1.14.5-alpha.1";
+			return "1.14.5-combat.2";
 
 		case "Combat Test 3":
 			// The third Combat Test, forked from 1.14.4
-			return "1.14.5-alpha.2";
+			return "1.14.5-combat.3";
 
 		case "Combat Test 4":
 			// The fourth Combat Test, forked from 1.15 Pre-release 3
-			return "1.15-rc.3.9"; // Not to be confused with 1.15 Pre-release 4
+			return "1.15-rc.3.combat.4";
 
 		case "Combat Test 5":
 			// The fifth Combat Test, forked from 1.15.2 Pre-release 2
-			return "1.15.2-rc.3";
+			return "1.15.2-rc.2.combat.5";
 
 		case "Combat Test 6":
 			// The sixth Combat Test, forked from 1.16.2 Pre-release 3
-			return "1.16.2-beta.4";
+			return "1.16.2-beta.3.combat.6";
 
 		case "Combat Test 7":
 			// Private testing Combat Test 7, forked from 1.16.2
-			return "1.16.3-alpha.1";
+			return "1.16.3-combat.7";
 
 		case "1.16_combat-2":
 			// Private testing Combat Test 7b, forked from 1.16.2
-			return "1.16.3-alpha.2";
+			return "1.16.3-combat.7.b";
 
 		case "1.16_combat-3":
 			// The seventh Combat Test 7c, forked from 1.16.2
-			return "1.16.3-alpha.3";
+			return "1.16.3-combat.7.c";
 
 		case "1.16_combat-4":
 			// Private testing Combat Test 8(a?), forked from 1.16.2
-			return "1.16.3-alpha.4";
+			return "1.16.3-combat.8";
 
 		case "1.16_combat-5":
 			// The eighth Combat Test 8b, forked from 1.16.2
-			return "1.16.3-alpha.5";
+			return "1.16.3-combat.8.b";
 
 		case "1.16_combat-6":
 			// The ninth Combat Test 8c, forked from 1.16.2
-			return "1.16.3-alpha.6";
+			return "1.16.3-combat.8.c";
 
 		case "1.18 Experimental Snapshot 1":
 		case "1.18 experimental snapshot 2":
@@ -541,7 +541,8 @@ public final class McVersionLookup {
 		case "1.18 experimental snapshot 6":
 		case "1.18 experimental snapshot 7":
 			// Pre-snapshot snapshots for 1.18 before the first (21w37a)
-			return "1.18-alpha.".concat(version.substring(27));
+			// Characters are compared lexically, so E(xperimental) < a(lpha)
+			return "1.18-Experimental.".concat(version.substring(27));
 
 		default:
 			return null; //Don't recognise the version

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
@@ -463,7 +463,7 @@ public final class McVersionLookup {
 		return ret.substring(start, end);
 	}
 
-	private static String normalizeSpecialVersion(String version ) {
+	private static String normalizeSpecialVersion(String version) {
 		switch (version) {
 		case "13w12~":
 			// A pair of debug snapshots immediately before 1.5.1-pre


### PR DESCRIPTION
Aims to build from what #517 (re-)broke. I made up versions to work within the constraints of what already exists (and sem ver): mainly the second combat snapshot inventing 1.14.5 (to be after 1.14.4 but the protocol/data versions suggest it is not a 1.15 snapshot), the fourth combat snapshot sitting between `1.15-rc.3` and `1.15-rc.4` (which both exist), and 20w14∞ sitting between `1.16-alpha.20.13.b` and `1.16-alpha.20.14.a`. Quite open to other ideas handling the edge cases in general.

| JSON ID | `version.info` | Normalized |
| --- | --- | --- |
| 1.14_combat-212796 | 1.14.3 - Combat Test | 1.14.3-rc.4.combat.1 |
| 1.14_combat-0 | Combat Test 2 | 1.14.5-combat.2 |
| 1.14_combat-3 | Combat Test 3 | 1.14.5-combat.3 |
| 1.15_combat-1 | Combat Test 4 | 1.15-rc.3.combat.4 |
| 1.15_combat-6 | Combat Test 5 | 1.15.2-rc.2.combat.5 |
| 1.16_combat-0 | Combat Test 6 | 1.16.2-beta.3.combat.6 |
| 1.16_combat-1 | Combat Test 7 | 1.16.3-combat.7 |
| 1.16_combat-2 | 1.16_combat-2 | 1.16.3-combat.7.b |
| 1.16_combat-3 | 1.16_combat-3 | 1.16.3-combat.7.c |
| 1.16_combat-5 | 1.16_combat-5 | 1.16.3-combat.8.b |
| 1.16_combat-6 | 1.16_combat-6 | 1.16.3-combat.8.c |
| 1.18_experimental-snapshot-1 | 1.18 Experimental Snapshot 1 | 1.18-Experimental.1 |
| 1.18_experimental-snapshot-2 | 1.18 experimental snapshot 2 | 1.18-Experimental.2 |
| 1.18_experimental-snapshot-3 | 1.18 experimental snapshot 3 | 1.18-Experimental.3 |
| 1.18_experimental-snapshot-4 | 1.18 experimental snapshot 4 | 1.18-Experimental.4 |
| 1.18_experimental-snapshot-5 | 1.18 experimental snapshot 5 | 1.18-Experimental.5 |
| 1.18_experimental-snapshot-6 | 1.18 experimental snapshot 6 | 1.18-Experimental.6 |
| 1.18_experimental-snapshot-7 | 1.18 experimental snapshot 7 | 1.18-Experimental.7 |
| 1.RV-Pre1 | *N/A* | 1.9.2-rv+trendy |
| 13w12~ | *N/A* | 1.5.1-alpha.13.12.a |
| 15w14a | *N/A* | 1.8.4-alpha.15.14.a+loveandhugs |
| 20w14∞ | 20w14~ | 1.16-alpha.20.13.inf |
| 3D Shareware v1.34 | 3D Shareware v1.34 | 1.14-alpha.19.13.shareware |