### PR TITLE
Add class path groups to map multiple class path entries to a mod

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -139,7 +139,7 @@ public class MinecraftGameProvider implements GameProvider {
 			}
 		}
 
-		return Collections.singletonList(new BuiltinMod(gameJar, metadata.build()));
+		return Collections.singletonList(new BuiltinMod(Collections.singletonList(gameJar), metadata.build()));
 	}
 
 	public Path getGameJar() {

--- a/src/main/java/net/fabricmc/loader/api/ModContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/ModContainer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.ModOrigin;
 
 /**
  * Represents a mod.
@@ -65,6 +66,21 @@ public interface ModContainer {
 
 		return Optional.empty();
 	}
+
+	/**
+	 * Gets where the mod was loaded from originally, the mod jar/folder itself.
+	 *
+	 * <p>This location is not necessarily identical to the code source used at runtime, a mod may get copied or
+	 * otherwise transformed before being put on the class path. It thus mostly represents the installation and initial
+	 * loading, not what is being directly accessed at runtime.
+	 *
+	 * <p>The mod origin is provided for working with the installation like telling the user where a mod has been
+	 * installed at. Accessing the files inside a mod jar/folder should use {@link #findPath} and {@link #getRootPaths}
+	 * instead. Those also abstract jar accesses through the virtual {@code ZipFileSystem} away.
+	 *
+	 * @return mod origin
+	 */
+	ModOrigin getOrigin();
 
 	/**
 	 * Get the mod containing this mod (nested jar parent).

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModOrigin.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModOrigin.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.api.metadata;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Representation of the various locations a mod was loaded from originally.
+ *
+ * <p>This location is not necessarily identical to the code source used at runtime, a mod may get copied or otherwise
+ * transformed before being put on the class path. It thus mostly represents the installation and initial loading, not
+ * what is being directly accessed at runtime.
+ */
+public interface ModOrigin {
+	/**
+	 * Get the kind of this origin, determines the available methods.
+	 *
+	 * @return mod origin kind
+	 */
+	Kind getKind();
+
+	/**
+	 * Get the jar or folder paths for a {@link Kind#PATH} origin.
+	 *
+	 * @return jar or folder paths
+	 * @throws UnsupportedOperationException for incompatible kinds
+	 */
+	List<Path> getPaths();
+
+	/**
+	 * Get the parent mod for a {@link Kind#NESTED} origin.
+	 *
+	 * @return parent mod
+	 * @throws UnsupportedOperationException for incompatible kinds
+	 */
+	String getParentModId();
+
+	/**
+	 * Get the jar or folder paths for a {@link Kind#PATH} origin.
+	 *
+	 * @return jar or folder paths
+	 * @throws UnsupportedOperationException for incompatible kinds
+	 */
+	String getParentSubLocation();
+
+	/**
+	 * Non-exhaustive list of possible {@link ModOrigin} kinds.
+	 *
+	 * <p>New kinds may be added in the future, use a default switch case!
+	 */
+	enum Kind {
+		PATH, NESTED, UNKNOWN
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -472,15 +472,15 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		for (net.fabricmc.loader.api.ModContainer modContainer : getAllMods()) {
 			LoaderModMetadata modMetadata = (LoaderModMetadata) modContainer.getMetadata();
 			String accessWidener = modMetadata.getAccessWidener();
+			if (accessWidener == null) continue;
 
-			if (accessWidener != null) {
-				Path path = modContainer.getPath(accessWidener);
+			Path path = modContainer.findPath(accessWidener).orElse(null);
+			if (path == null) throw new RuntimeException(String.format("Missing accessWidener file %s from mod %s", accessWidener, modContainer.getMetadata().getId()));
 
-				try (BufferedReader reader = Files.newBufferedReader(path)) {
-					accessWidenerReader.read(reader, getMappingResolver().getCurrentRuntimeNamespace());
-				} catch (Exception e) {
-					throw new RuntimeException("Failed to read accessWidener file from mod " + modMetadata.getId(), e);
-				}
+			try (BufferedReader reader = Files.newBufferedReader(path)) {
+				accessWidenerReader.read(reader, getMappingResolver().getCurrentRuntimeNamespace());
+			} catch (Exception e) {
+				throw new RuntimeException("Failed to read accessWidener file from mod " + modMetadata.getId(), e);
 			}
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -301,7 +301,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		// TODO: This can probably be made safer, but that's a long-term goal
 		for (ModContainerImpl mod : mods) {
 			if (!mod.getMetadata().getId().equals(MOD_ID) && !mod.getMetadata().getType().equals("builtin")) {
-				for (Path path : mod.getOriginPaths()) {
+				for (Path path : mod.getCodeSourcePaths()) {
 					FabricLauncherBase.getLauncher().addToClassPath(path);
 				}
 			}
@@ -316,7 +316,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 			Set<Path> knownModPaths = new HashSet<>();
 
 			for (ModContainerImpl mod : mods) {
-				for (Path path : mod.getOriginPaths()) {
+				for (Path path : mod.getCodeSourcePaths()) {
 					knownModPaths.add(path.toAbsolutePath().normalize());
 				}
 			}
@@ -461,7 +461,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 					}
 				}
 			} catch (Exception e) {
-				throw new RuntimeException(String.format("Failed to setup mod %s %s", mod.getInfo().getName(), mod.getOriginPaths()), e);
+				throw new RuntimeException(String.format("Failed to setup mod %s (%s)", mod.getInfo().getName(), mod.getOrigin()), e);
 			}
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/impl/ModContainerImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/ModContainerImpl.java
@@ -16,10 +16,12 @@
 
 package net.fabricmc.loader.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -150,6 +152,22 @@ public class ModContainerImpl extends net.fabricmc.loader.ModContainer {
 			return fs.getRootDirectories().iterator().next();
 
 			// We never close here. It's fine. getJarFileSystem() will handle it gracefully, and so should mods
+		}
+	}
+
+	@Override
+	public Path getPath(String file) {
+		Optional<Path> res = findPath(file);
+		if (res.isPresent()) return res.get();
+
+		List<Path> roots = this.roots;
+
+		if (!roots.isEmpty()) {
+			Path root = roots.get(0);
+
+			return root.resolve(file.replace("/", root.getFileSystem().getSeparator()));
+		} else {
+			return Paths.get(".").resolve("missing_ae236f4970ce").resolve(file.replace('/', File.separatorChar)); // missing dummy path
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ArgumentModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ArgumentModCandidateFinder.java
@@ -58,7 +58,7 @@ public class ArgumentModCandidateFinder implements ModCandidateFinder {
 				Path path = Paths.get(pathStr.substring(1));
 
 				if (!Files.isRegularFile(path)) {
-					Log.warn(LogCategory.DISCOVERY, "Missing/invalid %s provided mod list file %s", source, path);
+					Log.warn(LogCategory.DISCOVERY, "Skipping missing/invalid %s provided mod list file %s", source, path);
 					continue;
 				}
 
@@ -85,7 +85,7 @@ public class ArgumentModCandidateFinder implements ModCandidateFinder {
 		Path path = Paths.get(pathStr).toAbsolutePath().normalize();
 
 		if (!Files.exists(path)) { // missing
-			Log.warn(LogCategory.DISCOVERY, "Missing %s provided mod path %s", source, path);
+			Log.warn(LogCategory.DISCOVERY, "Skipping missing %s provided mod path %s", source, path);
 		} else if (Files.isDirectory(path)) { // directory for extracted mod (in-dev usually) or jars (like mods, but recursive)
 			if (isHidden(path)) {
 				Log.warn(LogCategory.DISCOVERY, "Ignoring hidden %s provided mod path %s", source, path);

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidate.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidate.java
@@ -49,6 +49,7 @@ public final class ModCandidate implements DomainObject.Mod {
 		}
 	};
 
+	private final List<Path> originPaths;
 	private List<Path> paths;
 	private final String localPath;
 	private final long hash;
@@ -82,6 +83,7 @@ public final class ModCandidate implements DomainObject.Mod {
 	}
 
 	private ModCandidate(List<Path> paths, String localPath, long hash, LoaderModMetadata metadata, boolean requiresRemap, Collection<ModCandidate> nestedMods) {
+		this.originPaths = paths;
 		this.paths = paths;
 		this.localPath = localPath;
 		this.metadata = metadata;
@@ -90,6 +92,10 @@ public final class ModCandidate implements DomainObject.Mod {
 		this.nestedMods = nestedMods;
 		this.parentMods = paths == null ? new ArrayList<>() : Collections.emptyList();
 		this.minNestLevel = paths != null ? 0 : Integer.MAX_VALUE;
+	}
+
+	public List<Path> getOriginPaths() {
+		return originPaths;
 	}
 
 	public boolean hasPath() {
@@ -109,7 +115,7 @@ public final class ModCandidate implements DomainObject.Mod {
 		clearCachedData();
 	}
 
-	String getLocalPath() {
+	public String getLocalPath() {
 		if (localPath != null) {
 			return localPath;
 		} else if (paths.size() == 1) {

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidateFinder.java
@@ -17,12 +17,18 @@
 package net.fabricmc.loader.impl.discovery;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 
 @FunctionalInterface
 interface ModCandidateFinder {
 	void findCandidates(ModCandidateConsumer out);
 
 	interface ModCandidateConsumer {
-		void accept(Path path, boolean requiresRemap);
+		default void accept(Path path, boolean requiresRemap) {
+			accept(Collections.singletonList(path), requiresRemap);
+		}
+
+		void accept(List<Path> paths, boolean requiresRemap);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,10 @@ public final class RuntimeModRemapper {
 				info.tag = tag;
 
 				if (mod.hasPath()) {
-					info.inputPath = mod.getPath();
+					List<Path> paths = mod.getPaths();
+					if (paths.size() != 1) throw new UnsupportedOperationException("multiple path for "+mod);
+
+					info.inputPath = paths.get(0);
 				} else {
 					info.inputPath = mod.copyToDir(tmpDir, true);
 					info.inputIsTemp = true;
@@ -147,7 +151,7 @@ public final class RuntimeModRemapper {
 					}
 				}
 
-				mod.setPath(info.outputPath);
+				mod.setPaths(Collections.singletonList(info.outputPath));
 			}
 		} catch (Throwable t) {
 			remapper.finish();

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -18,6 +18,7 @@ package net.fabricmc.loader.impl.game;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 import net.fabricmc.loader.api.metadata.ModMetadata;
@@ -61,15 +62,15 @@ public interface GameProvider { // name directly referenced in net.fabricmc.load
 	}
 
 	class BuiltinMod {
-		public BuiltinMod(Path path, ModMetadata metadata) {
-			Objects.requireNonNull(path, "null path");
+		public BuiltinMod(List<Path> paths, ModMetadata metadata) {
+			Objects.requireNonNull(paths, "null paths");
 			Objects.requireNonNull(metadata, "null metadata");
 
-			this.path = path;
+			this.paths = paths;
 			this.metadata = metadata;
 		}
 
-		public final Path path;
+		public final List<Path> paths;
 		public final ModMetadata metadata;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/metadata/ModOriginImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/ModOriginImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.metadata;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import net.fabricmc.loader.api.metadata.ModOrigin;
+
+public final class ModOriginImpl implements ModOrigin {
+	private final Kind kind;
+	private List<Path> paths;
+	private String parentModId;
+	private String parentSubLocation;
+
+	public ModOriginImpl() {
+		this.kind = Kind.UNKNOWN;
+	}
+
+	public ModOriginImpl(List<Path> paths) {
+		this.kind = Kind.PATH;
+		this.paths = paths;
+	}
+
+	public ModOriginImpl(String parentModId, String parentSubLocation) {
+		this.kind = Kind.NESTED;
+		this.parentModId = parentModId;
+		this.parentSubLocation = parentSubLocation;
+	}
+
+	@Override
+	public Kind getKind() {
+		return kind;
+	}
+
+	@Override
+	public List<Path> getPaths() {
+		if (kind != Kind.PATH) throw new UnsupportedOperationException("kind "+kind.name()+" doesn't have paths");
+
+		return paths;
+	}
+
+	@Override
+	public String getParentModId() {
+		if (kind != Kind.NESTED) throw new UnsupportedOperationException("kind "+kind.name()+" doesn't have a parent mod");
+
+		return parentModId;
+	}
+
+	@Override
+	public String getParentSubLocation() {
+		if (kind != Kind.NESTED) throw new UnsupportedOperationException("kind "+kind.name()+" doesn't have a parent sub-location");
+
+		return parentSubLocation;
+	}
+
+	@Override
+	public String toString() {
+		switch (getKind()) {
+		case PATH:
+			return paths.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
+		case NESTED:
+			return String.format("%s:%s", parentModId, parentSubLocation);
+		default:
+			return "unknown";
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -33,6 +33,8 @@ public final class SystemProperties {
 	public static final String ADD_MODS = "fabric.addMods";
 	// file containing the class path for in-dev runtime mod remapping
 	public static final String REMAP_CLASSPATH_FILE = "fabric.remapClasspathFile";
+	// class path groups to map multiple class path entries to a mod (paths separated by path separator, groups by double path separator)
+	public static final String PATH_GROUPS = "fabric.classPathGroups";
 	// throw exceptions from entrypoints, discovery etc. directly instead of gathering and attaching as suppressed
 	public static final String DEBUG_THROW_DIRECTLY = "fabric.debug.throwDirectly";
 	// logs class transformation errors to uncover caught exceptions without adequate logging

--- a/src/main/legacyJava/net/fabricmc/loader/ModContainer.java
+++ b/src/main/legacyJava/net/fabricmc/loader/ModContainer.java
@@ -19,6 +19,7 @@ package net.fabricmc.loader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 
 import net.fabricmc.loader.impl.util.UrlUtil;
 import net.fabricmc.loader.metadata.LoaderModMetadata;
@@ -29,11 +30,11 @@ import net.fabricmc.loader.metadata.LoaderModMetadata;
 @Deprecated
 public abstract class ModContainer implements net.fabricmc.loader.api.ModContainer {
 	public abstract LoaderModMetadata getInfo();
-	protected abstract Path getOriginPath();
+	protected abstract List<Path> getOriginPaths();
 
 	public URL getOriginUrl() {
 		try {
-			return UrlUtil.asUrl(getOriginPath());
+			return UrlUtil.asUrl(getOriginPaths().get(0));
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/legacyJava/net/fabricmc/loader/ModContainer.java
+++ b/src/main/legacyJava/net/fabricmc/loader/ModContainer.java
@@ -30,11 +30,11 @@ import net.fabricmc.loader.metadata.LoaderModMetadata;
 @Deprecated
 public abstract class ModContainer implements net.fabricmc.loader.api.ModContainer {
 	public abstract LoaderModMetadata getInfo();
-	protected abstract List<Path> getOriginPaths();
+	protected abstract List<Path> getCodeSourcePaths();
 
 	public URL getOriginUrl() {
 		try {
-			return UrlUtil.asUrl(getOriginPaths().get(0));
+			return UrlUtil.asUrl(getCodeSourcePaths().get(0));
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
This adds a system property `fabric.classPathGroups` to specify class path groups. It takes paths separated by path separator, groups by double path separator. A group will cause all of its paths to be associated with a mod sourced from any of the paths.

The API addition `ModContainer.getRootPaths` exposes the multiple paths, existing methods have been deprecated or had their implementation adjusted. `getRootPath` and similar return only the first path and log a warning for the first access in production, always in-dev.

Most of the diff is from changing everything to handle multiple paths, which impacts everything from mod discovery to the resulting API exposure and class path impact.

With this feature it'll be possible to use more than one IDE project for a mod, e.g. to separate optional dependencies out while ensuring the bulk of the code can't even compile if it had an access to such a dependency. This is useful for code interacting with 3rd party mods, abstracting mod loaders out, splitting client/common/server and more. A typical use might be `-Dfabric.classPathGroups=../bin:../../mymod-xyIntegration/bin:../../mymod-core/bin`

Fixes https://github.com/FabricMC/fabric-loader/issues/411