### PR TITLE
Ignore class path group entries not on the class path

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -54,6 +54,7 @@ import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.FabricMixinBootstrap;
 import net.fabricmc.loader.impl.util.Arguments;
 import net.fabricmc.loader.impl.util.FileSystemUtil;
+import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.ManifestUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.UrlUtil;
@@ -125,7 +126,10 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		classPath.clear();
 
 		for (URL url : launchClassLoader.getSources()) {
-			classPath.add(UrlUtil.asPath(url));
+			Path path = UrlUtil.asPath(url);
+			if (!Files.exists(path)) continue;
+
+			classPath.add(LoaderUtil.normalizeExistingPath(path));
 		}
 
 		GameProvider provider = new MinecraftGameProvider();

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
@@ -99,7 +99,7 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 				Path resolvedPath = Paths.get(path);
 
 				if (!Files.exists(resolvedPath)) {
-					Log.warn(LogCategory.DISCOVERY, "Skipping missing class path group entry %s", path);
+					Log.debug(LogCategory.DISCOVERY, "Skipping missing class path group entry %s", path);
 					continue;
 				}
 
@@ -111,7 +111,7 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 			}
 
 			if (paths.size() < 2) {
-				Log.warn(LogCategory.DISCOVERY, "Skipping class path group with no effect: %s", group);
+				Log.debug(LogCategory.DISCOVERY, "Skipping class path group with no effect: %s", group);
 				continue;
 			}
 

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -86,6 +87,7 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 		String prop = System.getProperty(SystemProperties.PATH_GROUPS);
 		if (prop == null) return Collections.emptyMap();
 
+		Set<Path> cp = new HashSet<>(FabricLauncherBase.getLauncher().getClassPath());
 		Map<Path, List<Path>> ret = new HashMap<>();
 
 		for (String group : prop.split(File.pathSeparator+File.pathSeparator)) {
@@ -101,7 +103,11 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 					continue;
 				}
 
-				paths.add(LoaderUtil.normalizeExistingPath(resolvedPath));
+				resolvedPath = LoaderUtil.normalizeExistingPath(resolvedPath);
+
+				if (cp.contains(resolvedPath)) {
+					paths.add(resolvedPath);
+				}
 			}
 
 			if (paths.size() < 2) {

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -121,7 +121,7 @@ public final class Knot extends FabricLauncherBase {
 				continue;
 			}
 
-			classPath.add(path);
+			classPath.add(LoaderUtil.normalizeExistingPath(path));
 		}
 
 		if (unsupported != null) Log.warn(LogCategory.KNOT, "Knot does not support wildcard class path entries: %s - the game may not load properly!", String.join(", ", unsupported));


### PR DESCRIPTION
This avoids accidentally pulling in additional code sources, which isn't intended for the cp group feature.