### PR TITLE
Handle uncaught exceptions by logging them and displaying the error gui, refactor error gui invocation

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -41,13 +41,13 @@ import net.fabricmc.loader.api.ObjectShare;
 import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
+import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.game.GameProviderHelper;
 import net.fabricmc.loader.impl.game.minecraft.patch.BrandingPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatchFML125;
 import net.fabricmc.loader.impl.game.patch.GameTransformer;
-import net.fabricmc.loader.impl.gui.FabricGuiEntry;
 import net.fabricmc.loader.impl.launch.FabricLauncher;
 import net.fabricmc.loader.impl.metadata.BuiltinModMetadata;
 import net.fabricmc.loader.impl.metadata.ModDependencyImpl;
@@ -567,19 +567,9 @@ public class MinecraftGameProvider implements GameProvider {
 			Method m = c.getMethod("main", String[].class);
 			m.invoke(null, (Object) arguments.toArray());
 		} catch (InvocationTargetException e) {
-			if (!onCrash(e.getCause(), "Minecraft has crashed!")) {
-				throw new RuntimeException("Minecraft has crashed", e.getCause()); // Pass it on
-			}
+			throw new FormattedException("Minecraft has crashed!", e.getCause());
 		} catch (ReflectiveOperationException e) {
-			if (!onCrash(e, "Failed to start Minecraft!")) {
-				throw new RuntimeException("Failed to start Minecraft", e);
-			}
+			throw new FormattedException("Failed to start Minecraft", e);
 		}
-	}
-
-	@Override
-	public boolean onCrash(Throwable exception, String context) {
-		FabricGuiEntry.displayError(context, exception, false);
-		return false; // Allow the crash to propagate
 	}
 }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -45,6 +45,7 @@ import net.minecraft.launchwrapper.LaunchClassLoader;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
+import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.entrypoint.EntrypointUtils;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider;
@@ -109,6 +110,16 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.ClientModInitializer");
 		launchClassLoader.addClassLoaderExclusion("net.fabricmc.api.DedicatedServerModInitializer");
 
+		try {
+			init();
+		} catch (FormattedException e) {
+			handleFormattedException(e);
+		}
+	}
+
+	private void init() {
+		setupUncaughtExceptionHandler();
+
 		GameProvider provider = new MinecraftGameProvider();
 
 		if (!provider.isEnabled()
@@ -138,9 +149,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		try {
 			EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
 		} catch (RuntimeException e) {
-			if (!provider.onCrash(e, "A mod crashed on startup")) {
-				throw e;
-			}
+			throw new FormattedException("A mod crashed on startup!", e);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -54,7 +54,6 @@ import net.fabricmc.loader.impl.discovery.ModResolver;
 import net.fabricmc.loader.impl.discovery.RuntimeModRemapper;
 import net.fabricmc.loader.impl.entrypoint.EntrypointStorage;
 import net.fabricmc.loader.impl.game.GameProvider;
-import net.fabricmc.loader.impl.gui.FabricGuiEntry;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.knot.Knot;
 import net.fabricmc.loader.impl.metadata.DependencyOverrides;
@@ -114,6 +113,10 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 	public GameProvider getGameProvider() {
 		if (provider == null) throw new IllegalStateException("game provider not set (yet)");
 
+		return provider;
+	}
+
+	public GameProvider tryGetGameProvider() {
 		return provider;
 	}
 
@@ -181,7 +184,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		try {
 			setup();
 		} catch (ModResolutionException exception) {
-			FabricGuiEntry.displayCriticalError(exception, true);
+			throw new FormattedException("Incompatible mod set!", exception);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/FormattedException.java
+++ b/src/main/java/net/fabricmc/loader/impl/FormattedException.java
@@ -17,22 +17,22 @@
 package net.fabricmc.loader.impl;
 
 @SuppressWarnings("serial")
-public class DependencyException extends RuntimeException {
-	public DependencyException() { }
+public final class FormattedException extends RuntimeException {
+	private final String mainText;
 
-	public DependencyException(String message) {
-		super(message);
-	}
-
-	public DependencyException(String message, Throwable cause) {
+	public FormattedException(String mainText, String message, Throwable cause) {
 		super(message, cause);
+
+		this.mainText = mainText;
 	}
 
-	public DependencyException(Throwable cause) {
+	public FormattedException(String mainText, Throwable cause) {
 		super(cause);
+
+		this.mainText = mainText;
 	}
 
-	public DependencyException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-		super(message, cause, enableSuppression, writableStackTrace);
+	public String getMainText() {
+		return mainText;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -44,7 +44,10 @@ public interface GameProvider { // name directly referenced in net.fabricmc.load
 	GameTransformer getEntrypointTransformer();
 	void unlockClassPath(FabricLauncher launcher);
 	void launch(ClassLoader loader);
-	boolean onCrash(Throwable exception, String context);
+
+	default boolean displayCrash(Throwable exception, String context) {
+		return false;
+	}
 
 	Arguments getArguments();
 	String[] getLaunchArguments(boolean sanitize);

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -45,7 +45,7 @@ public final class FabricGuiEntry {
 	 *
 	 * @throws Exception if something went wrong while opening the window. */
 	public static void open(FabricStatusTree tree) throws Exception {
-		GameProvider provider = FabricLoaderImpl.INSTANCE.getGameProvider();
+		GameProvider provider = FabricLoaderImpl.INSTANCE.tryGetGameProvider();
 
 		if (provider == null && LoaderUtil.hasAwtSupport()
 				|| provider != null && provider.hasAwtSupport()) {
@@ -110,7 +110,7 @@ public final class FabricGuiEntry {
 	}
 
 	public static void displayError(String mainText, Throwable exception, Consumer<FabricStatusTree> treeCustomiser, boolean exitAfter) {
-		GameProvider provider = FabricLoaderImpl.INSTANCE.getGameProvider();
+		GameProvider provider = FabricLoaderImpl.INSTANCE.tryGetGameProvider();
 
 		if (!GraphicsEnvironment.isHeadless() && (provider == null || provider.canOpenErrorGui())) {
 			Version loaderVersion = getLoaderVersion();


### PR DESCRIPTION
Previously early exceptions like from an invalid mixin config file reference wouldn't reach the log file, this PR fixes that. Error GUI invocation now happens through a special exception.