### PR TITLE
Strip Log4J2 substitution lookups as necessary

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
@@ -80,7 +80,7 @@ public final class Log4jLogHandler implements LogHandler {
 		if (needsLookupRemoval()) {
 			patchJndi();
 		} else {
-			Log.debug(LogCategory.GAME_PROVIDER, "Log4J JNDI is unnecessary");
+			Log.debug(LogCategory.GAME_PROVIDER, "Log4J2 JNDI removal is unnecessary");
 		}
 	}
 

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
@@ -16,10 +16,24 @@
 
 package net.fabricmc.loader.impl.game.minecraft;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.jar.Attributes.Name;
+import java.util.jar.Manifest;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.spi.LoggerContext;
 
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.impl.util.ManifestUtil;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 import net.fabricmc.loader.impl.util.log.LogHandler;
@@ -61,4 +75,87 @@ public final class Log4jLogHandler implements LogHandler {
 
 	@Override
 	public void close() { }
+
+	static {
+		if (needsLookupRemoval()) {
+			patchJndi();
+		} else {
+			Log.debug(LogCategory.GAME_PROVIDER, "Log4J JNDI is unnecessary");
+		}
+	}
+
+	private static boolean needsLookupRemoval() {
+		Manifest manifest;
+
+		try {
+			manifest = ManifestUtil.readManifest(LogManager.class);
+		} catch (IOException | URISyntaxException e) {
+			Log.warn(LogCategory.GAME_PROVIDER, "Can't read Log4J2 Manifest", e);
+			return true;
+		}
+
+		if (manifest == null) return true;
+
+		String title = ManifestUtil.getManifestValue(manifest, Name.IMPLEMENTATION_TITLE);
+		if (title == null || !title.toLowerCase(Locale.ENGLISH).contains("log4j")) return true;
+
+		String version = ManifestUtil.getManifestValue(manifest, Name.IMPLEMENTATION_VERSION);
+		if (version == null) return true;
+
+		try {
+			return Version.parse(version).compareTo(Version.parse("2.10")) < 0; // 2.10+ supports the log4j2.formatMsgNoLookups system property or doesn't lookup by default
+		} catch (VersionParsingException e) {
+			Log.warn(LogCategory.GAME_PROVIDER, "Can't parse Log4J2 Manifest version %s", version, e);
+			return true;
+		}
+	}
+
+	private static void patchJndi() {
+		LoggerContext context = LogManager.getContext(false);
+
+		try {
+			context.getClass().getMethod("addPropertyChangeListener", PropertyChangeListener.class).invoke(context, new PropertyChangeListener() {
+				@Override
+				public void propertyChange(PropertyChangeEvent evt) {
+					if (evt.getPropertyName().equals("config")) {
+						removeJndiLookup();
+					}
+				}
+			});
+		} catch (Exception e) {
+			Log.warn(LogCategory.GAME_PROVIDER, "Can't register Log4J2 PropertyChangeListener: %s", e);
+		}
+
+		removeJndiLookup();
+	}
+
+	private static void removeJndiLookup() {
+		// strip the jndi lookup from the active org.apache.logging.log4j.core.lookup.Interpolator instance's lookups map
+
+		try {
+			LoggerContext context = LogManager.getContext(false);
+			Object config = context.getClass().getMethod("getConfiguration").invoke(context);
+			Object substitutor = config.getClass().getMethod("getStrSubstitutor").invoke(config);
+			Object varResolver = substitutor.getClass().getMethod("getVariableResolver").invoke(substitutor);
+			if (varResolver == null) return;
+
+			boolean removed = false;
+
+			for (Field field : varResolver.getClass().getDeclaredFields()) {
+				if (Map.class.isAssignableFrom(field.getType())) {
+					field.setAccessible(true);
+					@SuppressWarnings("unchecked")
+					Map<String, ?> map = (Map<String, ?>) field.get(varResolver);
+					removed = map.remove("jndi") != null;
+					if (removed) break;
+				}
+			}
+
+			if (!removed) throw new RuntimeException("couldn't find JNDI lookup entry");
+
+			Log.debug(LogCategory.GAME_PROVIDER, "Removed Log4J2 JNDI Lookup");
+		} catch (Exception e) {
+			Log.warn(LogCategory.GAME_PROVIDER, "Can't remove Log4J2 JNDI Lookup: %s", e);
+		}
+	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/util/ManifestUtil.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/ManifestUtil.java
@@ -18,12 +18,45 @@ package net.fabricmc.loader.impl.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.CodeSource;
 import java.util.jar.Attributes.Name;
 import java.util.jar.Manifest;
 
 public final class ManifestUtil {
+	public static Manifest readManifest(Class<?> cls) throws IOException, URISyntaxException {
+		CodeSource cs = cls.getProtectionDomain().getCodeSource();
+		if (cs == null) return null;
+
+		URL url = cs.getLocation();
+		if (url == null) return null;
+
+		return readManifest(url);
+	}
+
+	public static Manifest readManifest(URL codeSourceUrl) throws IOException, URISyntaxException {
+		Path path = UrlUtil.asPath(codeSourceUrl);
+
+		if (Files.isDirectory(path)) {
+			return readManifest(path);
+		} else {
+			URLConnection connection = new URL("jar:" + codeSourceUrl.toString() + "!/").openConnection();
+
+			if (connection instanceof JarURLConnection) {
+				return ((JarURLConnection) connection).getManifest();
+			}
+
+			try (FileSystemUtil.FileSystemDelegate jarFs = FileSystemUtil.getJarFileSystem(path, false)) {
+				return readManifest(jarFs.get().getRootDirectories().iterator().next());
+			}
+		}
+	}
+
 	public static Manifest readManifest(Path basePath) throws IOException {
 		Path path = basePath.resolve("META-INF").resolve("MANIFEST.MF");
 		if (!Files.exists(path)) return null;


### PR DESCRIPTION
This should resolve CVE-2021-44228 for all versions.

It first checks if the Log4J version is affected and doesn't react to the system property, then removes the JNDI lookup. Reflection use avoids depending on Log4J core at compile time.