### PR TITLE
Refactor dep/version overrides, tweak exception display

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -59,6 +59,7 @@ import net.fabricmc.loader.impl.launch.knot.Knot;
 import net.fabricmc.loader.impl.metadata.DependencyOverrides;
 import net.fabricmc.loader.impl.metadata.EntrypointMetadata;
 import net.fabricmc.loader.impl.metadata.LoaderModMetadata;
+import net.fabricmc.loader.impl.metadata.VersionOverrides;
 import net.fabricmc.loader.impl.util.DefaultLanguageAdapter;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
@@ -200,6 +201,22 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		modCandidates = discoverer.discoverMods(this);
 
+		// apply version and dependency overrides
+
+		VersionOverrides versionOverrides = new VersionOverrides();
+		versionOverrides.apply(modCandidates);
+
+		DependencyOverrides depOverrides = new DependencyOverrides(configDir);
+		depOverrides.apply(modCandidates);
+
+		if (!versionOverrides.getAffectedModIds().isEmpty()) {
+			Log.info(LogCategory.GENERAL, "Versions overridden for %s", String.join(", ", versionOverrides.getAffectedModIds()));
+		}
+
+		if (!depOverrides.getAffectedModIds().isEmpty()) {
+			Log.info(LogCategory.GENERAL, "Dependencies overridden for %s", String.join(", ", depOverrides.getAffectedModIds()));
+		}
+
 		// resolve mods
 
 		modCandidates = ModResolver.resolve(modCandidates, getEnvironmentType());
@@ -224,10 +241,6 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		int count = modCandidates.size();
 		Log.info(LogCategory.GENERAL, "Loading %d mod%s:%n%s", count, count != 1 ? "s" : "", modListText);
-
-		if (DependencyOverrides.INSTANCE.getDependencyOverrides().size() > 0) {
-			Log.info(LogCategory.GENERAL, "Dependencies overridden for \"%s\"", String.join(", ", DependencyOverrides.INSTANCE.getDependencyOverrides()));
-		}
 
 		Path cacheDir = gameDir.resolve(CACHE_DIR_NAME);
 		Path outputdir = cacheDir.resolve(PROCESSED_MODS_DIR_NAME);

