### PR TITLE
Fix unbundled external server jar handling

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
@@ -123,7 +123,7 @@ public final class Log4jLogHandler implements LogHandler {
 				}
 			});
 		} catch (Exception e) {
-			Log.warn(LogCategory.GAME_PROVIDER, "Can't register Log4J2 PropertyChangeListener: %s", e);
+			Log.warn(LogCategory.GAME_PROVIDER, "Can't register Log4J2 PropertyChangeListener: %s", e.toString());
 		}
 
 		removeSubstitutionLookups();
@@ -134,6 +134,8 @@ public final class Log4jLogHandler implements LogHandler {
 
 		try {
 			LoggerContext context = LogManager.getContext(false);
+			if (context.getClass().getName().equals("org.apache.logging.log4j.simple.SimpleLoggerContext")) return; // -> no log4j core
+
 			Object config = context.getClass().getMethod("getConfiguration").invoke(context);
 			Object substitutor = config.getClass().getMethod("getStrSubstitutor").invoke(config);
 			Object varResolver = substitutor.getClass().getMethod("getVariableResolver").invoke(substitutor);
@@ -159,7 +161,7 @@ public final class Log4jLogHandler implements LogHandler {
 
 			Log.debug(LogCategory.GAME_PROVIDER, "Removed Log4J2 substitution lookups");
 		} catch (Exception e) {
-			Log.warn(LogCategory.GAME_PROVIDER, "Can't remove Log4J2 JNDI substitution Lookup: %s", e);
+			Log.warn(LogCategory.GAME_PROVIDER, "Can't remove Log4J2 JNDI substitution Lookup: %s", e.toString());
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -90,14 +90,14 @@ public final class GameProviderHelper {
 		}
 	}
 
-	public static FindResult findFirstClass(List<Path> paths, Map<Path, ZipFile> zipFiles, String... classNames) {
-		for (String className : classNames) {
-			String classFilename = LoaderUtil.getClassFileName(className);
+	public static FindResult findFirst(List<Path> paths, Map<Path, ZipFile> zipFiles, boolean isClassName, String... names) {
+		for (String name : names) {
+			String file = isClassName ? LoaderUtil.getClassFileName(name) : name;
 
 			for (Path path : paths) {
 				if (Files.isDirectory(path)) {
-					if (Files.exists(path.resolve(classFilename))) {
-						return new FindResult(className, path);
+					if (Files.exists(path.resolve(file))) {
+						return new FindResult(name, path);
 					}
 				} else {
 					ZipFile zipFile = zipFiles.get(path);
@@ -111,8 +111,8 @@ public final class GameProviderHelper {
 						}
 					}
 
-					if (zipFile.getEntry(classFilename) != null) {
-						return new FindResult(className, path);
+					if (zipFile.getEntry(file) != null) {
+						return new FindResult(name, path);
 					}
 				}
 			}
@@ -122,11 +122,11 @@ public final class GameProviderHelper {
 	}
 
 	public static final class FindResult {
-		public final String className;
+		public final String name;
 		public final Path path;
 
-		FindResult(String className, Path path) {
-			this.className = className;
+		FindResult(String name, Path path) {
+			this.name = name;
 			this.path = path;
 		}
 	}


### PR DESCRIPTION
There were a few issues around extraneous class-to-file name conversions and very old Log4J versions didn't find its core component.