### PR TITLE
Fix server launchers leaking their class path to knot CL, move to Path completely

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -192,7 +192,7 @@ public class MinecraftGameProvider implements GameProvider {
 			envGameJar = classifier.getOrigin(envGameLib);
 			if (envGameJar == null) return false;
 
-			Log.enableBuiltinHandlerBuffering(true);
+			Log.configureBuiltin(true, false);
 
 			commonGameJar = classifier.getOrigin(McLibrary.MC_COMMON);
 

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -140,6 +140,8 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 			throw new RuntimeException("Could not locate Minecraft: provider locate failed");
 		}
 
+		Log.finishBuiltinConfig();
+
 		arguments = null;
 
 		provider.initialize(this);

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -58,6 +58,7 @@ import net.fabricmc.loader.impl.metadata.EntrypointMetadata;
 import net.fabricmc.loader.impl.metadata.LoaderModMetadata;
 import net.fabricmc.loader.impl.metadata.VersionOverrides;
 import net.fabricmc.loader.impl.util.DefaultLanguageAdapter;
+import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
@@ -532,5 +533,9 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 			return instance;
 		}
+	}
+
+	static {
+		LoaderUtil.verifyNotInTargetCl(FabricLoaderImpl.class);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
@@ -52,7 +52,7 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 					URL url = mods.nextElement();
 
 					try {
-						Path path = UrlUtil.getSourcePath("fabric.mod.json", url).toAbsolutePath().normalize();
+						Path path = UrlUtil.getCodeSource(url, "fabric.mod.json").toAbsolutePath().normalize();
 						List<Path> paths = pathGroups.get(path);
 
 						if (paths == null) {

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -79,7 +79,7 @@ public final class GameProviderHelper {
 
 		if ((url = loader.getResource(filename)) != null) {
 			try {
-				return Optional.of(UrlUtil.getSourcePath(filename, url));
+				return Optional.of(UrlUtil.getCodeSource(url, filename));
 			} catch (UrlConversionException e) {
 				// TODO: Point to a logger
 				e.printStackTrace();
@@ -98,7 +98,7 @@ public final class GameProviderHelper {
 				URL url = urls.nextElement();
 
 				try {
-					paths.add(UrlUtil.getSourcePath(filename, url));
+					paths.add(UrlUtil.getCodeSource(url, filename));
 				} catch (UrlConversionException e) {
 					// TODO: Point to a logger
 					e.printStackTrace();

--- a/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/LoaderLibrary.java
@@ -69,7 +69,7 @@ enum LoaderLibrary {
 		URL url = LoaderLibrary.class.getClassLoader().getResource(file);
 
 		try {
-			this.path = url != null ? UrlUtil.getSourcePath(file, url) : null;
+			this.path = url != null ? UrlUtil.getCodeSource(url, file) : null;
 			this.env = env;
 		} catch (UrlConversionException e) {
 			throw new RuntimeException(e);

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -119,6 +119,7 @@ public final class Knot extends FabricLauncherBase {
 		}
 
 		provider = createGameProvider(args);
+		Log.dropUnusedBuiltinReplayBuffer();
 		Log.info(LogCategory.GAME_PROVIDER, "Loading %s %s with Fabric Loader %s", provider.getGameName(), provider.getRawGameVersion(), FabricLoaderImpl.VERSION);
 
 		isDevelopment = Boolean.parseBoolean(System.getProperty(SystemProperties.DEVELOPMENT, "false"));

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -44,6 +44,7 @@ import net.fabricmc.loader.impl.entrypoint.EntrypointUtils;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.FabricMixinBootstrap;
+import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.UrlUtil;
 import net.fabricmc.loader.impl.util.log.Log;
@@ -306,7 +307,9 @@ public final class Knot extends FabricLauncherBase {
 
 	@Override
 	public ClassLoader getTargetClassLoader() {
-		return classLoader.getClassLoader();
+		KnotClassLoaderInterface classLoader = this.classLoader;
+
+		return classLoader != null ? classLoader.getClassLoader() : null;
 	}
 
 	@Override
@@ -337,5 +340,9 @@ public final class Knot extends FabricLauncherBase {
 
 	public static void main(String[] args) {
 		new Knot(null).init(args);
+	}
+
+	static {
+		LoaderUtil.verifyNotInTargetCl(Knot.class);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -19,8 +19,6 @@ package net.fabricmc.loader.impl.launch.knot;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -263,37 +261,18 @@ public final class Knot extends FabricLauncherBase {
 	public void addToClassPath(Path path, String... allowedPrefixes) {
 		Log.debug(LogCategory.KNOT, "Adding " + path + " to classpath.");
 
-		try {
-			URL url = UrlUtil.asUrl(path);
-			classLoader.setAllowedPrefixes(url, allowedPrefixes);
-			classLoader.addUrl(url);
-		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		}
+		classLoader.setAllowedPrefixes(path, allowedPrefixes);
+		classLoader.addCodeSource(path);
 	}
 
 	@Override
 	public void setAllowedPrefixes(Path path, String... prefixes) {
-		try {
-			classLoader.setAllowedPrefixes(UrlUtil.asUrl(path), prefixes);
-		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		}
+		classLoader.setAllowedPrefixes(path, prefixes);
 	}
 
 	@Override
 	public void setValidParentClassPath(Collection<Path> paths) {
-		List<URL> urls = new ArrayList<>(paths.size());
-
-		try {
-			for (Path path : paths) {
-				urls.add(UrlUtil.asUrl(path));
-			}
-		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		}
-
-		classLoader.setValidParentClassPath(urls);
+		classLoader.setValidParentClassPath(paths);
 	}
 
 	@Override
@@ -334,11 +313,7 @@ public final class Knot extends FabricLauncherBase {
 
 	@Override
 	public Manifest getManifest(Path originPath) {
-		try {
-			return classLoader.getManifest(UrlUtil.asUrl(originPath));
-		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		}
+		return classLoader.getManifest(originPath);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -29,6 +29,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.ClassLoaderAccess;
 
+// class name referenced by string constant in net.fabricmc.loader.impl.util.LoaderUtil.verifyNotInTargetCl
 final class KnotClassLoader extends SecureClassLoader implements ClassLoaderAccess {
 	private static final class DynamicURLClassLoader extends URLClassLoader {
 		private DynamicURLClassLoader(URL[] urls) {

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -17,7 +17,7 @@
 package net.fabricmc.loader.impl.launch.knot;
 
 import java.io.IOException;
-import java.net.URL;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.jar.Manifest;
 
@@ -38,11 +38,11 @@ interface KnotClassLoaderInterface {
 
 	ClassLoader getClassLoader();
 
-	void addUrl(URL url);
-	void setAllowedPrefixes(URL url, String... prefixes);
-	void setValidParentClassPath(Collection<URL> urls);
+	void addCodeSource(Path path);
+	void setAllowedPrefixes(Path codeSource, String... prefixes);
+	void setValidParentClassPath(Collection<Path> codeSources);
 
-	Manifest getManifest(URL url);
+	Manifest getManifest(Path codeSource);
 
 	boolean isClassLoaded(String name);
 	Class<?> loadIntoTarget(String name) throws ClassNotFoundException;

--- a/src/main/java/net/fabricmc/loader/impl/util/LoaderUtil.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/LoaderUtil.java
@@ -23,6 +23,15 @@ public final class LoaderUtil {
 		return className.replace('.', '/').concat(".class");
 	}
 
+	public static void verifyNotInTargetCl(Class<?> cls) {
+		if (cls.getClassLoader().getClass().getName().equals("net.fabricmc.loader.impl.launch.knot.KnotClassLoader")) {
+			// This usually happens when fabric loader has been added to the target class loader. This is a bad state.
+			// Such additions may be indirect, a JAR can use the Class-Path manifest attribute to drag additional
+			// libraries with it, likely recursively.
+			throw new IllegalStateException("trying to load "+cls.getName()+" from target class loader");
+		}
+	}
+
 	public static boolean hasMacOs() {
 		return System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("mac");
 	}

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -40,6 +40,10 @@ public final class SystemProperties {
 	public static final String PATH_GROUPS = "fabric.classPathGroups";
 	// throw exceptions from entrypoints, discovery etc. directly instead of gathering and attaching as suppressed
 	public static final String DEBUG_THROW_DIRECTLY = "fabric.debug.throwDirectly";
+	// logs library classification activity
+	public static final String DEBUG_LOG_LIB_CLASSIFICATION = "fabric.debug.logLibClassification";
+	// logs class loading
+	public static final String DEBUG_LOG_CLASS_LOAD = "fabric.debug.logClassLoad";
 	// logs class loading errors to uncover caught exceptions without adequate logging
 	public static final String DEBUG_LOG_CLASS_LOAD_ERRORS = "fabric.debug.logClassLoadErrors";
 	// logs class transformation errors to uncover caught exceptions without adequate logging

--- a/src/main/java/net/fabricmc/loader/impl/util/UrlUtil.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/UrlUtil.java
@@ -19,7 +19,6 @@ package net.fabricmc.loader.impl.util;
 import java.io.File;
 import java.net.JarURLConnection;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -30,19 +29,19 @@ import java.security.CodeSource;
 public final class UrlUtil {
 	public static final Path LOADER_CODE_SOURCE = getCodeSource(UrlUtil.class);
 
-	public static URI getSource(String filename, URL resourceURL) throws UrlConversionException {
+	public static Path getCodeSource(URL url, String localPath) throws UrlConversionException {
 		try {
-			URLConnection connection = resourceURL.openConnection();
+			URLConnection connection = url.openConnection();
 
 			if (connection instanceof JarURLConnection) {
-				return asUri(((JarURLConnection) connection).getJarFileURL());
+				return asPath(((JarURLConnection) connection).getJarFileURL());
 			} else {
-				String path = resourceURL.getPath();
+				String path = url.getPath();
 
-				if (path.endsWith(filename)) {
-					return asUri(new URL(resourceURL.getProtocol(), resourceURL.getHost(), resourceURL.getPort(), path.substring(0, path.length() - filename.length())));
+				if (path.endsWith(localPath)) {
+					return asPath(new URL(url.getProtocol(), url.getHost(), url.getPort(), path.substring(0, path.length() - localPath.length())));
 				} else {
-					throw new UrlConversionException("Could not figure out code source for file '" + filename + "' and URL '" + resourceURL + "'!");
+					throw new UrlConversionException("Could not figure out code source for file '" + localPath + "' in URL '" + url + "'!");
 				}
 			}
 		} catch (Exception e) {
@@ -50,20 +49,8 @@ public final class UrlUtil {
 		}
 	}
 
-	public static Path getSourcePath(String filename, URL resourceURL) throws UrlConversionException {
-		try {
-			return asPath(getSource(filename, resourceURL));
-		} catch (URISyntaxException e) {
-			throw new UrlConversionException(e);
-		}
-	}
-
-	public static Path asPath(URI uri) throws URISyntaxException {
-		return Paths.get(uri);
-	}
-
 	public static Path asPath(URL url) throws URISyntaxException {
-		return asPath(url.toURI());
+		return Paths.get(url.toURI());
 	}
 
 	public static URL asUrl(File file) throws MalformedURLException {
@@ -72,22 +59,6 @@ public final class UrlUtil {
 
 	public static URL asUrl(Path path) throws MalformedURLException {
 		return path.toUri().toURL();
-	}
-
-	public static URL asUrl(URI uri) {
-		try {
-			return uri.toURL();
-		} catch (MalformedURLException e) {
-			throw new IllegalArgumentException(e);
-		}
-	}
-
-	public static URI asUri(URL url) {
-		try {
-			return url.toURI();
-		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException(e);
-		}
 	}
 
 	public static Path getCodeSource(Class<?> cls) {

--- a/src/main/java/net/fabricmc/loader/impl/util/log/BuiltinLogHandler.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/log/BuiltinLogHandler.java
@@ -146,7 +146,7 @@ final class BuiltinLogHandler extends ConsoleLogHandler {
 					Path file = Paths.get(fileName).toAbsolutePath().normalize();
 					Files.createDirectories(file.getParent());
 
-					try (Writer writer = Files.newBufferedWriter(file, StandardOpenOption.WRITE, StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
+					try (Writer writer = Files.newBufferedWriter(file, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)) {
 						for (int i = 0; i < buffer.size(); i++) { // index based loop to tolerate replay producing log output by itself
 							ReplayEntry entry = buffer.get(i);
 							writer.write(formatLog(entry.time, entry.level, entry.category, entry.msg, entry.exc));

--- a/src/main/java/net/fabricmc/loader/impl/util/log/Log.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/log/Log.java
@@ -39,15 +39,27 @@ public final class Log {
 	}
 
 	/**
-	 * Enable buffering builtin log output instead of emitting it.
+	 * Configure builtin log handler.
 	 *
-	 * @param suppressOutput whether to suppress builtin log output until an ERROR-level log arrives
+	 * @param buffer whether to buffer log messages for later replaying
+	 * @param output whether to output log messages directly
 	 */
-	public static void enableBuiltinHandlerBuffering(boolean suppressOutput) {
+	public static void configureBuiltin(boolean buffer, boolean output) {
 		LogHandler handler = Log.handler;
 
 		if (handler instanceof BuiltinLogHandler) {
-			((BuiltinLogHandler) handler).enableBuffering(suppressOutput);
+			((BuiltinLogHandler) handler).configure(buffer, output);
+		}
+	}
+
+	/**
+	 * Finish configuring builtin log handler, using defaults if unconfigured.
+	 */
+	public static void finishBuiltinConfig() {
+		LogHandler handler = Log.handler;
+
+		if (handler instanceof BuiltinLogHandler) {
+			((BuiltinLogHandler) handler).finishConfig();
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/util/log/LogCategory.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/log/LogCategory.java
@@ -24,6 +24,7 @@ public final class LogCategory {
 	public static final LogCategory GAME_REMAP = new LogCategory("GameRemap");
 	public static final LogCategory GENERAL = new LogCategory();
 	public static final LogCategory KNOT = new LogCategory("Knot");
+	public static final LogCategory LIB_CLASSIFICATION = new LogCategory("LibClassify");
 	public static final LogCategory LOG = new LogCategory("Log");
 	public static final LogCategory MAPPINGS = new LogCategory("Mappings");
 	public static final LogCategory METADATA = new LogCategory("Metadata");


### PR DESCRIPTION
The server launchers were seen as game libraries, thus getting added to knot including the Loader libraries -> Loader existed on both class loaders.

This also adds some additional debugging tools.