--- a/src/main/java/net/fabricmc/loader/impl/discovery/BuiltinMetadataWrapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/BuiltinMetadataWrapper.java
@@ -38,11 +38,13 @@ import net.fabricmc.loader.impl.metadata.NestedJarEntry;
 class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMetadata {
 	private final ModMetadata parent;
 	private Version version;
+	private final Collection<ModDependency> dependencies;
 
 	BuiltinMetadataWrapper(ModMetadata parent) {
 		this.parent = parent;
 
 		version = parent.getVersion();
+		dependencies = parent.getDependencies();
 	}
 
 	@Override
@@ -78,6 +80,11 @@ class BuiltinMetadataWrapper extends AbstractModMetadata implements LoaderModMet
 	@Override
 	public Collection<ModDependency> getDependencies() {
 		return parent.getDependencies();
+	}
+
+	@Override
+	public void setDependencies(Collection<ModDependency> dependencies) {
+		dependencies = Collections.unmodifiableCollection(dependencies);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
@@ -44,8 +44,6 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.discovery.ModCandidateFinder.ModCandidateConsumer;
 import net.fabricmc.loader.impl.game.GameProvider.BuiltinMod;
@@ -58,7 +56,6 @@ import net.fabricmc.loader.impl.util.ExceptionUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
-import net.fabricmc.loader.impl.util.version.VersionParser;
 
 public final class ModDiscoverer {
 	private final List<ModCandidateFinder> candidateFinders = new ArrayList<>();
@@ -160,47 +157,11 @@ public final class ModDiscoverer {
 			}
 		}
 
-		// apply version replacements
-
-		applyVersionReplacements(candidates);
-
 		long endTime = System.nanoTime();
 
 		Log.debug(LogCategory.DISCOVERY, "Mod discovery time: %.1f ms", (endTime - startTime) * 1e-6);
 
 		return candidates;
-	}
-
-	private static void applyVersionReplacements(List<ModCandidate> mods) {
-		String replacements = System.getProperty(SystemProperties.DEBUG_REPLACE_VERSION);
-		if (replacements == null) return;
-
-		for (String entry : replacements.split(",")) {
-			int pos = entry.indexOf(":");
-			if (pos <= 0 || pos >= entry.length() - 1) throw new RuntimeException("invalid version replacement entry: "+entry);
-
-			String id = entry.substring(0, pos);
-			String rawVersion = entry.substring(pos + 1);
-			Version version;
-
-			try {
-				version = VersionParser.parse(rawVersion, false);
-			} catch (VersionParsingException e) {
-				throw new RuntimeException(String.format("Invalid replacement version for mod %s: %s", id, rawVersion), e);
-			}
-
-			boolean found = false;
-
-			for (ModCandidate mod : mods) {
-				if (mod.getId().equals(id)) {
-					found = true;
-					mod.getMetadata().setVersion(version);
-					break;
-				}
-			}
-
-			if (!found) Log.warn(LogCategory.DISCOVERY, "Can't find mod %s referenced by a version replacement", id);
-		}
 	}
 
 	@SuppressWarnings("serial")

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricStatusTree.java
@@ -31,6 +31,8 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.UnaryOperator;
 
+import net.fabricmc.loader.impl.FormattedException;
+
 public final class FabricStatusTree {
 	public enum FabricTreeWarningLevel {
 		ERROR,
@@ -393,8 +395,17 @@ public final class FabricStatusTree {
 		}
 
 		private FabricStatusNode addException(Throwable exception, StackTraceElement[] parentTrace) {
-			String msg = exception.getMessage();
-			String[] lines = (msg == null || msg.isEmpty() ? exception.toString() : msg).split("\n");
+			String msg;
+
+			if (exception instanceof FormattedException) {
+				msg = Objects.toString(exception.getMessage());
+			} else if (exception.getMessage() == null || exception.getMessage().isEmpty()) {
+				msg = exception.toString();
+			} else {
+				msg = String.format("%s: %s", exception.getClass().getSimpleName(), exception.getMessage());
+			}
+
+			String[] lines = msg.split("\n");
 
 			FabricStatusNode sub = new FabricStatusNode(this, lines[0]);
 			children.add(sub);

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
@@ -72,12 +72,13 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 	}
 
 	protected static void handleFormattedException(FormattedException exc) {
-		Log.error(LogCategory.GENERAL, exc.getMainText(), exc.getCause());
+		Throwable actualExc = exc.getMessage() != null ? exc : exc.getCause();
+		Log.error(LogCategory.GENERAL, exc.getMainText(), actualExc);
 
 		GameProvider gameProvider = FabricLoaderImpl.INSTANCE.tryGetGameProvider();
 
-		if (gameProvider == null || !gameProvider.displayCrash(exc.getCause(), exc.getMainText())) {
-			FabricGuiEntry.displayError(exc.getMainText(), exc.getCause(), true);
+		if (gameProvider == null || !gameProvider.displayCrash(actualExc, exc.getMainText())) {
+			FabricGuiEntry.displayError(exc.getMainText(), actualExc, true);
 		} else {
 			System.exit(1);
 		}

--- a/src/main/java/net/fabricmc/loader/impl/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/BuiltinModMetadata.java
@@ -66,7 +66,7 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 		this.contact = contact;
 		this.license = Collections.unmodifiableCollection(license);
 		this.icons = icons;
-		this.dependencies = Collections.unmodifiableCollection(DependencyOverrides.INSTANCE.apply(id, dependencies));
+		this.dependencies = Collections.unmodifiableCollection(dependencies);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/metadata/LoaderModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/LoaderModMetadata.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.metadata.ModDependency;
 
 /**
  * Internal variant of the ModMetadata interface.
@@ -51,4 +52,5 @@ public interface LoaderModMetadata extends net.fabricmc.loader.metadata.LoaderMo
 	void emitFormatWarnings();
 
 	void setVersion(Version version);
+	void setDependencies(Collection<ModDependency> dependencies);
 }

--- a/src/main/java/net/fabricmc/loader/impl/metadata/V0ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/V0ModMetadata.java
@@ -57,7 +57,7 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 			String name, String description, Collection<Person> authors, Collection<Person> contributors, ContactInformation links, String license) {
 		this.id = id;
 		this.version = version;
-		this.dependencies = Collections.unmodifiableCollection(DependencyOverrides.INSTANCE.apply(id, dependencies));
+		this.dependencies = Collections.unmodifiableCollection(dependencies);
 
 		if (mixins == null) {
 			this.mixins = V0ModMetadata.EMPTY_MIXINS;
@@ -125,6 +125,11 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	@Override
 	public Collection<ModDependency> getDependencies() {
 		return dependencies;
+	}
+
+	@Override
+	public void setDependencies(Collection<ModDependency> dependencies) {
+		dependencies = Collections.unmodifiableCollection(dependencies);
 	}
 
 	// General metadata

--- a/src/main/java/net/fabricmc/loader/impl/metadata/V1ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/V1ModMetadata.java
@@ -89,7 +89,7 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 		this.jars = Collections.unmodifiableCollection(jars);
 		this.mixins = Collections.unmodifiableCollection(mixins);
 		this.accessWidener = accessWidener;
-		this.dependencies = Collections.unmodifiableCollection(DependencyOverrides.INSTANCE.apply(id, dependencies));
+		this.dependencies = Collections.unmodifiableCollection(dependencies);
 		this.hasRequires = hasRequires;
 		this.name = name;
 
@@ -164,6 +164,11 @@ final class V1ModMetadata extends AbstractModMetadata implements LoaderModMetada
 	@Override
 	public Collection<ModDependency> getDependencies() {
 		return dependencies;
+	}
+
+	@Override
+	public void setDependencies(Collection<ModDependency> dependencies) {
+		dependencies = Collections.unmodifiableCollection(dependencies);
 	}
 
 	// General metadata

--- a/src/main/java/net/fabricmc/loader/impl/metadata/VersionOverrides.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/VersionOverrides.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.metadata;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.impl.discovery.ModCandidate;
+import net.fabricmc.loader.impl.util.SystemProperties;
+import net.fabricmc.loader.impl.util.version.VersionParser;
+
+public final class VersionOverrides {
+	private final Map<String, Version> replacements = new HashMap<>();
+
+	public VersionOverrides() {
+		String property = System.getProperty(SystemProperties.DEBUG_REPLACE_VERSION);
+		if (property == null) return;
+
+		for (String entry : property.split(",")) {
+			int pos = entry.indexOf(":");
+			if (pos <= 0 || pos >= entry.length() - 1) throw new RuntimeException("invalid version replacement entry: "+entry);
+
+			String id = entry.substring(0, pos);
+			String rawVersion = entry.substring(pos + 1);
+			Version version;
+
+			try {
+				version = VersionParser.parse(rawVersion, false);
+			} catch (VersionParsingException e) {
+				throw new RuntimeException(String.format("Invalid replacement version for mod %s: %s", id, rawVersion), e);
+			}
+
+			replacements.put(id, version);
+		}
+	}
+
+	public void apply(List<ModCandidate> mods) {
+		if (replacements.isEmpty()) return;
+
+		for (ModCandidate mod : mods) {
+			Version replacement = replacements.get(mod.getId());
+
+			if (replacement != null) {
+				mod.getMetadata().setVersion(replacement);
+			}
+		}
+	}
+
+	public Collection<String> getAffectedModIds() {
+		return replacements.keySet();
+	}
+}


### PR DESCRIPTION
This removes the static initializer / global singleton that incurs an useless exception as reported by https://github.com/FabricMC/fabric-loader/issues/563 and refactors everything to separate metadata parsing from override application.

I also added version overrides to the printout and moved both above mod resolution so they'll be in the log even if resolution fails.

The error gui now includes at least the exception class name (unless it is FormattedException) since just having the message is not always helpful.