### PR TITLE
Improve class loader isolation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
 asm_version = 9.2
-mixin_version = 0.11.2+mixin.0.8.5
+mixin_version = 0.11.3+mixin.0.8.5

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/BundlerProcessor.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/BundlerProcessor.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.LibClassifier;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 
@@ -118,7 +117,7 @@ final class BundlerProcessor {
 		classifier.remove(bundlerOrigin);
 
 		for (URL url : urls) {
-			classifier.process(url, EnvType.SERVER);
+			classifier.process(url);
 		}
 	}
 }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/BundlerProcessor.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/BundlerProcessor.java
@@ -26,14 +26,14 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.impl.game.minecraft.LibClassifier.Lib;
+import net.fabricmc.loader.impl.game.LibClassifier;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 
 final class BundlerProcessor {
 	private static final String MAIN_CLASS_PROPERTY = "bundlerMainClass";
 
-	static void process(LibClassifier classifier) throws IOException {
-		Path bundlerOrigin = classifier.getOrigin(Lib.MC_BUNDLER);
+	static void process(LibClassifier<McLibrary> classifier) throws IOException {
+		Path bundlerOrigin = classifier.getOrigin(McLibrary.MC_BUNDLER);
 
 		// determine urls by running the bundler and extracting them from the context class loader
 
@@ -83,7 +83,7 @@ final class BundlerProcessor {
 				}
 			}
 		}) {
-			Class<?> cls = Class.forName(classifier.getClassName(Lib.MC_BUNDLER), true, bundlerCl);
+			Class<?> cls = Class.forName(classifier.getClassName(McLibrary.MC_BUNDLER), true, bundlerCl);
 			Method method = cls.getMethod("main", String[].class);
 
 			// save + restore the system property and context class loader just in case

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -31,11 +31,12 @@ enum McLibrary implements LibraryType {
 	LOG4J_CORE("META-INF/services/org.apache.logging.log4j.spi.Provider", "META-INF/log4j-provider.properties"),
 	LOG4J_CONFIG("log4j2.xml"),
 	LOG4J_PLUGIN("com/mojang/util/QueueLogAppender.class"),
+	LOG4J_PLUGIN_2("net/minecrell/terminalconsole/util/LoggerNamePatternSelector.class"), // used by loom's log4j config
 	SLF4J_API("org/slf4j/Logger.class"),
 	SLF4J_CORE("META-INF/services/org.slf4j.spi.SLF4JServiceProvider");
 
 	static final McLibrary[] GAME = { MC_CLIENT, MC_SERVER, MC_BUNDLER };
-	static final McLibrary[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, SLF4J_API, SLF4J_CORE };
+	static final McLibrary[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, LOG4J_PLUGIN_2, SLF4J_API, SLF4J_CORE };
 
 	private final EnvType env;
 	private final boolean shaded;

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -20,8 +20,10 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.LibClassifier.LibraryType;
 
 enum McLibrary implements LibraryType {
+	FABRIC_LOADER_MC(null, true, "net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.class"),
 	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class"),
 	MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
+	MC_COMMON("net/minecraft/server/MinecraftServer.class"),
 	MC_BUNDLER(EnvType.SERVER, "net/minecraft/bundler/Main.class"),
 	REALMS(EnvType.CLIENT, "realmsVersion"),
 	MODLOADER("ModLoader"),
@@ -32,9 +34,11 @@ enum McLibrary implements LibraryType {
 	SLF4J_API("org/slf4j/Logger.class"),
 	SLF4J_CORE("META-INF/services/org.slf4j.spi.SLF4JServiceProvider");
 
+	static final McLibrary[] GAME = { MC_CLIENT, MC_SERVER, MC_BUNDLER };
 	static final McLibrary[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, SLF4J_API, SLF4J_CORE };
 
 	private final EnvType env;
+	private final boolean shaded;
 	private final String[] paths;
 
 	McLibrary(String path) {
@@ -42,17 +46,22 @@ enum McLibrary implements LibraryType {
 	}
 
 	McLibrary(String... paths) {
-		this(null, paths);
+		this(null, false, paths);
 	}
 
 	McLibrary(EnvType env, String... paths) {
+		this(env, false, paths);
+	}
+
+	McLibrary(EnvType env, boolean shaded, String... paths) {
 		this.paths = paths;
+		this.shaded = shaded;
 		this.env = env;
 	}
 
 	@Override
-	public boolean isInEnv(EnvType env) {
-		return this.env == null || this.env == env;
+	public boolean isApplicable(EnvType env, boolean shaded) {
+		return (this.env == null || this.env == env) && (!shaded || !this.shaded);
 	}
 
 	@Override

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -30,9 +30,9 @@ enum McLibrary implements LibraryType {
 	LOG4J_API("org/apache/logging/log4j/LogManager.class"),
 	LOG4J_CORE("META-INF/services/org.apache.logging.log4j.spi.Provider", "META-INF/log4j-provider.properties"),
 	LOG4J_CONFIG("log4j2.xml"),
-	LOG4J_PLUGIN("com/mojang/util/QueueLogAppender.class"),
-	LOG4J_PLUGIN_2("com/mojang/patchy/LegacyXMLLayout.class"),
-	LOG4J_PLUGIN_3("net/minecrell/terminalconsole/util/LoggerNamePatternSelector.class"), // used by loom's log4j config
+	LOG4J_PLUGIN("com/mojang/util/UUIDTypeAdapter.class"), // in authlib
+	LOG4J_PLUGIN_2("com/mojang/patchy/LegacyXMLLayout.class"), // in patchy
+	LOG4J_PLUGIN_3("net/minecrell/terminalconsole/util/LoggerNamePatternSelector.class"), // in terminalconsoleappender, used by loom's log4j config
 	GSON("com/google/gson/TypeAdapter.class"), // used by log4j plugins
 	SLF4J_API("org/slf4j/Logger.class"),
 	SLF4J_CORE("META-INF/services/org.slf4j.spi.SLF4JServiceProvider");

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.game.minecraft;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.impl.game.LibClassifier.LibraryType;
+
+enum McLibrary implements LibraryType {
+	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class"),
+	MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
+	MC_BUNDLER(EnvType.SERVER, "net/minecraft/bundler/Main.class"),
+	REALMS(EnvType.CLIENT, "realmsVersion"),
+	MODLOADER("ModLoader"),
+	LOG4J_API("org/apache/logging/log4j/LogManager.class"),
+	LOG4J_CORE("META-INF/services/org.apache.logging.log4j.spi.Provider", "META-INF/log4j-provider.properties"),
+	LOG4J_CONFIG("log4j2.xml"),
+	LOG4J_PLUGIN("com/mojang/util/QueueLogAppender.class"),
+	SLF4J_API("org/slf4j/Logger.class"),
+	SLF4J_CORE("META-INF/services/org.slf4j.spi.SLF4JServiceProvider");
+
+	static final McLibrary[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, SLF4J_API, SLF4J_CORE };
+
+	private final EnvType env;
+	private final String[] paths;
+
+	McLibrary(String path) {
+		this(null, new String[] { path });
+	}
+
+	McLibrary(String... paths) {
+		this(null, paths);
+	}
+
+	McLibrary(EnvType env, String... paths) {
+		this.paths = paths;
+		this.env = env;
+	}
+
+	@Override
+	public boolean isInEnv(EnvType env) {
+		return this.env == null || this.env == env;
+	}
+
+	@Override
+	public String[] getPaths() {
+		return paths;
+	}
+}

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -20,7 +20,6 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.LibClassifier.LibraryType;
 
 enum McLibrary implements LibraryType {
-	FABRIC_LOADER_MC(null, true, "net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.class"),
 	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class"),
 	MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
 	MC_COMMON("net/minecraft/server/MinecraftServer.class"),
@@ -41,7 +40,6 @@ enum McLibrary implements LibraryType {
 	static final McLibrary[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, LOG4J_PLUGIN_2, LOG4J_PLUGIN_3, GSON, SLF4J_API, SLF4J_CORE };
 
 	private final EnvType env;
-	private final boolean shaded;
 	private final String[] paths;
 
 	McLibrary(String path) {
@@ -49,22 +47,17 @@ enum McLibrary implements LibraryType {
 	}
 
 	McLibrary(String... paths) {
-		this(null, false, paths);
+		this(null, paths);
 	}
 
 	McLibrary(EnvType env, String... paths) {
-		this(env, false, paths);
-	}
-
-	McLibrary(EnvType env, boolean shaded, String... paths) {
 		this.paths = paths;
-		this.shaded = shaded;
 		this.env = env;
 	}
 
 	@Override
-	public boolean isApplicable(EnvType env, boolean shaded) {
-		return (this.env == null || this.env == env) && (!shaded || !this.shaded);
+	public boolean isApplicable(EnvType env) {
+		return this.env == null || this.env == env;
 	}
 
 	@Override

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -31,12 +31,14 @@ enum McLibrary implements LibraryType {
 	LOG4J_CORE("META-INF/services/org.apache.logging.log4j.spi.Provider", "META-INF/log4j-provider.properties"),
 	LOG4J_CONFIG("log4j2.xml"),
 	LOG4J_PLUGIN("com/mojang/util/QueueLogAppender.class"),
-	LOG4J_PLUGIN_2("net/minecrell/terminalconsole/util/LoggerNamePatternSelector.class"), // used by loom's log4j config
+	LOG4J_PLUGIN_2("com/mojang/patchy/LegacyXMLLayout.class"),
+	LOG4J_PLUGIN_3("net/minecrell/terminalconsole/util/LoggerNamePatternSelector.class"), // used by loom's log4j config
+	GSON("com/google/gson/TypeAdapter.class"), // used by log4j plugins
 	SLF4J_API("org/slf4j/Logger.class"),
 	SLF4J_CORE("META-INF/services/org.slf4j.spi.SLF4JServiceProvider");
 
 	static final McLibrary[] GAME = { MC_CLIENT, MC_SERVER, MC_BUNDLER };
-	static final McLibrary[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, LOG4J_PLUGIN_2, SLF4J_API, SLF4J_CORE };
+	static final McLibrary[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, LOG4J_PLUGIN_2, LOG4J_PLUGIN_3, GSON, SLF4J_API, SLF4J_CORE };
 
 	private final EnvType env;
 	private final boolean shaded;

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
@@ -105,6 +105,8 @@ public final class McVersionLookup {
 
 		try (SimpleClassPath cp = new SimpleClassPath(Collections.singletonList(gameJar))) {
 			fillVersionFromJar(cp, builder);
+		} catch (IOException e) {
+			throw ExceptionUtil.wrap(e);
 		}
 
 		return builder.build();

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -41,7 +41,7 @@ import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.game.GameProviderHelper;
-import net.fabricmc.loader.impl.game.minecraft.LibClassifier.Lib;
+import net.fabricmc.loader.impl.game.LibClassifier;
 import net.fabricmc.loader.impl.game.minecraft.patch.BrandingPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatchFML125;
@@ -180,25 +180,25 @@ public class MinecraftGameProvider implements GameProvider {
 				lookupPaths = launcher.getClassPath();
 			}
 
-			LibClassifier classifier = new LibClassifier();
+			LibClassifier<McLibrary> classifier = new LibClassifier<>(McLibrary.class);
 			classifier.process(lookupPaths, envType);
 
-			if (classifier.has(Lib.MC_BUNDLER)) {
+			if (classifier.has(McLibrary.MC_BUNDLER)) {
 				BundlerProcessor.process(classifier);
 			}
 
-			Lib gameLib = envType == EnvType.CLIENT ? Lib.MC_CLIENT : Lib.MC_SERVER;
+			McLibrary gameLib = envType == EnvType.CLIENT ? McLibrary.MC_CLIENT : McLibrary.MC_SERVER;
 			gameJar = classifier.getOrigin(gameLib);
 			if (gameJar == null) return false;
 
 			entrypoint = classifier.getClassName(gameLib);
-			realmsJar = classifier.getOrigin(Lib.REALMS);
-			useGameJarForLogging = classifier.is(gameJar, Lib.LOGGING);
-			hasModLoader = classifier.has(Lib.MODLOADER);
-			log4jAvailable = classifier.has(Lib.LOG4J_API) && classifier.has(Lib.LOG4J_CORE);
-			slf4jAvailable = classifier.has(Lib.SLF4J_API) && classifier.has(Lib.SLF4J_CORE);
+			realmsJar = classifier.getOrigin(McLibrary.REALMS);
+			useGameJarForLogging = classifier.is(gameJar, McLibrary.LOGGING);
+			hasModLoader = classifier.has(McLibrary.MODLOADER);
+			log4jAvailable = classifier.has(McLibrary.LOG4J_API) && classifier.has(McLibrary.LOG4J_CORE);
+			slf4jAvailable = classifier.has(McLibrary.SLF4J_API) && classifier.has(McLibrary.SLF4J_CORE);
 
-			for (Lib lib : Lib.LOGGING) {
+			for (McLibrary lib : McLibrary.LOGGING) {
 				Path path = classifier.getOrigin(lib);
 
 				if (path != null && !path.equals(gameJar) && !lookupPaths.contains(path)) {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -19,7 +19,6 @@ package net.fabricmc.loader.impl.game.minecraft;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -54,6 +53,7 @@ import net.fabricmc.loader.impl.util.ExceptionUtil;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
+import net.fabricmc.loader.impl.util.log.LogCategory;
 import net.fabricmc.loader.impl.util.log.LogHandler;
 
 public class MinecraftGameProvider implements GameProvider {
@@ -74,13 +74,13 @@ public class MinecraftGameProvider implements GameProvider {
 	private EnvType envType;
 	private String entrypoint;
 	private Arguments arguments;
-	private Path gameJar, realmsJar;
+	private final List<Path> gameJars = new ArrayList<>(2); // env game jar and potentially common game jar
+	private Path realmsJar;
 	private final Set<Path> logJars = new HashSet<>();
 	private boolean log4jAvailable;
 	private boolean slf4jAvailable;
 	private final List<Path> miscGameLibraries = new ArrayList<>(); // libraries not relevant for loader's uses
 	private McVersion versionData;
-	private boolean useGameJarForLogging;
 	private boolean hasModLoader = false;
 
 	private static final GameTransformer TRANSFORMER = new GameTransformer(
@@ -123,11 +123,11 @@ public class MinecraftGameProvider implements GameProvider {
 			}
 		}
 
-		return Collections.singletonList(new BuiltinMod(Collections.singletonList(gameJar), metadata.build()));
+		return Collections.singletonList(new BuiltinMod(gameJars, metadata.build()));
 	}
 
 	public Path getGameJar() {
-		return gameJar;
+		return gameJars.get(0);
 	}
 
 	@Override
@@ -166,34 +166,45 @@ public class MinecraftGameProvider implements GameProvider {
 		arguments.parse(args);
 
 		try {
-			String gameJarProperty = System.getProperty(SystemProperties.GAME_JAR_PATH);
-			List<Path> lookupPaths;
+			LibClassifier<McLibrary> classifier = new LibClassifier<>(McLibrary.class, envType);
+			McLibrary envGameLib = envType == EnvType.CLIENT ? McLibrary.MC_CLIENT : McLibrary.MC_SERVER;
+			Path commonGameJar = GameProviderHelper.getCommonGameJar();
+			Path envGameJar = GameProviderHelper.getEnvGameJar(envType);
+			boolean commonGameJarDeclared = commonGameJar != null;
 
-			if (gameJarProperty != null) {
-				Path path = Paths.get(gameJarProperty).toAbsolutePath().normalize();
-				if (!Files.exists(path)) throw new RuntimeException("Game jar "+path+" configured through "+SystemProperties.GAME_JAR_PATH+" system property doesn't exist");
+			if (commonGameJarDeclared) {
+				if (envGameJar != null) {
+					classifier.process(envGameJar, McLibrary.MC_COMMON);
+				}
 
-				lookupPaths = new ArrayList<>();
-				lookupPaths.add(path);
-				lookupPaths.addAll(launcher.getClassPath());
-			} else {
-				lookupPaths = launcher.getClassPath();
+				classifier.process(commonGameJar);
+			} else if (envGameJar != null) {
+				classifier.process(envGameJar);
 			}
 
-			LibClassifier<McLibrary> classifier = new LibClassifier<>(McLibrary.class);
-			classifier.process(lookupPaths, envType);
+			classifier.process(launcher.getClassPath());
 
 			if (classifier.has(McLibrary.MC_BUNDLER)) {
 				BundlerProcessor.process(classifier);
 			}
 
-			McLibrary gameLib = envType == EnvType.CLIENT ? McLibrary.MC_CLIENT : McLibrary.MC_SERVER;
-			gameJar = classifier.getOrigin(gameLib);
-			if (gameJar == null) return false;
+			envGameJar = classifier.getOrigin(envGameLib);
+			if (envGameJar == null) return false;
 
-			entrypoint = classifier.getClassName(gameLib);
+			commonGameJar = classifier.getOrigin(McLibrary.MC_COMMON);
+
+			if (commonGameJarDeclared && commonGameJar == null) {
+				Log.warn(LogCategory.GAME_PROVIDER, "The declared common game jar didn't contain any of the expected classes!");
+			}
+
+			gameJars.add(envGameJar);
+
+			if (commonGameJar != null && !commonGameJar.equals(envGameJar)) {
+				gameJars.add(commonGameJar);
+			}
+
+			entrypoint = classifier.getClassName(envGameLib);
 			realmsJar = classifier.getOrigin(McLibrary.REALMS);
-			useGameJarForLogging = classifier.is(gameJar, McLibrary.LOGGING);
 			hasModLoader = classifier.has(McLibrary.MODLOADER);
 			log4jAvailable = classifier.has(McLibrary.LOG4J_API) && classifier.has(McLibrary.LOG4J_CORE);
 			slf4jAvailable = classifier.has(McLibrary.SLF4J_API) && classifier.has(McLibrary.SLF4J_CORE);
@@ -201,30 +212,31 @@ public class MinecraftGameProvider implements GameProvider {
 			for (McLibrary lib : McLibrary.LOGGING) {
 				Path path = classifier.getOrigin(lib);
 
-				if (path != null && !path.equals(gameJar) && !lookupPaths.contains(path)) {
-					logJars.add(path);
+				if (path != null) {
+					if (log4jAvailable || slf4jAvailable) {
+						logJars.add(path);
+					} else if (!gameJars.contains(path)) {
+						miscGameLibraries.add(path);
+					}
 				}
 			}
 
 			for (Path path : classifier.getUnmatchedOrigins()) {
-				if (!lookupPaths.contains(path)) miscGameLibraries.add(path);
+				miscGameLibraries.add(path);
 			}
 		} catch (IOException e) {
 			throw ExceptionUtil.wrap(e);
 		}
 
-		if (!useGameJarForLogging && logJars.isEmpty()) { // use Log4J/SLF4J log handler directly if it is not shaded into the game jar, otherwise delay it to initialize() after deobfuscation
-			setupLogHandler(launcher, false);
-		}
-
 		// expose obfuscated jar locations for mods to more easily remap code from obfuscated to intermediary
 		ObjectShare share = FabricLoaderImpl.INSTANCE.getObjectShare();
-		share.put("fabric-loader:inputGameJar", gameJar);
+		share.put("fabric-loader:inputGameJar", gameJars.get(0)); // deprecated
+		share.put("fabric-loader:inputGameJars", gameJars);
 		if (realmsJar != null) share.put("fabric-loader:inputRealmsJar", realmsJar);
 
 		String version = arguments.remove(Arguments.GAME_VERSION);
 		if (version == null) version = System.getProperty(SystemProperties.GAME_VERSION);
-		versionData = McVersionLookup.getVersion(gameJar, entrypoint, version);
+		versionData = McVersionLookup.getVersion(gameJars, entrypoint, version);
 
 		processArgumentMap(arguments, envType);
 
@@ -269,39 +281,57 @@ public class MinecraftGameProvider implements GameProvider {
 
 	@Override
 	public void initialize(FabricLauncher launcher) {
-		Map<String, Path> gameJars = new HashMap<>(2);
-		String name = envType.name().toLowerCase(Locale.ENGLISH);
-		gameJars.put(name, gameJar);
-
-		if (realmsJar != null) {
-			gameJars.put("realms", realmsJar);
-		}
-
 		if (isObfuscated()) {
-			gameJars = GameProviderHelper.deobfuscate(gameJars,
+			Map<String, Path> obfJars = new HashMap<>(3);
+			String[] names = new String[gameJars.size()];
+
+			for (int i = 0; i < gameJars.size(); i++) {
+				String name;
+
+				if (i == 0) {
+					name = envType.name().toLowerCase(Locale.ENGLISH);
+				} else if (i == 1) {
+					name = "common";
+				} else {
+					name = String.format("extra-%d", i - 2);
+				}
+
+				obfJars.put(name, gameJars.get(i));
+				names[i] = name;
+			}
+
+			if (realmsJar != null) {
+				obfJars.put("realms", realmsJar);
+			}
+
+			obfJars = GameProviderHelper.deobfuscate(obfJars,
 					getGameId(), getNormalizedGameVersion(),
 					getLaunchDirectory(),
 					launcher);
 
-			gameJar = gameJars.get(name);
-			realmsJar = gameJars.get("realms");
-		}
+			for (int i = 0; i < gameJars.size(); i++) {
+				Path newJar = obfJars.get(names[i]);
+				Path oldJar = gameJars.set(i, newJar);
 
-		if (useGameJarForLogging || !logJars.isEmpty()) {
-			if (useGameJarForLogging) {
-				launcher.addToClassPath(gameJar, ALLOWED_EARLY_CLASS_PREFIXES);
+				if (logJars.remove(oldJar)) logJars.add(newJar);
 			}
 
-			if (!logJars.isEmpty()) {
-				for (Path jar : logJars) {
+			realmsJar = obfJars.get("realms");
+		}
+
+		if (!logJars.isEmpty()) {
+			for (Path jar : logJars) {
+				if (gameJars.contains(jar)) {
+					launcher.addToClassPath(jar, ALLOWED_EARLY_CLASS_PREFIXES);
+				} else {
 					launcher.addToClassPath(jar);
 				}
 			}
-
-			setupLogHandler(launcher, true);
 		}
 
-		TRANSFORMER.locateEntrypoints(launcher, gameJar);
+		setupLogHandler(launcher, true);
+
+		TRANSFORMER.locateEntrypoints(launcher, gameJars);
 	}
 
 	private void setupLogHandler(FabricLauncher launcher, boolean useTargetCl) {
@@ -389,10 +419,12 @@ public class MinecraftGameProvider implements GameProvider {
 
 	@Override
 	public void unlockClassPath(FabricLauncher launcher) {
-		if (useGameJarForLogging) {
-			launcher.setAllowedPrefixes(gameJar);
-		} else {
-			launcher.addToClassPath(gameJar);
+		for (Path gameJar : gameJars) {
+			if (logJars.contains(gameJar)) {
+				launcher.setAllowedPrefixes(gameJar);
+			} else {
+				launcher.addToClassPath(gameJar);
+			}
 		}
 
 		if (realmsJar != null) launcher.addToClassPath(realmsJar);

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.JarEntry;
@@ -182,6 +183,11 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public void setAllowedPrefixes(Path path, String... prefixes) {
+		// not implemented (no-op)
+	}
+
+	@Override
+	public void setValidParentClassPath(Collection<Path> paths) {
 		// not implemented (no-op)
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -62,6 +62,7 @@ import net.fabricmc.loader.impl.metadata.LoaderModMetadata;
 import net.fabricmc.loader.impl.metadata.VersionOverrides;
 import net.fabricmc.loader.impl.util.DefaultLanguageAdapter;
 import net.fabricmc.loader.impl.util.SystemProperties;
+import net.fabricmc.loader.impl.util.UrlUtil;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 
@@ -148,6 +149,8 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 	 */
 	@Override
 	public Path getGameDir() {
+		if (gameDir == null) throw new IllegalStateException("invoked too early?");
+
 		return gameDir;
 	}
 
@@ -326,8 +329,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 			}
 
 			// suppress fabric loader explicitly in case its fabric.mod.json is in a different folder from the classes
-			Path fabricLoaderPath = ClasspathModCandidateFinder.getFabricLoaderPath();
-			if (fabricLoaderPath != null) knownModPaths.add(fabricLoaderPath.toAbsolutePath().normalize());
+			knownModPaths.add(UrlUtil.LOADER_CODE_SOURCE.toAbsolutePath().normalize());
 
 			for (String pathName : System.getProperty("java.class.path", "").split(File.pathSeparator)) {
 				if (pathName.isEmpty() || pathName.endsWith("*")) continue;

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
@@ -69,7 +69,7 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 			}
 		} else { // production, add loader as a mod
 			try {
-				out.accept(getFabricLoaderPath(), false);
+				out.accept(UrlUtil.LOADER_CODE_SOURCE, false);
 			} catch (Throwable t) {
 				Log.debug(LogCategory.DISCOVERY, "Could not retrieve launcher code source!", t);
 			}
@@ -116,14 +116,5 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 		}
 
 		return ret;
-	}
-
-	public static Path getFabricLoaderPath() {
-		try {
-			return UrlUtil.asPath(FabricLauncherBase.getLauncher().getClass().getProtectionDomain().getCodeSource().getLocation());
-		} catch (Throwable t) {
-			Log.debug(LogCategory.DISCOVERY, "Could not retrieve launcher code source!", t);
-			return null;
-		}
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -34,11 +35,13 @@ import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.zip.ZipFile;
 
+import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.launch.FabricLauncher;
 import net.fabricmc.loader.impl.launch.MappingConfiguration;
 import net.fabricmc.loader.impl.util.LoaderUtil;
+import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.UrlConversionException;
 import net.fabricmc.loader.impl.util.UrlUtil;
 import net.fabricmc.loader.impl.util.log.Log;
@@ -52,6 +55,24 @@ import net.fabricmc.tinyremapper.TinyRemapper;
 
 public final class GameProviderHelper {
 	private GameProviderHelper() { }
+
+	public static Path getCommonGameJar() {
+		return getGameJar(SystemProperties.GAME_JAR_PATH);
+	}
+
+	public static Path getEnvGameJar(EnvType env) {
+		return getGameJar(env == EnvType.CLIENT ? SystemProperties.GAME_JAR_PATH_CLIENT : SystemProperties.GAME_JAR_PATH_SERVER);
+	}
+
+	private static Path getGameJar(String property) {
+		String val = System.getProperty(property);
+		if (val == null) return null;
+
+		Path path = Paths.get(val).toAbsolutePath().normalize();
+		if (!Files.exists(path)) throw new RuntimeException("Game jar "+path+" configured through "+property+" system property doesn't exist");
+
+		return path;
+	}
 
 	public static Optional<Path> getSource(ClassLoader loader, String filename) {
 		URL url;

--- a/src/main/java/net/fabricmc/loader/impl/game/LibClassifier.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/LibClassifier.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.loader.impl.game.minecraft;
+package net.fabricmc.loader.impl.game;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -31,12 +31,20 @@ import java.util.zip.ZipError;
 import java.util.zip.ZipFile;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.impl.game.LibClassifier.LibraryType;
 import net.fabricmc.loader.impl.util.UrlUtil;
 
-final class LibClassifier {
-	private final Map<Lib, Path> matches = new EnumMap<>(Lib.class);
-	private final Map<Lib, String> localPaths = new EnumMap<>(Lib.class);
+public final class LibClassifier<L extends Enum<L> & LibraryType> {
+	private final L[] libs;
+	private final Map<L, Path> origins;
+	private final Map<L, String> localPaths;
 	private final List<Path> unmatchedOrigins = new ArrayList<>();
+
+	public LibClassifier(Class<L> cls) {
+		libs = cls.getEnumConstants();
+		origins = new EnumMap<>(cls);
+		localPaths = new EnumMap<>(cls);
+	}
 
 	public void process(URL url, EnvType env) throws IOException {
 		try {
@@ -56,30 +64,28 @@ final class LibClassifier {
 		boolean matched = false;
 
 		if (Files.isDirectory(path)) {
-			for (Lib lib : Lib.VALUES) {
-				if (!lib.isInEnv(env) || matches.containsKey(lib)) continue;
+			for (L lib : libs) {
+				if (!lib.isInEnv(env) || origins.containsKey(lib)) continue;
 
-				for (String p : lib.paths) {
+				for (String p : lib.getPaths()) {
 					if (Files.exists(path.resolve(p))) {
 						matched = true;
-						matches.put(lib, path);
-						localPaths.put(lib, p);
+						addLibrary(lib, path, p);
 						break;
 					}
 				}
 			}
 		} else {
 			try (ZipFile zf = new ZipFile(path.toFile())) {
-				for (Lib lib : Lib.VALUES) {
-					if (!lib.isInEnv(env) || matches.containsKey(lib)) continue;
+				for (L lib : libs) {
+					if (!lib.isInEnv(env) || origins.containsKey(lib)) continue;
 
-					for (String p : lib.paths) {
+					for (String p : lib.getPaths()) {
 						ZipEntry entry = zf.getEntry(p);
 
 						if (entry != null) {
 							matched = true;
-							matches.put(lib, path);
-							localPaths.put(lib, p);
+							addLibrary(lib, path, p);
 							break;
 						}
 					}
@@ -92,27 +98,33 @@ final class LibClassifier {
 		if (!matched) unmatchedOrigins.add(path);
 	}
 
-	public boolean is(Path path, Lib... libs) {
-		for (Lib lib : libs) {
-			if (path.equals(matches.get(lib))) return true;
+	private void addLibrary(L lib, Path originPath, String localPath) {
+		origins.put(lib, originPath);
+		localPaths.put(lib, localPath);
+	}
+
+	@SafeVarargs
+	public final boolean is(Path path, L... libs) {
+		for (L lib : libs) {
+			if (path.equals(origins.get(lib))) return true;
 		}
 
 		return false;
 	}
 
-	public boolean has(Lib lib) {
-		return matches.containsKey(lib);
+	public boolean has(L lib) {
+		return origins.containsKey(lib);
 	}
 
-	public Path getOrigin(Lib lib) {
-		return matches.get(lib);
+	public Path getOrigin(L lib) {
+		return origins.get(lib);
 	}
 
-	public String getLocalPath(Lib lib) {
+	public String getLocalPath(L lib) {
 		return localPaths.get(lib);
 	}
 
-	public String getClassName(Lib lib) {
+	public String getClassName(L lib) {
 		String localPath = localPaths.get(lib);
 		if (localPath == null || !localPath.endsWith(".class")) return null;
 
@@ -128,8 +140,8 @@ final class LibClassifier {
 
 		boolean ret = false;
 
-		for (Iterator<Map.Entry<Lib, Path>> it = matches.entrySet().iterator(); it.hasNext(); ) {
-			Map.Entry<Lib, Path> entry = it.next();
+		for (Iterator<Map.Entry<L, Path>> it = origins.entrySet().iterator(); it.hasNext(); ) {
+			Map.Entry<L, Path> entry = it.next();
 
 			if (entry.getValue().equals(path)) {
 				localPaths.remove(entry.getKey());
@@ -142,40 +154,8 @@ final class LibClassifier {
 		return ret;
 	}
 
-	enum Lib {
-		MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class"),
-		MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
-		MC_BUNDLER(EnvType.SERVER, "net/minecraft/bundler/Main.class"),
-		REALMS(EnvType.CLIENT, "realmsVersion"),
-		MODLOADER("ModLoader"),
-		LOG4J_API("org/apache/logging/log4j/LogManager.class"),
-		LOG4J_CORE("META-INF/services/org.apache.logging.log4j.spi.Provider", "META-INF/log4j-provider.properties"),
-		LOG4J_CONFIG("log4j2.xml"),
-		LOG4J_PLUGIN("com/mojang/util/QueueLogAppender.class"),
-		SLF4J_API("org/slf4j/Logger.class"),
-		SLF4J_CORE("META-INF/services/org.slf4j.spi.SLF4JServiceProvider");
-
-		static final Lib[] VALUES = values();
-		static final Lib[] LOGGING = { LOG4J_API, LOG4J_CORE, LOG4J_CONFIG, LOG4J_PLUGIN, SLF4J_API, SLF4J_CORE };
-
-		final String[] paths;
-		final EnvType env;
-
-		Lib(String path) {
-			this(null, new String[] { path });
-		}
-
-		Lib(String... paths) {
-			this(null, paths);
-		}
-
-		Lib(EnvType env, String... paths) {
-			this.paths = paths;
-			this.env = env;
-		}
-
-		boolean isInEnv(EnvType env) {
-			return this.env == null || this.env == env;
-		}
+	public interface LibraryType {
+		boolean isInEnv(EnvType env);
+		String[] getPaths();
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
@@ -1,0 +1,35 @@
+package net.fabricmc.loader.impl.game;
+
+import net.fabricmc.api.EnvType;
+
+enum LoaderLibrary {
+	FABRIC_LOADER("net/fabricmc/loader/api/FabricLoader.class"),
+	TINY_MAPPINGS_PARSER("net/fabricmc/mapping/tree/TinyMappingFactory.class"),
+	SPONGE_MIXIN("org/spongepowered/asm/launch/MixinBootstrap.class"),
+	TINY_REMAPPER("net/fabricmc/tinyremapper/TinyRemapper.class"),
+	ACCESS_WIDENER("net/fabricmc/accesswidener/AccessWidener.class"),
+	ASM("org/objectweb/asm/ClassReader.class"),
+	ASM_ANALYSIS("org/objectweb/asm/tree/analysis/Analyzer.class"),
+	ASM_COMMONS("org/objectweb/asm/commons/Remapper.class"),
+	ASM_TREE("org/objectweb/asm/tree/ClassNode.class"),
+	ASM_UTIL("org/objectweb/asm/util/CheckClassAdapter.class"),
+	INTERMEDIARY("mappings/mappings.tiny"),
+	SAT4J_CORE(true, "org/sat4j/specs/ContradictionException.class"),
+	SAT4J_PB(true, "org/sat4j/pb/SolverFactory.class");
+
+	final boolean shaded;
+	final String path;
+
+	LoaderLibrary(String path) {
+		this(false, path);
+	}
+
+	LoaderLibrary(boolean shaded, String path) {
+		this.shaded = shaded;
+		this.path = path;
+	}
+
+	public boolean isApplicable(EnvType env, boolean shaded) {
+		return !shaded || !this.shaded;
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
@@ -16,36 +16,45 @@
 
 package net.fabricmc.loader.impl.game;
 
-import net.fabricmc.api.EnvType;
+import java.nio.file.Path;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.commons.Remapper;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.sat4j.pb.SolverFactory;
+import org.sat4j.specs.ContradictionException;
+import org.spongepowered.asm.launch.MixinBootstrap;
+
+import net.fabricmc.accesswidener.AccessWidener;
+import net.fabricmc.loader.impl.util.UrlUtil;
+import net.fabricmc.mapping.tree.TinyMappingFactory;
+import net.fabricmc.tinyremapper.TinyRemapper;
 
 enum LoaderLibrary {
-	FABRIC_LOADER("net/fabricmc/loader/api/FabricLoader.class"),
-	TINY_MAPPINGS_PARSER("net/fabricmc/mapping/tree/TinyMappingFactory.class"),
-	SPONGE_MIXIN("org/spongepowered/asm/launch/MixinBootstrap.class"),
-	TINY_REMAPPER("net/fabricmc/tinyremapper/TinyRemapper.class"),
-	ACCESS_WIDENER("net/fabricmc/accesswidener/AccessWidener.class"),
-	ASM("org/objectweb/asm/ClassReader.class"),
-	ASM_ANALYSIS("org/objectweb/asm/tree/analysis/Analyzer.class"),
-	ASM_COMMONS("org/objectweb/asm/commons/Remapper.class"),
-	ASM_TREE("org/objectweb/asm/tree/ClassNode.class"),
-	ASM_UTIL("org/objectweb/asm/util/CheckClassAdapter.class"),
-	INTERMEDIARY("mappings/mappings.tiny"),
-	SAT4J_CORE(true, "org/sat4j/specs/ContradictionException.class"),
-	SAT4J_PB(true, "org/sat4j/pb/SolverFactory.class");
+	FABRIC_LOADER(UrlUtil.LOADER_CODE_SOURCE),
+	TINY_MAPPINGS_PARSER(TinyMappingFactory.class),
+	SPONGE_MIXIN(MixinBootstrap.class),
+	TINY_REMAPPER(TinyRemapper.class),
+	ACCESS_WIDENER(AccessWidener.class),
+	ASM(ClassReader.class),
+	ASM_ANALYSIS(Analyzer.class),
+	ASM_COMMONS(Remapper.class),
+	ASM_TREE(ClassNode.class),
+	ASM_UTIL(CheckClassAdapter.class),
+	SAT4J_CORE(ContradictionException.class),
+	SAT4J_PB(SolverFactory.class);
 
-	final boolean shaded;
-	final String path;
+	final Path path;
 
-	LoaderLibrary(String path) {
-		this(false, path);
+	LoaderLibrary(Class<?> cls) {
+		this(UrlUtil.getCodeSource(cls));
 	}
 
-	LoaderLibrary(boolean shaded, String path) {
-		this.shaded = shaded;
+	LoaderLibrary(Path path) {
+		if (path == null) throw new RuntimeException("missing loader library "+name());
+
 		this.path = path;
-	}
-
-	public boolean isApplicable(EnvType env, boolean shaded) {
-		return !shaded || !this.shaded;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.loader.impl.game;
 
 import net.fabricmc.api.EnvType;

--- a/src/main/java/net/fabricmc/loader/impl/game/patch/GameTransformer.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/patch/GameTransformer.java
@@ -91,6 +91,8 @@ public class GameTransformer {
 			for (GamePatch patch : patches) {
 				patch.process(launcher, classSource, this::addPatchedClass);
 			}
+		} catch (IOException e) {
+			throw ExceptionUtil.wrap(e);
 		}
 
 		Log.debug(LogCategory.GAME_PATCH, "Patched %d class%s", patchedClasses.size(), patchedClasses.size() != 1 ? "s" : "");

--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -28,12 +28,12 @@ import java.nio.file.Paths;
 import java.util.function.Consumer;
 
 import net.fabricmc.loader.impl.FabricLoaderImpl;
-import net.fabricmc.loader.impl.discovery.ClasspathModCandidateFinder;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricBasicButtonType;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricStatusTab;
 import net.fabricmc.loader.impl.gui.FabricStatusTree.FabricTreeWarningLevel;
 import net.fabricmc.loader.impl.util.LoaderUtil;
+import net.fabricmc.loader.impl.util.UrlUtil;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 
@@ -69,10 +69,7 @@ public final class FabricGuiEntry {
 
 		if (javaPath == null) throw new RuntimeException("can't find java executable in "+javaBinDir);
 
-		Path loaderPath = ClasspathModCandidateFinder.getFabricLoaderPath();
-		if (loaderPath == null) throw new RuntimeException("can't determine Fabric Loader path");
-
-		Process process = new ProcessBuilder(javaPath.toString(), "-Xmx100M", "-cp", loaderPath.toString(), FabricGuiEntry.class.getName())
+		Process process = new ProcessBuilder(javaPath.toString(), "-Xmx100M", "-cp", UrlUtil.LOADER_CODE_SOURCE.toString(), FabricGuiEntry.class.getName())
 				.redirectOutput(ProcessBuilder.Redirect.INHERIT)
 				.redirectError(ProcessBuilder.Redirect.INHERIT)
 				.start();

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
@@ -19,6 +19,7 @@ package net.fabricmc.loader.impl.launch;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.jar.Manifest;
 
@@ -29,6 +30,7 @@ public interface FabricLauncher {
 
 	void addToClassPath(Path path, String... allowedPrefixes);
 	void setAllowedPrefixes(Path path, String... prefixes);
+	void setValidParentClassPath(Collection<Path> paths);
 
 	EnvType getEnvironmentType();
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.loader.impl.launch;
 
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.Map;
 
@@ -107,7 +110,14 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 					}
 				} catch (Throwable e2) { // just in case
 					e.addSuppressed(e2);
-					e.printStackTrace();
+
+					try {
+						e.printStackTrace();
+					} catch (Throwable e3) {
+						PrintWriter pw = new PrintWriter(new FileOutputStream(FileDescriptor.err));
+						e.printStackTrace(pw);
+						pw.flush();
+					}
 				}
 			}
 		});

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricMixinBootstrap.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricMixinBootstrap.java
@@ -38,6 +38,8 @@ import net.fabricmc.loader.api.metadata.ModDependency.Kind;
 import net.fabricmc.loader.api.metadata.version.VersionInterval;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.ModContainerImpl;
+import net.fabricmc.loader.impl.launch.knot.MixinServiceKnot;
+import net.fabricmc.loader.impl.launch.knot.MixinServiceKnotBootstrap;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 import net.fabricmc.loader.impl.util.mappings.MixinIntermediaryDevRemapper;
@@ -52,6 +54,11 @@ public final class FabricMixinBootstrap {
 		if (initialized) {
 			throw new RuntimeException("FabricMixinBootstrap has already been initialized!");
 		}
+
+		System.setProperty("mixin.bootstrapService", MixinServiceKnotBootstrap.class.getName());
+		System.setProperty("mixin.service", MixinServiceKnot.class.getName());
+
+		MixinBootstrap.init();
 
 		if (FabricLauncherBase.getLauncher().isDevelopment()) {
 			MappingConfiguration mappingConfiguration = FabricLauncherBase.getLauncher().getMappingConfiguration();
@@ -74,8 +81,6 @@ public final class FabricMixinBootstrap {
 				}
 			}
 		}
-
-		MixinBootstrap.init();
 
 		Map<String, ModContainerImpl> configToModMap = new HashMap<>();
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -281,6 +282,21 @@ public final class Knot extends FabricLauncherBase {
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@Override
+	public void setValidParentClassPath(Collection<Path> paths) {
+		List<URL> urls = new ArrayList<>(paths.size());
+
+		try {
+			for (Path path : paths) {
+				urls.add(UrlUtil.asUrl(path));
+			}
+		} catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+
+		classLoader.setValidParentClassPath(urls);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -38,8 +38,6 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.spongepowered.asm.launch.MixinBootstrap;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
@@ -144,7 +142,6 @@ public final class Knot extends FabricLauncherBase {
 
 		FabricLoaderImpl.INSTANCE.loadAccessWideners();
 
-		MixinBootstrap.init();
 		FabricMixinBootstrap.init(getEnvironmentType(), loader);
 		FabricLauncherBase.finishMixinBootstrapping();
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -216,8 +215,8 @@ public final class Knot extends FabricLauncherBase {
 	 */
 	private static GameProvider findEmbedddedGameProvider() {
 		try {
-			Path flPath = UrlUtil.asPath(Knot.class.getProtectionDomain().getCodeSource().getLocation());
-			if (!flPath.getFileName().toString().endsWith(".jar")) return null; // not a jar
+			Path flPath = UrlUtil.getCodeSource(Knot.class);
+			if (flPath == null || !flPath.getFileName().toString().endsWith(".jar")) return null; // not a jar
 
 			try (ZipFile zf = new ZipFile(flPath.toFile())) {
 				ZipEntry entry = zf.getEntry("META-INF/services/net.fabricmc.loader.impl.game.GameProvider"); // same file as used by service loader
@@ -246,7 +245,7 @@ public final class Knot extends FabricLauncherBase {
 			}
 
 			return null;
-		} catch (IOException | URISyntaxException | ReflectiveOperationException e) {
+		} catch (IOException | ReflectiveOperationException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -126,11 +126,13 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 
 		synchronized (this) {
 			Set<String> urls = this.urls;
-			if (!urls.add(urlStr)) return;
+			if (urls.contains(urlStr)) return;
 
-			this.urls = new HashSet<>(urls.size() + 1);
-			this.urls.addAll(urls);
-			this.urls.add(urlStr);
+			Set<String> newUrls = new HashSet<>(urls.size() + 1, 1);
+			newUrls.addAll(urls);
+			newUrls.add(urlStr);
+
+			this.urls = newUrls;
 		}
 
 		classLoader.addUrlFwd(url);

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -27,9 +27,10 @@ import java.util.Objects;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.GameProvider;
+import net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.ClassLoaderAccess;
 
-final class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterface {
-	private static class DynamicURLClassLoader extends URLClassLoader {
+final class KnotClassLoader extends SecureClassLoader implements ClassLoaderAccess {
+	private static final class DynamicURLClassLoader extends URLClassLoader {
 		private DynamicURLClassLoader(URL[] urls) {
 			super(urls, new DummyClassLoader());
 		}
@@ -46,25 +47,17 @@ final class KnotClassLoader extends SecureClassLoader implements KnotClassLoader
 
 	private final DynamicURLClassLoader urlLoader;
 	private final ClassLoader originalLoader;
-	private final KnotClassDelegate delegate;
+	private final KnotClassDelegate<KnotClassLoader> delegate;
 
 	KnotClassLoader(boolean isDevelopment, EnvType envType, GameProvider provider) {
 		super(new DynamicURLClassLoader(new URL[0]));
 		this.originalLoader = getClass().getClassLoader();
 		this.urlLoader = (DynamicURLClassLoader) getParent();
-		this.delegate = new KnotClassDelegate(isDevelopment, envType, this, provider);
+		this.delegate = new KnotClassDelegate<>(isDevelopment, envType, this, originalLoader, provider);
 	}
 
-	@Override
-	public KnotClassDelegate getDelegate() {
+	KnotClassDelegate<?> getDelegate() {
 		return delegate;
-	}
-
-	@Override
-	public boolean isClassLoaded(String name) {
-		synchronized (getClassLoadingLock(name)) {
-			return findLoadedClass(name) != null;
-		}
 	}
 
 	@Override
@@ -148,23 +141,7 @@ final class KnotClassLoader extends SecureClassLoader implements KnotClassLoader
 
 	@Override
 	protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-		synchronized (getClassLoadingLock(name)) {
-			Class<?> c = findLoadedClass(name);
-
-			if (c == null) {
-				c = delegate.tryLoadClass(name, false);
-
-				if (c == null) {
-					c = originalLoader.loadClass(name);
-				}
-			}
-
-			if (resolve) {
-				resolveClass(c);
-			}
-
-			return c;
-		}
+		return delegate.loadClass(name, resolve);
 	}
 
 	@Override
@@ -173,54 +150,44 @@ final class KnotClassLoader extends SecureClassLoader implements KnotClassLoader
 	}
 
 	@Override
-	public Class<?> loadIntoTarget(String name) throws ClassNotFoundException {
-		synchronized (getClassLoadingLock(name)) {
-			Class<?> c = findLoadedClass(name);
-
-			if (c == null) {
-				c = delegate.tryLoadClass(name, true);
-
-				if (c == null) {
-					throw new ClassNotFoundException("can't find class "+name);
-				}
-			}
-
-			resolveClass(c);
-
-			return c;
-		}
-	}
-
-	@Override
-	public void addURL(URL url) {
+	public void addUrlFwd(URL url) {
 		urlLoader.addURL(url);
 	}
 
 	@Override
-	public InputStream getResourceAsStream(String classFile, boolean allowFromParent) throws IOException {
-		InputStream inputStream = urlLoader.getResourceAsStream(classFile);
-
-		if (inputStream == null && allowFromParent) {
-			inputStream = originalLoader.getResourceAsStream(classFile);
-		}
-
-		return inputStream;
+	public URL findResourceFwd(String name) {
+		return urlLoader.findResource(name);
 	}
 
 	@Override
-	public Package getPackage(String name) {
+	public Package getPackageFwd(String name) {
 		return super.getPackage(name);
 	}
 
 	@Override
-	public Package definePackage(String name, String specTitle, String specVersion, String specVendor,
+	public Package definePackageFwd(String name, String specTitle, String specVersion, String specVendor,
 			String implTitle, String implVersion, String implVendor, URL sealBase) throws IllegalArgumentException {
 		return super.definePackage(name, specTitle, specVersion, specVendor, implTitle, implVersion, implVendor, sealBase);
 	}
 
 	@Override
+	public Object getClassLoadingLockFwd(String name) {
+		return super.getClassLoadingLock(name);
+	}
+
+	@Override
+	public Class<?> findLoadedClassFwd(String name) {
+		return super.findLoadedClass(name);
+	}
+
+	@Override
 	public Class<?> defineClassFwd(String name, byte[] b, int off, int len, CodeSource cs) {
 		return super.defineClass(name, b, off, len, cs);
+	}
+
+	@Override
+	public void resolveClassFwd(Class<?> cls) {
+		super.resolveClass(cls);
 	}
 
 	static {

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -18,6 +18,7 @@ package net.fabricmc.loader.impl.launch.knot;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.jar.Manifest;
 
 import net.fabricmc.api.EnvType;
@@ -39,6 +40,7 @@ interface KnotClassLoaderInterface {
 
 	void addUrl(URL url);
 	void setAllowedPrefixes(URL url, String... prefixes);
+	void setValidParentClassPath(Collection<URL> urls);
 
 	Manifest getManifest(URL url);
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -17,19 +17,34 @@
 package net.fabricmc.loader.impl.launch.knot;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.security.CodeSource;
+import java.util.jar.Manifest;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.impl.game.GameProvider;
 
 interface KnotClassLoaderInterface {
-	KnotClassDelegate getDelegate();
+	@SuppressWarnings("resource")
+	static KnotClassLoaderInterface create(boolean useCompatibility, boolean isDevelopment, EnvType envType, GameProvider provider) {
+		if (useCompatibility) {
+			return new KnotCompatibilityClassLoader(isDevelopment, envType, provider).getDelegate();
+		} else {
+			return new KnotClassLoader(isDevelopment, envType, provider).getDelegate();
+		}
+	}
+
+	void initializeTransformers();
+
+	ClassLoader getClassLoader();
+
+	void addUrl(URL url);
+	void setAllowedPrefixes(URL url, String... prefixes);
+
+	Manifest getManifest(URL url);
+
 	boolean isClassLoaded(String name);
 	Class<?> loadIntoTarget(String name) throws ClassNotFoundException;
-	void addURL(URL url);
-	URL getResource(String name);
-	InputStream getResourceAsStream(String filename, boolean skipOriginalLoader) throws IOException;
 
-	Package getPackage(String name);
-	Package definePackage(String name, String specTitle, String specVersion, String specVendor, String implTitle, String implVersion, String implVendor, URL sealBase) throws IllegalArgumentException;
-	Class<?> defineClassFwd(String name, byte[] b, int off, int len, CodeSource cs);
+	byte[] getRawClassBytes(String name) throws IOException;
+	byte[] getPreMixinClassBytes(String name);
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/MixinServiceKnot.java
@@ -18,7 +18,6 @@ package net.fabricmc.loader.impl.launch.knot;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,6 +41,7 @@ import org.spongepowered.asm.service.ITransformerProvider;
 import org.spongepowered.asm.util.ReEntranceLock;
 
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
+import net.fabricmc.loader.impl.util.UrlUtil;
 
 public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBytecodeProvider, ITransformerProvider, IClassTracker {
 	static IMixinTransformer transformer;
@@ -173,11 +173,7 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 
 	@Override
 	public IContainerHandle getPrimaryContainer() {
-		try {
-			return new ContainerHandleURI(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-		} catch (URISyntaxException e) {
-			throw new RuntimeException(e);
-		}
+		return new ContainerHandleURI(UrlUtil.LOADER_CODE_SOURCE.toUri());
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/util/SimpleClassPath.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SimpleClassPath.java
@@ -1,0 +1,118 @@
+package net.fabricmc.loader.impl.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipError;
+import java.util.zip.ZipFile;
+
+public final class SimpleClassPath implements Closeable {
+	public SimpleClassPath(List<Path> paths) {
+		this.paths = paths;
+		this.jarMarkers = new boolean[paths.size()];
+		this.openJars = new ZipFile[paths.size()];
+
+		for (int i = 0; i < jarMarkers.length; i++) {
+			if (!Files.isDirectory(paths.get(i))) {
+				jarMarkers[i] = true;
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		for (int i = 0; i < openJars.length; i++) {
+			Closeable file = openJars[i];
+
+			try {
+				if (file != null) file.close();
+			} catch (IOException e) { }
+
+			openJars[i] = null;
+		}
+	}
+
+	public List<Path> getPaths() {
+		return paths;
+	}
+
+	public CpEntry getEntry(String subPath) throws IOException {
+		for (int i = 0; i < jarMarkers.length; i++) {
+			if (jarMarkers[i]) {
+				ZipFile zf = openJars[i];
+
+				if (zf == null) {
+					Path path = paths.get(i);
+
+					try {
+						openJars[i] = zf = new ZipFile(path.toFile());
+					} catch (IOException | ZipError e) {
+						throw new IOException(String.format("error opening %s: %s", path.toAbsolutePath(), e), e);
+					}
+				}
+
+				ZipEntry entry = zf.getEntry(subPath);
+
+				if (entry != null) {
+					return new CpEntry(i, subPath, entry);
+				}
+
+			} else {
+				Path file = paths.get(i).resolve(subPath);
+
+				if (Files.isRegularFile(file)) {
+					return new CpEntry(i, subPath, file);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	public InputStream getInputStream(String subPath) throws IOException {
+		CpEntry entry = getEntry(subPath);
+
+		return entry != null ? entry.getInputStream() : null;
+	}
+
+	public final class CpEntry {
+		private CpEntry(int idx, String subPath, Object instance) {
+			this.idx = idx;
+			this.subPath = subPath;
+			this.instance = instance;
+		}
+
+		public Path getOrigin() {
+			return paths.get(idx);
+		}
+
+		public String getSubPath() {
+			return subPath;
+		}
+
+		public InputStream getInputStream() throws IOException {
+			if (instance instanceof ZipEntry) {
+				return openJars[idx].getInputStream((ZipEntry) instance);
+			} else {
+				return Files.newInputStream((Path) instance);
+			}
+		}
+
+		@Override
+		public String toString() {
+			return String.format("%s:%s", getOrigin(), subPath);
+		}
+
+		private final int idx;
+		private final String subPath;
+		private final Object instance;
+	}
+
+	private final List<Path> paths;
+	private final boolean[] jarMarkers;
+	private final ZipFile[] openJars;
+}

--- a/src/main/java/net/fabricmc/loader/impl/util/SimpleClassPath.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SimpleClassPath.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.loader.impl.util;
 
 import java.io.Closeable;
@@ -24,16 +40,26 @@ public final class SimpleClassPath implements Closeable {
 	}
 
 	@Override
-	public void close() {
+	public void close() throws IOException {
+		IOException exc = null;
+
 		for (int i = 0; i < openJars.length; i++) {
 			Closeable file = openJars[i];
 
 			try {
 				if (file != null) file.close();
-			} catch (IOException e) { }
+			} catch (IOException e) {
+				if (exc == null) {
+					exc = e;
+				} else {
+					exc.addSuppressed(e);
+				}
+			}
 
 			openJars[i] = null;
 		}
+
+		if (exc != null) throw exc;
 	}
 
 	public List<Path> getPaths() {
@@ -60,7 +86,6 @@ public final class SimpleClassPath implements Closeable {
 				if (entry != null) {
 					return new CpEntry(i, subPath, entry);
 				}
-
 			} else {
 				Path file = paths.get(i).resolve(subPath);
 
@@ -113,6 +138,6 @@ public final class SimpleClassPath implements Closeable {
 	}
 
 	private final List<Path> paths;
-	private final boolean[] jarMarkers;
+	private final boolean[] jarMarkers; // whether the path is a jar (otherwise plain dir)
 	private final ZipFile[] openJars;
 }

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -22,7 +22,10 @@ public final class SystemProperties {
 	public static final String SIDE = "fabric.side";
 	// skips the embedded MC game provider, letting ServiceLoader-provided ones take over
 	public static final String SKIP_MC_PROVIDER = "fabric.skipMcProvider";
+	// game jar paths for common/client/server, replaces lookup from class path if present, env specific takes precedence
 	public static final String GAME_JAR_PATH = "fabric.gameJarPath";
+	public static final String GAME_JAR_PATH_CLIENT = "fabric.gameJarPath.client";
+	public static final String GAME_JAR_PATH_SERVER = "fabric.gameJarPath.server";
 	// set the game version for the builtin game mod/dependencies, bypassing auto-detection
 	public static final String GAME_VERSION = "fabric.gameVersion";
 	// fallback log file for the builtin log handler (dumped on exit if not replaced with another handler)

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -40,8 +40,12 @@ public final class SystemProperties {
 	public static final String PATH_GROUPS = "fabric.classPathGroups";
 	// throw exceptions from entrypoints, discovery etc. directly instead of gathering and attaching as suppressed
 	public static final String DEBUG_THROW_DIRECTLY = "fabric.debug.throwDirectly";
+	// logs class loading errors to uncover caught exceptions without adequate logging
+	public static final String DEBUG_LOG_CLASS_LOAD_ERRORS = "fabric.debug.logClassLoadErrors";
 	// logs class transformation errors to uncover caught exceptions without adequate logging
 	public static final String DEBUG_LOG_TRANSFORM_ERRORS = "fabric.debug.logTransformErrors";
+	// disables system class path isolation, allowing bogus lib accesses (too early, transient jars)
+	public static final String DEBUG_DISABLE_CLASS_PATH_ISOLATION = "fabric.debug.disableClassPathIsolation";
 	// disables mod load order shuffling to be the same in-dev as in production
 	public static final String DEBUG_DISABLE_MOD_SHUFFLE = "fabric.debug.disableModShuffle";
 	// workaround for bad load order dependencies

--- a/src/main/java/net/fabricmc/loader/impl/util/UrlUtil.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/UrlUtil.java
@@ -24,9 +24,10 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.CodeSource;
 
 public final class UrlUtil {
-	private UrlUtil() { }
+	public static final Path LOADER_CODE_SOURCE = getCodeSource(UrlUtil.class);
 
 	public static URL getSource(String filename, URL resourceURL) throws UrlConversionException {
 		URL codeSourceURL;
@@ -70,5 +71,16 @@ public final class UrlUtil {
 
 	public static URL asUrl(Path path) throws MalformedURLException {
 		return path.toUri().toURL();
+	}
+
+	public static Path getCodeSource(Class<?> cls) {
+		CodeSource cs = cls.getProtectionDomain().getCodeSource();
+		if (cs == null) return null;
+
+		try {
+			return asPath(cs.getLocation());
+		} catch (URISyntaxException e) {
+			throw ExceptionUtil.wrap(e);
+		}
 	}
 }

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -9,7 +9,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:sponge-mixin:0.11.2+mixin.0.8.5",
+        "name": "net.fabricmc:sponge-mixin:0.11.3+mixin.0.8.5",
         "url": "https://maven.fabricmc.net/"
       },
       {

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -12,7 +12,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:sponge-mixin:0.11.2+mixin.0.8.5",
+        "name": "net.fabricmc:sponge-mixin:0.11.3+mixin.0.8.5",
         "url": "https://maven.fabricmc.net/"
       },
       {


### PR DESCRIPTION
With this PR Loader should achieve proper isolation between the system/app class loader and the transforming class loader, hopefully eliminating remaining shadowing issues outside rather intentional misbehavior. All game and mod content is supposed to be on the transforming class loader, only Loader and its core libs should be loaded from the app CL.

A side effect of this effort is that the entire game including libraries becomes exposed to Mixin and other bytecode editing. This allows more direct patching of something like the Log4J issue in the future.

LibClassifier has been refactored to become usable by 3rd party game providers.

Mod class path handling still needs to be finalized.