### PR TITLE
Allow arbitrary +build contents in semver parser, warn earlier about non-semver and only indev, refactoring

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidate.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModCandidate.java
@@ -37,7 +37,9 @@ import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.impl.game.GameProvider.BuiltinMod;
 import net.fabricmc.loader.impl.metadata.AbstractModMetadata;
+import net.fabricmc.loader.impl.metadata.DependencyOverrides;
 import net.fabricmc.loader.impl.metadata.LoaderModMetadata;
+import net.fabricmc.loader.impl.metadata.VersionOverrides;
 
 public final class ModCandidate implements DomainObject.Mod {
 	static final Comparator<ModCandidate> ID_VERSION_COMPARATOR = new Comparator<ModCandidate>() {
@@ -60,8 +62,12 @@ public final class ModCandidate implements DomainObject.Mod {
 	private int minNestLevel;
 	private SoftReference<ByteBuffer> dataRef;
 
-	static ModCandidate createBuiltin(BuiltinMod mod) {
-		return new ModCandidate(mod.paths, null, -1, new BuiltinMetadataWrapper(mod.metadata), false, Collections.emptyList());
+	static ModCandidate createBuiltin(BuiltinMod mod, VersionOverrides versionOverrides, DependencyOverrides depOverrides) {
+		LoaderModMetadata metadata = new BuiltinMetadataWrapper(mod.metadata);
+		versionOverrides.apply(metadata);
+		depOverrides.apply(metadata);
+
+		return new ModCandidate(mod.paths, null, -1, metadata, false, Collections.emptyList());
 	}
 
 	static ModCandidate createPlain(List<Path> paths, LoaderModMetadata metadata, boolean requiresRemap, Collection<ModCandidate> nestedMods) {

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
@@ -46,25 +46,36 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.discovery.ModCandidateFinder.ModCandidateConsumer;
 import net.fabricmc.loader.impl.game.GameProvider.BuiltinMod;
 import net.fabricmc.loader.impl.metadata.BuiltinModMetadata;
+import net.fabricmc.loader.impl.metadata.DependencyOverrides;
 import net.fabricmc.loader.impl.metadata.LoaderModMetadata;
+import net.fabricmc.loader.impl.metadata.MetadataVerifier;
 import net.fabricmc.loader.impl.metadata.ModMetadataParser;
 import net.fabricmc.loader.impl.metadata.NestedJarEntry;
 import net.fabricmc.loader.impl.metadata.ParseMetadataException;
+import net.fabricmc.loader.impl.metadata.VersionOverrides;
 import net.fabricmc.loader.impl.util.ExceptionUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 
 public final class ModDiscoverer {
+	private final VersionOverrides versionOverrides;
+	private final DependencyOverrides depOverrides;
 	private final List<ModCandidateFinder> candidateFinders = new ArrayList<>();
 	private final EnvType envType = FabricLoaderImpl.INSTANCE.getEnvironmentType();
 	private final Map<Long, ModScanTask> jijDedupMap = new ConcurrentHashMap<>(); // avoids reading the same jar twice
 	private final List<NestedModInitData> nestedModInitDatas = Collections.synchronizedList(new ArrayList<>()); // breaks potential cycles from deduplication
+
+	public ModDiscoverer(VersionOverrides versionOverrides, DependencyOverrides depOverrides) {
+		this.versionOverrides = versionOverrides;
+		this.depOverrides = depOverrides;
+	}
 
 	public void addCandidateFinder(ModCandidateFinder f) {
 		candidateFinders.add(f);
@@ -105,15 +116,12 @@ public final class ModDiscoverer {
 
 		// add builtin mods
 		for (BuiltinMod mod : loader.getGameProvider().getBuiltinMods()) {
-			candidates.add(ModCandidate.createBuiltin(mod));
+			ModCandidate candidate = ModCandidate.createBuiltin(mod, versionOverrides, depOverrides);
+			candidates.add(MetadataVerifier.verifyIndev(candidate));
 		}
 
 		// Add the current Java version
-		candidates.add(ModCandidate.createBuiltin(new BuiltinMod(
-				Collections.singletonList(Paths.get(System.getProperty("java.home"))),
-				new BuiltinModMetadata.Builder("java", System.getProperty("java.specification.version").replaceFirst("^1\\.", ""))
-				.setName(System.getProperty("java.vm.name"))
-				.build())));
+		candidates.add(MetadataVerifier.verifyIndev(createJavaMod()));
 
 		ModResolutionException exception = null;
 
@@ -191,6 +199,15 @@ public final class ModDiscoverer {
 		return new ArrayList<>(ret);
 	}
 
+	private ModCandidate createJavaMod() {
+		ModMetadata metadata = new BuiltinModMetadata.Builder("java", System.getProperty("java.specification.version").replaceFirst("^1\\.", ""))
+				.setName(System.getProperty("java.vm.name"))
+				.build();
+		BuiltinMod builtinMod = new BuiltinMod(Collections.singletonList(Paths.get(System.getProperty("java.home"))), metadata);
+
+		return ModCandidate.createBuiltin(builtinMod, versionOverrides, depOverrides);
+	}
+
 	@SuppressWarnings("serial")
 	final class ModScanTask extends RecursiveTask<ModCandidate> {
 		private final List<Path> paths;
@@ -247,7 +264,7 @@ public final class ModDiscoverer {
 				LoaderModMetadata metadata;
 
 				try (InputStream is = Files.newInputStream(modJson)) {
-					metadata = ModMetadataParser.parseMetadata(is, path.toString(), parentPaths);
+					metadata = parseMetadata(is, path.toString());
 				}
 
 				return ModCandidate.createPlain(paths, metadata, requiresRemap, Collections.emptyList());
@@ -266,7 +283,7 @@ public final class ModDiscoverer {
 				LoaderModMetadata metadata;
 
 				try (InputStream is = zf.getInputStream(entry)) {
-					metadata = ModMetadataParser.parseMetadata(is, localPath, parentPaths);
+					metadata = parseMetadata(is, localPath);
 				}
 
 				if (!metadata.loadsInEnvironment(envType)) {
@@ -334,7 +351,7 @@ public final class ModDiscoverer {
 			try (ZipInputStream zis = new ZipInputStream(is)) {
 				while ((entry = zis.getNextEntry()) != null) {
 					if (entry.getName().equals("fabric.mod.json")) {
-						metadata = ModMetadataParser.parseMetadata(zis, localPath, parentPaths);
+						metadata = parseMetadata(zis, localPath);
 						break;
 					}
 				}
@@ -441,6 +458,10 @@ public final class ModDiscoverer {
 			if (localTask != null) localTask.invoke();
 
 			return tasks;
+		}
+
+		private LoaderModMetadata parseMetadata(InputStream is, String localPath) throws ParseMetadataException {
+			return ModMetadataParser.parseMetadata(is, localPath, parentPaths, versionOverrides, depOverrides);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ResultAnalyzer.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ResultAnalyzer.java
@@ -480,7 +480,7 @@ final class ResultAnalyzer {
 			return false;
 		}
 
-		for (int i = incrementedComponent + 1; i < 3; i++) {
+		for (int i = incrementedComponent + 1, m = Math.max(min.getVersionComponentCount(), max.getVersionComponentCount()); i < m; i++) {
 			// all following components need to be 0
 			if (min.getVersionComponent(i) != 0 || max.getVersionComponent(i) != 0) {
 				return false;

--- a/src/main/java/net/fabricmc/loader/impl/metadata/DependencyOverrides.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/DependencyOverrides.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.impl.FormattedException;
-import net.fabricmc.loader.impl.discovery.ModCandidate;
 import net.fabricmc.loader.impl.lib.gson.JsonReader;
 import net.fabricmc.loader.impl.lib.gson.JsonToken;
 
@@ -202,15 +201,9 @@ public final class DependencyOverrides {
 		return ret;
 	}
 
-	public void apply(Collection<ModCandidate> mods) {
+	public void apply(LoaderModMetadata metadata) {
 		if (dependencyOverrides.isEmpty()) return;
 
-		for (ModCandidate mod : mods) {
-			apply(mod.getMetadata());
-		}
-	}
-
-	private void apply(LoaderModMetadata metadata) {
 		List<Entry> modOverrides = dependencyOverrides.get(metadata.getId());
 		if (modOverrides == null) return;
 

--- a/src/main/java/net/fabricmc/loader/impl/metadata/MetadataVerifier.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/MetadataVerifier.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.metadata;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.SemanticVersion;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.impl.FabricLoaderImpl;
+import net.fabricmc.loader.impl.discovery.ModCandidate;
+import net.fabricmc.loader.impl.util.log.Log;
+import net.fabricmc.loader.impl.util.log.LogCategory;
+
+public final class MetadataVerifier {
+	private static final Pattern MOD_ID_PATTERN = Pattern.compile("[a-z][a-z0-9-_]{1,63}");
+
+	public static ModCandidate verifyIndev(ModCandidate mod) {
+		if (FabricLoaderImpl.INSTANCE.isDevelopmentEnvironment()) {
+			try {
+				MetadataVerifier.verify(mod.getMetadata());
+			} catch (ParseMetadataException e) {
+				e.setModPaths(mod.getLocalPath(), Collections.emptyList());
+				throw new RuntimeException("Invalid mod metadata", e);
+			}
+		}
+
+		return mod;
+	}
+
+	static void verify(LoaderModMetadata metadata) throws ParseMetadataException {
+		checkModId(metadata.getId(), "mod id");
+
+		for (String providesDecl : metadata.getProvides()) {
+			checkModId(providesDecl, "provides declaration");
+		}
+
+		// TODO: verify mod id and version decls in deps
+
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
+			if (metadata.getSchemaVersion() < ModMetadataParser.LATEST_VERSION) {
+				Log.warn(LogCategory.METADATA, "Mod %s uses an outdated schema version: %d < %d", metadata.getId(), metadata.getSchemaVersion(), ModMetadataParser.LATEST_VERSION);
+			}
+
+			if (!(metadata.getVersion() instanceof SemanticVersion)) {
+				String version = metadata.getVersion().getFriendlyString();
+				VersionParsingException exc;
+
+				try {
+					SemanticVersion.parse(version);
+					exc = null;
+				} catch (VersionParsingException e) {
+					exc = e;
+				}
+
+				if (exc != null) {
+					Log.warn(LogCategory.METADATA, "Mod %s uses the version %s which isn't compatible with Loader's extended semantic version format (%s), SemVer is recommended for reliable dependency comparisons",
+							metadata.getId(), version, exc.getMessage());
+				}
+			}
+
+			metadata.emitFormatWarnings();
+		}
+	}
+
+	private static void checkModId(String id, String name) throws ParseMetadataException {
+		if (MOD_ID_PATTERN.matcher(id).matches()) return;
+
+		List<String> errorList = new ArrayList<>();
+
+		// A more useful error list for MOD_ID_PATTERN
+		if (id.isEmpty()) {
+			errorList.add("is empty!");
+		} else {
+			if (id.length() == 1) {
+				errorList.add("is only a single character! (It must be at least 2 characters long)!");
+			} else if (id.length() > 64) {
+				errorList.add("has more than 64 characters!");
+			}
+
+			char first = id.charAt(0);
+
+			if (first < 'a' || first > 'z') {
+				errorList.add("starts with an invalid character '" + first + "' (it must be a lowercase a-z - uppercase isn't allowed anywhere in the ID)");
+			}
+
+			Set<Character> invalidChars = null;
+
+			for (int i = 1; i < id.length(); i++) {
+				char c = id.charAt(i);
+
+				if (c == '-' || c == '_' || ('0' <= c && c <= '9') || ('a' <= c && c <= 'z')) {
+					continue;
+				}
+
+				if (invalidChars == null) {
+					invalidChars = new HashSet<>();
+				}
+
+				invalidChars.add(c);
+			}
+
+			if (invalidChars != null) {
+				StringBuilder error = new StringBuilder("contains invalid characters: ");
+				error.append(invalidChars.stream().map(value -> "'" + value + "'").collect(Collectors.joining(", ")));
+				errorList.add(error.append("!").toString());
+			}
+		}
+
+		assert !errorList.isEmpty();
+
+		StringWriter sw = new StringWriter();
+
+		try (PrintWriter pw = new PrintWriter(sw)) {
+			pw.printf("Invalid %s %s:", name, id);
+
+			if (errorList.size() == 1) {
+				pw.printf(" It %s", errorList.get(0));
+			} else {
+				for (String error : errorList) {
+					pw.printf("\n\t- It %s", error);
+				}
+			}
+		}
+
+		throw new ParseMetadataException(sw.toString());
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/metadata/ParseMetadataException.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/ParseMetadataException.java
@@ -41,7 +41,7 @@ public class ParseMetadataException extends Exception {
 		super(t);
 	}
 
-	void setModPaths(String modPath, List<String> modParentPaths) {
+	public void setModPaths(String modPath, List<String> modParentPaths) {
 		modPaths = new ArrayList<>(modParentPaths);
 		modPaths.add(modPath);
 	}

--- a/src/main/java/net/fabricmc/loader/impl/metadata/VersionOverrides.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/VersionOverrides.java
@@ -18,12 +18,10 @@ package net.fabricmc.loader.impl.metadata;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
-import net.fabricmc.loader.impl.discovery.ModCandidate;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.version.VersionParser;
 
@@ -52,15 +50,13 @@ public final class VersionOverrides {
 		}
 	}
 
-	public void apply(List<ModCandidate> mods) {
+	public void apply(LoaderModMetadata metadata) {
 		if (replacements.isEmpty()) return;
 
-		for (ModCandidate mod : mods) {
-			Version replacement = replacements.get(mod.getId());
+		Version replacement = replacements.get(metadata.getId());
 
-			if (replacement != null) {
-				mod.getMetadata().setVersion(replacement);
-			}
+		if (replacement != null) {
+			metadata.setVersion(replacement);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/util/version/SemanticVersionImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/SemanticVersionImpl.java
@@ -26,6 +26,15 @@ import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
 
+/**
+ * Parser for a superset of the semantic version format described at <a href="https://semver.org">semver.org</a>.
+ *
+ * <p>This superset allows additionally
+ * <ul><li>Arbitrary number of {@code <version core>} components, but at least 1
+ * <li>{@code x}, {@code X} or {@code *} for the last {@code <version core>} component with {@code storeX} if not the first
+ * <li>Arbitrary {@code <build>} contents
+ * </ul>
+ */
 @SuppressWarnings("deprecation")
 public class SemanticVersionImpl extends net.fabricmc.loader.util.version.SemanticVersionImpl implements SemanticVersion {
 	private static final Pattern DOT_SEPARATED_ID = Pattern.compile("|[-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*");
@@ -56,10 +65,6 @@ public class SemanticVersionImpl extends net.fabricmc.loader.util.version.Semant
 
 		if (prerelease != null && !DOT_SEPARATED_ID.matcher(prerelease).matches()) {
 			throw new VersionParsingException("Invalid prerelease string '" + prerelease + "'!");
-		}
-
-		if (build != null && !DOT_SEPARATED_ID.matcher(build).matches()) {
-			throw new VersionParsingException("Invalid build string '" + build + "'!");
 		}
 
 		if (version.endsWith(".")) {

--- a/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
+++ b/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 
@@ -36,9 +37,11 @@ import org.junit.jupiter.api.Test;
 
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.impl.metadata.DependencyOverrides;
 import net.fabricmc.loader.impl.metadata.LoaderModMetadata;
 import net.fabricmc.loader.impl.metadata.ModMetadataParser;
 import net.fabricmc.loader.impl.metadata.ParseMetadataException;
+import net.fabricmc.loader.impl.metadata.VersionOverrides;
 
 @Disabled // TODO needs fixing.
 final class V1ModJsonParsingTests {
@@ -185,7 +188,7 @@ final class V1ModJsonParsingTests {
 
 	private static LoaderModMetadata parseMetadata(Path path) throws IOException, ParseMetadataException {
 		try (InputStream is = Files.newInputStream(path)) {
-			return ModMetadataParser.parseMetadata(null, "dummy", Collections.emptyList());
+			return ModMetadataParser.parseMetadata(null, "dummy", Collections.emptyList(), new VersionOverrides(), new DependencyOverrides(Paths.get("randomMissing")));
 		}
 	}
 }


### PR DESCRIPTION
This PR intends to change two things:

a) Make the semver parser ignore anything after +, passing it through as-is

IMO there isn't any strong justification to limit the contents of the build metadata in our application, it is effectively only used for displaying purposes. Comparisons can always strip this metadata as it is being ignored anyway, so even spaces wouldn't be a serious issue for the space separated version predicates. This fixes fabric-api's use in e.g. `0.46.5+1.19_experimental` (can't normally have _ anywhere)

b) Warn early about non-semver versions that don't allow range comparisons and only in-dev

This required applying version overrides earlier to avoid useless warnings for setups using `$version`-like tokens with `-Dfabric.debug.replaceVersion`-based correction. The warnings were reduced to in-dev only since the end user normally can't do anything about them.

Additionally I removed the warning for more than three version components, we've been supporting them for a long time now and it doesn't really add anything. It is quite important for wrapper mods that want to reuse the version of their content and also add a component for themselves.