### PR TITLE
Handle complex dependency failures more gracefully

### DIFF
--- a/src/main/resources/net/fabricmc/loader/Messages.properties
+++ b/src/main/resources/net/fabricmc/loader/Messages.properties
@@ -25,6 +25,8 @@ resolution.solution.replaceModVersionDifferent=Replace {0} with {1} that is comp
 resolution.solution.replaceModVersionDifferent.reqSupportedModVersion={0} {1}
 ## mod versionRange
 resolution.solution.replaceModVersionDifferent.reqSupportedModVersions={0}, {1}
+##
+resolution.solution.replaceModVersionDifferent.unknown=Other constraints that can't be automatically determined
 # solution to install a mod that can load in the current environment: Install someMod, any version.
 ## oldMod newMod versionRange env
 resolution.solution.replaceModEnvDisabled=Replace {0} with {2} of {1} that can load in the current environment ({3}) or update/remove the mods depending on it. This happens because a mod wants to load in a {3} environment but depends on another mod that doesn''t load in the {3} environment.
@@ -37,12 +39,14 @@ resolution.solution.replaceMod.oldModNoPath={0} {1}
 
 resolution.depends.envDisabled={0} {1} requires {3} of {2}, which is disabled for this environment (client/server only)!
 resolution.depends.missing={0} {1} requires {3} of {2}, which is missing!
-resolution.depends.invalid={0} {1} requires {3} of {2}, but only the wrong version{5, choice, 1# is|2#s are} present: {4}!
+resolution.depends.mismatch={0} {1} requires {3} of {2}, but only the wrong version{5, choice, 1# is|2#s are} present: {4}!
+resolution.depends.invalid={0} {1} requires {3} of {2}, which can''t be loaded due to other constraints!
 resolution.depends.suggestion=You need to install {3} of {2}.
 
 resolution.recommends.envDisabled={0} {1} recommends {3} of {2}, which is disabled for this environment (client/server only)!
 resolution.recommends.missing={0} {1} recommends {3} of {2}, which is missing!
-resolution.recommends.invalid={0} {1} recommends {3} of {2}, but only the wrong version{5, choice, 1# is|2#s are} present: {4}!
+resolution.recommends.mismatch={0} {1} recommends {3} of {2}, but only the wrong version{5, choice, 1# is|2#s are} present: {4}!
+resolution.recommends.invalid={0} {1} recommends {3} of {2}, which can''t be loaded due to other constraints!
 resolution.recommends.suggestion=You should install {3} of {2} for the optimal experience.
 
 resolution.breaks.invalid={0} {1} is incompatible with {3} of {2}, but{5, choice, 1# a|2#} matching version{5, choice, 1# is|2#s are} present: {4}!


### PR DESCRIPTION
The solver may consider dependencies as unsatisfiable even if the referenced mod is there, but can't be loaded for other reasons. Those reasons can be anything involving a combination of secondary dependency failures, nesting load requirements (can't load a nested jar without its encompassing jar) or id conflicts. The PR handles these cases by giving a generic failure reason instead of no reason or a misleading reason as before.