### PR TITLE
Implement ClassLoader.findClass for java.lang.Package.getPackageInfo()

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -168,6 +168,11 @@ final class KnotClassLoader extends SecureClassLoader implements KnotClassLoader
 	}
 
 	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException {
+		return delegate.tryLoadClass(name, false);
+	}
+
+	@Override
 	public Class<?> loadIntoTarget(String name) throws ClassNotFoundException {
 		synchronized (getClassLoadingLock(name)) {
 			Class<?> c = findLoadedClass(name);

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
@@ -67,6 +67,11 @@ class KnotCompatibilityClassLoader extends URLClassLoader implements KnotClassLo
 	}
 
 	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException {
+		return delegate.tryLoadClass(name, false);
+	}
+
+	@Override
 	public Class<?> loadIntoTarget(String name) throws ClassNotFoundException {
 		synchronized (getClassLoadingLock(name)) {
 			Class<?> c = findLoadedClass(name);


### PR DESCRIPTION
should fix the inability to grab package annotations, reported by BasiqueEvangelist on Discord