### PR TITLE
Always fall back to lexicographical comparison when StringVersion is involved, always show non-semver warning

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/metadata/MetadataVerifier.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/MetadataVerifier.java
@@ -63,22 +63,22 @@ public final class MetadataVerifier {
 			if (metadata.getSchemaVersion() < ModMetadataParser.LATEST_VERSION) {
 				Log.warn(LogCategory.METADATA, "Mod %s uses an outdated schema version: %d < %d", metadata.getId(), metadata.getSchemaVersion(), ModMetadataParser.LATEST_VERSION);
 			}
+		}
 
-			if (!(metadata.getVersion() instanceof SemanticVersion)) {
-				String version = metadata.getVersion().getFriendlyString();
-				VersionParsingException exc;
+		if (!(metadata.getVersion() instanceof SemanticVersion)) {
+			String version = metadata.getVersion().getFriendlyString();
+			VersionParsingException exc;
 
-				try {
-					SemanticVersion.parse(version);
-					exc = null;
-				} catch (VersionParsingException e) {
-					exc = e;
-				}
+			try {
+				SemanticVersion.parse(version);
+				exc = null;
+			} catch (VersionParsingException e) {
+				exc = e;
+			}
 
-				if (exc != null) {
-					Log.warn(LogCategory.METADATA, "Mod %s uses the version %s which isn't compatible with Loader's extended semantic version format (%s), SemVer is recommended for reliable dependency comparisons",
-							metadata.getId(), version, exc.getMessage());
-				}
+			if (exc != null) {
+				Log.warn(LogCategory.METADATA, "Mod %s uses the version %s which isn't compatible with Loader's extended semantic version format (%s), SemVer is recommended for reliably evaluating dependencies and prioritizing newer version",
+						metadata.getId(), version, exc.getMessage());
 			}
 
 			metadata.emitFormatWarnings();

--- a/src/main/java/net/fabricmc/loader/impl/util/version/SemanticVersionImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/SemanticVersionImpl.java
@@ -252,7 +252,7 @@ public class SemanticVersionImpl extends net.fabricmc.loader.util.version.Semant
 	@Override
 	public int compareTo(Version other) {
 		if (!(other instanceof SemanticVersion)) {
-			return 1;
+			return getFriendlyString().compareTo(other.getFriendlyString());
 		}
 
 		SemanticVersion o = (SemanticVersion) other;

--- a/src/main/java/net/fabricmc/loader/impl/util/version/StringVersion.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/StringVersion.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.loader.impl.util.version;
 
-import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.Version;
 
 public class StringVersion implements Version {
@@ -42,10 +41,6 @@ public class StringVersion implements Version {
 
 	@Override
 	public int compareTo(Version o) {
-		if (o instanceof SemanticVersion) {
-			return -1;
-		}
-
 		return getFriendlyString().compareTo(o.getFriendlyString());
 	}
 


### PR DESCRIPTION
This should resolve some inconsistencies and make it easier to find related issues that aren't observable in-dev, but get introduced by the build.