### PR TITLE
Allow BuiltIn mods to have custom values.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/BuiltinModMetadata.java
@@ -19,6 +19,7 @@ package net.fabricmc.loader.impl.metadata;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
@@ -47,6 +48,7 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 	private final Collection<String> license;
 	private final NavigableMap<Integer, String> icons;
 	private final Collection<ModDependency> dependencies;
+	private final Map<String, CustomValue> customValues;
 
 	private BuiltinModMetadata(String id, Version version,
 			ModEnvironment environment,
@@ -55,7 +57,8 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 			ContactInformation contact,
 			Collection<String> license,
 			NavigableMap<Integer, String> icons,
-			Collection<ModDependency> dependencies) {
+			Collection<ModDependency> dependencies,
+			Map<String, CustomValue> customValues) {
 		this.id = id;
 		this.version = version;
 		this.environment = environment;
@@ -67,6 +70,7 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 		this.license = Collections.unmodifiableCollection(license);
 		this.icons = icons;
 		this.dependencies = Collections.unmodifiableCollection(dependencies);
+		this.customValues = Collections.unmodifiableMap(customValues);
 	}
 
 	@Override
@@ -142,17 +146,17 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 
 	@Override
 	public boolean containsCustomValue(String key) {
-		return false;
+		return customValues.containsKey(key);
 	}
 
 	@Override
 	public CustomValue getCustomValue(String key) {
-		return null;
+		return customValues.get(key);
 	}
 
 	@Override
 	public Map<String, CustomValue> getCustomValues() {
-		return Collections.emptyMap();
+		return customValues;
 	}
 
 	public static class Builder {
@@ -167,6 +171,7 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 		private final Collection<String> license = new ArrayList<>();
 		private final NavigableMap<Integer, String> icons = new TreeMap<>();
 		private final Collection<ModDependency> dependencies = new ArrayList<>();
+		private final Map<String, CustomValue> customValues = new HashMap<>();
 
 		public Builder(String id, String version) {
 			this.name = this.id = id;
@@ -222,9 +227,14 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 			this.dependencies.add(dependency);
 			return this;
 		}
+		
+		public Builder addCustomValue(String key, CustomValue customValue) {
+			this.customValues.put(key, customValue);
+			return this;
+		}
 
 		public ModMetadata build() {
-			return new BuiltinModMetadata(id, version, environment, name, description, authors, contributors, contact, license, icons, dependencies);
+			return new BuiltinModMetadata(id, version, environment, name, description, authors, contributors, contact, license, icons, dependencies, customValues);
 		}
 
 		private static Person createPerson(String name, Map<String, String> contactMap) {

--- a/src/main/java/net/fabricmc/loader/impl/metadata/CustomValueImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/CustomValueImpl.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.impl.lib.gson.JsonReader;
 
-abstract class CustomValueImpl implements CustomValue {
+public abstract class CustomValueImpl implements CustomValue {
 	static final CustomValue BOOLEAN_TRUE = new BooleanImpl(true);
 	static final CustomValue BOOLEAN_FALSE = new BooleanImpl(false);
 	static final CustomValue NULL = new NullImpl();
@@ -125,10 +125,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class ObjectImpl extends CustomValueImpl implements CvObject {
+	public static final class ObjectImpl extends CustomValueImpl implements CvObject {
 		private final Map<String, CustomValue> entries;
 
-		ObjectImpl(Map<String, CustomValue> entries) {
+		public ObjectImpl(Map<String, CustomValue> entries) {
 			this.entries = Collections.unmodifiableMap(entries);
 		}
 
@@ -158,10 +158,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class ArrayImpl extends CustomValueImpl implements CvArray {
+	public static final class ArrayImpl extends CustomValueImpl implements CvArray {
 		private final List<CustomValue> entries;
 
-		ArrayImpl(List<CustomValue> entries) {
+		public ArrayImpl(List<CustomValue> entries) {
 			this.entries = Collections.unmodifiableList(entries);
 		}
 
@@ -186,10 +186,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class StringImpl extends CustomValueImpl {
+	public static final class StringImpl extends CustomValueImpl {
 		final String value;
 
-		StringImpl(String value) {
+		public StringImpl(String value) {
 			this.value = value;
 		}
 
@@ -199,10 +199,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class NumberImpl extends CustomValueImpl {
+	public static final class NumberImpl extends CustomValueImpl {
 		final Number value;
 
-		NumberImpl(Number value) {
+		public NumberImpl(Number value) {
 			this.value = value;
 		}
 
@@ -212,10 +212,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class BooleanImpl extends CustomValueImpl {
+	public static final class BooleanImpl extends CustomValueImpl {
 		final boolean value;
 
-		BooleanImpl(boolean value) {
+		public BooleanImpl(boolean value) {
 			this.value = value;
 		}
 
@@ -225,7 +225,7 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class NullImpl extends CustomValueImpl {
+	public static final class NullImpl extends CustomValueImpl {
 		@Override
 		public CvType getType() {
 			return CvType.NULL;


### PR DESCRIPTION
* Makes CustomValueImpl and it's declared inner classes public
* Allows BuiltIn mods to declare custom values

I'm using fabric loader to mod a game that is not minecraft. To do so, I have created my own GameProvider, and have successfully gotten fabric-loader to launch and modify the game in a development environment. In order to have my GameProvider be on the classpath at launch time, I have shadowed fabric loader into my jar.

However, I would like to specify some custom values in my mod, but I cannot supply a fabric.mods.json as it will overwrite fabric-loader's fabric.mods.json when the jars are shadowed together, causing fabric loader to act in a strange, undefined manner. To get around this, I can add my mod as a BuiltIn mod in the gameprovider, but builtin mods currently have no way to add custom values.