### PR TITLE
Delay log output until it can be displayed properly, except when errors occur

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Log4jLogHandler.java
@@ -46,8 +46,8 @@ public final class Log4jLogHandler implements LogHandler {
 	}
 
 	@Override
-	public void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean isReplayedBuiltin) {
-		// TODO: suppress console log output if isReplayedBuiltin is true to avoid duplicate output
+	public void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean fromReplay, boolean wasSuppressed) {
+		// TODO: suppress console log output if wasSuppressed is false to avoid duplicate output
 		getLogger(category).log(translateLogLevel(level), msg, exc);
 	}
 

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -192,6 +192,8 @@ public class MinecraftGameProvider implements GameProvider {
 			envGameJar = classifier.getOrigin(envGameLib);
 			if (envGameJar == null) return false;
 
+			Log.enableBuiltinHandlerBuffering(true);
+
 			commonGameJar = classifier.getOrigin(McLibrary.MC_COMMON);
 
 			if (commonGameJarDeclared && commonGameJar == null) {
@@ -360,7 +362,7 @@ public class MinecraftGameProvider implements GameProvider {
 				logHandlerCls = Class.forName(logHandlerClsName);
 			}
 
-			Log.init((LogHandler) logHandlerCls.getConstructor().newInstance(), true);
+			Log.init((LogHandler) logHandlerCls.getConstructor().newInstance());
 			Thread.currentThread().setContextClassLoader(prevCl);
 		} catch (ReflectiveOperationException e) {
 			throw new RuntimeException(e);

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Slf4jLogHandler.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/Slf4jLogHandler.java
@@ -41,7 +41,7 @@ public final class Slf4jLogHandler implements LogHandler {
 	}
 
 	@Override
-	public void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean isReplayedBuiltin) {
+	public void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean fromReplay, boolean wasSuppressed) {
 		Logger logger = getLogger(category);
 
 		if (msg == null) {

--- a/src/main/java/net/fabricmc/loader/impl/util/log/ConsoleLogHandler.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/log/ConsoleLogHandler.java
@@ -24,7 +24,7 @@ public class ConsoleLogHandler implements LogHandler {
 	private static final LogLevel MIN_STDOUT_LEVEL = LogLevel.getDefault();
 
 	@Override
-	public void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean isRelayedBuiltin) {
+	public void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean fromReplay, boolean wasSuppressed) {
 		String formatted = formatLog(time, level, category, msg, exc);
 
 		if (level.isLessThan(MIN_STDERR_LEVEL)) {

--- a/src/main/java/net/fabricmc/loader/impl/util/log/Log.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/log/Log.java
@@ -25,17 +25,30 @@ public final class Log {
 
 	private static LogHandler handler = new BuiltinLogHandler();
 
-	public static void init(LogHandler handler, boolean replayBuiltin) {
+	public static void init(LogHandler handler) {
 		if (handler == null) throw new NullPointerException("null log handler");
 
-		LogHandler oldhHandler = Log.handler;
+		LogHandler oldHandler = Log.handler;
 
-		if (oldhHandler instanceof BuiltinLogHandler && replayBuiltin) {
-			((BuiltinLogHandler) oldhHandler).replay(handler);
+		if (oldHandler instanceof BuiltinLogHandler) {
+			((BuiltinLogHandler) oldHandler).replay(handler);
 		}
 
 		Log.handler = handler;
-		oldhHandler.close();
+		oldHandler.close();
+	}
+
+	/**
+	 * Enable buffering builtin log output instead of emitting it.
+	 *
+	 * @param suppressOutput whether to suppress builtin log output until an ERROR-level log arrives
+	 */
+	public static void enableBuiltinHandlerBuffering(boolean suppressOutput) {
+		LogHandler handler = Log.handler;
+
+		if (handler instanceof BuiltinLogHandler) {
+			((BuiltinLogHandler) handler).enableBuffering(suppressOutput);
+		}
 	}
 
 	public static void error(LogCategory category, String format, Object... args) {
@@ -191,7 +204,7 @@ public final class Log {
 	}
 
 	private static void log(LogHandler handler, LogLevel level, LogCategory category, String msg, Throwable exc) {
-		handler.log(System.currentTimeMillis(), level, category, msg.trim(), exc, false);
+		handler.log(System.currentTimeMillis(), level, category, msg.trim(), exc, false, false);
 	}
 
 	public static boolean shouldLog(LogLevel level, LogCategory category) {

--- a/src/main/java/net/fabricmc/loader/impl/util/log/LogHandler.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/log/LogHandler.java
@@ -17,7 +17,7 @@
 package net.fabricmc.loader.impl.util.log;
 
 public interface LogHandler {
-	void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean isReplayedBuiltin);
+	void log(long time, LogLevel level, LogCategory category, String msg, Throwable exc, boolean fromReplay, boolean wasSuppressed);
 	boolean shouldLog(LogLevel level, LogCategory category);
 	void close();
 }


### PR DESCRIPTION
This avoids printing early log output twice in benign scenarios. IMO it is the best approach to cover the gap between early logging needs and Log4J or any other game-provided logging lib being ready. The feature is opt-in from the game provider, the MC one enables it.