### PR TITLE
Start the game using MethodHandles

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -451,7 +451,7 @@ public class MinecraftGameProvider implements GameProvider {
 
 		try {
 			Class<?> c = loader.loadClass(targetClass);
-			invoker = MethodHandles.lookup().findStatic(c, "main", MethodType.methodType(Void.TYPE, String[].class));
+			invoker = MethodHandles.lookup().findStatic(c, "main", MethodType.methodType(void.class, String[].class));
 		} catch (NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
 			throw new FormattedException("Failed to start Minecraft", e);
 		}

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -17,8 +17,9 @@
 package net.fabricmc.loader.impl.game.minecraft;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -446,14 +447,19 @@ public class MinecraftGameProvider implements GameProvider {
 			targetClass = "net.fabricmc.loader.impl.game.minecraft.applet.AppletMain";
 		}
 
+		MethodHandle invoker;
+
 		try {
 			Class<?> c = loader.loadClass(targetClass);
-			Method m = c.getMethod("main", String[].class);
-			m.invoke(null, (Object) arguments.toArray());
-		} catch (InvocationTargetException e) {
-			throw new FormattedException("Minecraft has crashed!", e.getCause());
-		} catch (ReflectiveOperationException e) {
+			invoker = MethodHandles.lookup().findStatic(c, "main", MethodType.methodType(Void.TYPE, String[].class));
+		} catch (NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
 			throw new FormattedException("Failed to start Minecraft", e);
+		}
+
+		try {
+			invoker.invokeExact(arguments.toArray());
+		} catch (Throwable t) {
+			throw new FormattedException("Minecraft has crashed!", t);
 		}
 	}
 }

--- a/proguard.conf
+++ b/proguard.conf
@@ -4,6 +4,7 @@
 -dontoptimize
 -keepparameternames
 -keepattributes *
+-dontwarn java.lang.invoke.MethodHandle
 
 -keep class !net.fabricmc.loader.impl.lib.** {
     *;

--- a/src/main/java/net/fabricmc/loader/impl/launch/server/FabricServerLauncher.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/server/FabricServerLauncher.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -64,8 +66,8 @@ public class FabricServerLauncher {
 
 		try {
 			Class<?> c = Class.forName(mainClass);
-			c.getMethod("main", String[].class).invoke(null, (Object) args);
-		} catch (Exception e) {
+			MethodHandles.lookup().findStatic(c, "main", MethodType.methodType(Void.TYPE, String[].class)).invokeExact(args);
+		} catch (Throwable e) {
 			throw new RuntimeException("An exception occurred when launching the server!", e);
 		}
 	}

--- a/src/main/java/net/fabricmc/loader/impl/launch/server/FabricServerLauncher.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/server/FabricServerLauncher.java
@@ -66,7 +66,7 @@ public class FabricServerLauncher {
 
 		try {
 			Class<?> c = Class.forName(mainClass);
-			MethodHandles.lookup().findStatic(c, "main", MethodType.methodType(Void.TYPE, String[].class)).invokeExact(args);
+			MethodHandles.lookup().findStatic(c, "main", MethodType.methodType(void.class, String[].class)).invokeExact(args);
 		} catch (Throwable e) {
 			throw new RuntimeException("An exception occurred when launching the server!", e);
 		}


### PR DESCRIPTION
Resolves #665.

This PR makes Loader call the game's `main` method by using a MethodHandle instead of reflection. Doing this leaves no frames in the stack about the reflected invocation. It also changes the call to Knot in FabricServerLauncher to do the same.

Given proguard doesn't support polymorphism, this PR also adds a `dontwarn` directive to the proguard config to prevent it from complaining about it, as suggested in [this proguard issue](https://sourceforge.net/p/proguard/bugs/536/).

Tested using the installer's thing for using a custom loader JAR under 1.18.2 with no issues and with something weird that got `FabricServerLauncher#main` to run in debug that logged errors everywhere but launched a server. Are there instructions in how to properly debug loader?