### PR TITLE
feat: add ability to customize fabric directories

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -128,7 +129,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 	private void setGameDir(Path gameDir) {
 		this.gameDir = gameDir;
-		this.configDir = gameDir.resolve("config");
+		this.configDir = this.resolveFabricDirectory("config");
 	}
 
 	@Override
@@ -194,6 +195,12 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		}
 	}
 
+	private Path resolveFabricDirectory(String directoryName) {
+		String propertyName = "fabric.dir." + directoryName;
+		Path directory = Paths.get(System.getProperty(propertyName, directoryName));
+		return directory.isAbsolute() ? directory : getGameDir().resolve(directory);
+	}
+
 	private void setup() throws ModResolutionException {
 		boolean remapRegularMods = isDevelopmentEnvironment();
 		VersionOverrides versionOverrides = new VersionOverrides();
@@ -203,7 +210,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		ModDiscoverer discoverer = new ModDiscoverer(versionOverrides, depOverrides);
 		discoverer.addCandidateFinder(new ClasspathModCandidateFinder());
-		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(gameDir.resolve("mods"), remapRegularMods));
+		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(resolveFabricDirectory("mods"), remapRegularMods));
 		discoverer.addCandidateFinder(new ArgumentModCandidateFinder(remapRegularMods));
 
 		Map<String, Set<ModCandidate>> envDisabledMods = new HashMap<>();


### PR DESCRIPTION
Adds the ability to customize the `mods` and `config` directories via the `fabric.dir.mods` and `fabric.dir.config` Java properties. This can allow for different launcher profiles to have different mod directories so users don't need to install third party launchers to fix conflicting mods or config directories while keeping all of their settings, screenshots, and other preferences the same.

This is very similar to the functionality landed in #470 and the proposed changes in #512 so this might be unnecessary, but addresses the issue of potential breaking changes in configs between mod versions.