### PR TITLE
Fix realms library detection

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -24,7 +24,7 @@ enum McLibrary implements LibraryType {
 	MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
 	MC_COMMON("net/minecraft/server/MinecraftServer.class"),
 	MC_BUNDLER(EnvType.SERVER, "net/minecraft/bundler/Main.class"),
-	REALMS(EnvType.CLIENT, "realmsVersion"),
+	REALMS(EnvType.CLIENT, "realmsVersion", "com/mojang/realmsclient/RealmsVersion.class"),
 	MODLOADER("ModLoader"),
 	LOG4J_API("org/apache/logging/log4j/LogManager.class"),
 	LOG4J_CORE("META-INF/services/org.apache.logging.log4j.spi.Provider", "META-INF/log4j-provider.properties"),


### PR DESCRIPTION
It should fix remapping issues in pre-1.13 which didn't ship realms classes directly in minecraft jar but as an external library.
Example of crash reports related to the remapping issue: https://paste.ee/p/Hy2wW