### PR TITLE
Add support for pre 1.6 arguments

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletFrame.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletFrame.java
@@ -73,6 +73,9 @@ public class AppletFrame extends Frame implements WindowListener {
 
 		if (arguments.containsKey("session") /* 1.6 */) {
 			sessionid = arguments.get("session");
+		} else if (arguments.getExtraArgs().size() == 2 /* pre 1.6 */) {
+			username = arguments.getExtraArgs().get(0);
+			sessionid = arguments.getExtraArgs().get(1);
 		} else /* fallback */ {
 			sessionid = "";
 		}


### PR DESCRIPTION
Versions before [1.6](https://launchermeta.mojang.com/v1/packages/20116297638f7c70cd046e25a6ac90fee4cae61a/1.6.json) like [1.5](https://launchermeta.mojang.com/v1/packages/924a2dcd8bdc31f8e9d36229811c298b3537bbc7/1.5.2.json) and [b1.7.3](https://launchermeta.mojang.com/v1/packages/44f6969326bd45aa00dcd3c4ca3a7c05ebb24c04/b1.7.3.json) lack `--username` and `--session`, instead they pass them directly

1.6
```json
"minecraftArguments": "--username ${auth_player_name} --session ${auth_session} --version ${version_name} --gameDir ${game_directory} --assetsDir ${game_assets}",
```

pre 1.6
```json
"minecraftArguments": "${auth_player_name} ${auth_session} --gameDir ${game_directory} --assetsDir ${game_assets}"
```