### PR TITLE
Improve handling of env-disabled dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-version = 0.12.0
+version = 0.12.1
 asm_version = 9.2

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -194,7 +194,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		discoverer.addCandidateFinder(new ArgumentModCandidateFinder(remapRegularMods));
 
 		modCandidates = discoverer.discoverMods(this);
-		modCandidates = ModResolver.resolve(modCandidates);
+		modCandidates = ModResolver.resolve(modCandidates, getEnvironmentType());
 
 		String modListText = modCandidates.stream()
 				.map(candidate -> String.format("\t- %s %s", candidate.getId(), candidate.getVersion().getFriendlyString()))

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
@@ -212,10 +212,6 @@ public final class ModDiscoverer {
 				metadata = ModMetadataParser.parseMetadata(is, localPath, parentPaths);
 			}
 
-			if (!metadata.loadsInEnvironment(envType)) {
-				return null;
-			}
-
 			return ModCandidate.createPlain(path, metadata, requiresRemap, Collections.emptyList());
 		}
 
@@ -231,7 +227,7 @@ public final class ModDiscoverer {
 				}
 
 				if (!metadata.loadsInEnvironment(envType)) {
-					return null;
+					return ModCandidate.createPlain(path, metadata, requiresRemap, Collections.emptyList());
 				}
 
 				List<ModScanTask> nestedModTasks;
@@ -304,7 +300,7 @@ public final class ModDiscoverer {
 			if (metadata == null) return null;
 
 			if (!metadata.loadsInEnvironment(envType)) {
-				return null;
+				return ModCandidate.createNested(localPath, hash, metadata, requiresRemap, Collections.emptyList());
 			}
 
 			Collection<NestedJarEntry> nestedJars = metadata.getJars();

--- a/src/main/java/net/fabricmc/loader/impl/metadata/ModDependencyImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/ModDependencyImpl.java
@@ -27,7 +27,7 @@ import net.fabricmc.loader.api.metadata.version.VersionInterval;
 import net.fabricmc.loader.api.metadata.version.VersionPredicate;
 
 public final class ModDependencyImpl implements ModDependency {
-	private final Kind kind;
+	private Kind kind;
 	private final String modId;
 	private final List<String> matcherStringList;
 	private final Collection<VersionPredicate> ranges;
@@ -42,6 +42,10 @@ public final class ModDependencyImpl implements ModDependency {
 	@Override
 	public Kind getKind() {
 		return kind;
+	}
+
+	public void setKind(Kind kind) {
+		this.kind = kind;
 	}
 
 	@Override

--- a/src/main/resources/net/fabricmc/loader/Messages.properties
+++ b/src/main/resources/net/fabricmc/loader/Messages.properties
@@ -1,13 +1,19 @@
 # translation keys used by Fabric Loader
 # comments starting with # describe entries, those with ## describe the available arguments
 
+environment.client=client
+environment.server=dedicated server
+
 # mod resolution errors
 
 resolution.solutionHeader=A potential solution has been determined:
 resolution.depListHeader=Unmet dependency listing:
+resolution.inactiveMods=Inactive mods:
 
 ## mod version
 resolution.solution.addMod=Install {0} {1} (later versions might work too).
+## mod version env
+resolution.solution.addModEnvDisabled=Install a version of {0} (potentially {1} or later) that can load in the current environment ({2}) or update/remove the mods depending on it. This happens because a mod wants to load in a {2} environment but depends on another mod that doesn''t load in the {2} environment.
 ## mod version path
 resolution.solution.removeMod=Remove {0} {1} ({2}).
 ## oldMods newMod newVersion
@@ -19,26 +25,46 @@ resolution.solution.replaceMod.oldModNoPath={0} {1}
 
 ## mod dep depVersionRange presentVersions presentVersionCount
 
+resolution.depends.envDisabled={0} requires {2} of {1}, which is disabled for this environment (client/server only)!
 resolution.depends.missing={0} requires {2} of {1}, which is missing!
 resolution.depends.invalid={0} requires {2} of {1}, but only the wrong version{4, choice, 1# is|2#s are} present: {3}!
 resolution.depends.suggestion=You need to install {2} of {1}.
 
+resolution.recommends.envDisabled={0} recommends {2} of {1}, which is disabled for this environment (client/server only)!
 resolution.recommends.missing={0} recommends {2} of {1}, which is missing!
 resolution.recommends.invalid={0} recommends {2} of {1}, but only the wrong version{4, choice, 1# is|2#s are} present: {3}!
 resolution.recommends.suggestion=You should install {2} of {1} for the optimal experience.
 
 resolution.breaks.invalid={0} is incompatible with {2} of {1}, but{4, choice, 1# a|2#} matching version{4, choice, 1# is|2#s are} present: {3}!
-resolution.breaks.suggestion=The developer(s) of {0} have found that this combination doesn't work. You need to remove one of the mods or check for updates that resolve the issue.
+resolution.breaks.suggestion=The developer(s) of {0} have found that this combination doesn''t work. You need to remove one of the mods or check for updates that resolve the issue.
 
 resolution.conflicts.invalid={0} conflicts with {2} of {1}, which is present with the following version{4, choice, 2#s}: {3}!
-resolution.conflicts.suggestion=While this won't prevent you from starting the game, the developer(s) of {0} have found that this combination may cause issues. You should remove one of the mods or check for updates that resolve the issue.
+resolution.conflicts.suggestion=While this won''t prevent you from starting the game, the developer(s) of {0} have found that this combination may cause issues. You should remove one of the mods or check for updates that resolve the issue.
 
 ## mod version
-resolution.jij.builtin={0} {1} is an environment reference and usually requires installation or launcher changes to adjust.
-## mod version
-resolution.jij.root={0} {1} is being loaded from the mods directory or supplied through the command line.
+resolution.jij.builtin={0} {1} is an environment reference and usually requires installation or launcher changes to adjust
+## (no args)
+resolution.jij.builtinNoMention=environment reference, usually requires installation or launcher changes to adjust
 ## mod version path
-resolution.jij.normal={0} {1} is being provided through e.g. {2}.
+resolution.jij.root={0} {1} is being loaded from {2}
+## path
+resolution.jij.rootNoMention=loaded from {0}
+## mod version path
+resolution.jij.normal={0} {1} is being provided through e.g. {2}
+## path
+resolution.jij.normalNoMention=provided through e.g. {0}
+
+## mod version reason
+resolution.inactive={0} {1}, reason: {2}
+## (no args)
+resolution.inactive.inactive_parent=inactive parent mod (nested jar)
+resolution.inactive.incompatible=incompatible
+resolution.inactive.newer_active=newer version active
+resolution.inactive.same_active=same version active
+resolution.inactive.to_remove=to remove
+resolution.inactive.to_replace=to replace
+resolution.inactive.unknown=unknown
+resolution.inactive.wrong_environment=wrong environment (client/server only)
 
 resolution.type.mod=mod
 


### PR DESCRIPTION
The first commit improves the information given to the user, the 2nd commit adds a workaround that emulates old Loader behavior for old schema versions.