### PR TITLE
Allow array of strings for environment in metadata

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -51,6 +51,7 @@ import net.fabricmc.loader.impl.discovery.ModResolver;
 import net.fabricmc.loader.impl.discovery.RuntimeModRemapper;
 import net.fabricmc.loader.impl.entrypoint.EntrypointStorage;
 import net.fabricmc.loader.impl.game.GameProvider;
+import net.fabricmc.loader.impl.launch.FabricLauncher;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.knot.Knot;
 import net.fabricmc.loader.impl.metadata.DependencyOverrides;
@@ -373,7 +374,13 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 	@Override
 	public boolean isDevelopmentEnvironment() {
-		return FabricLauncherBase.getLauncher().isDevelopment();
+		FabricLauncher launcher = FabricLauncherBase.getLauncher();
+
+		if (launcher != null) {
+			return launcher.isDevelopment();
+		} else {
+			return true;
+		}
 	}
 
 	private void addMod(ModCandidate candidate) throws ModResolutionException {

--- a/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
+++ b/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
 import net.fabricmc.loader.impl.metadata.DependencyOverrides;
 import net.fabricmc.loader.impl.metadata.LoaderModMetadata;
 import net.fabricmc.loader.impl.metadata.ModMetadataParser;
@@ -156,6 +157,14 @@ final class V1ModJsonParsingTests {
 		if (modMetadata.getDependencies().isEmpty()) {
 			throw new RuntimeException("Incorrect amount of dependencies");
 		}
+	}
+
+	@Test
+	@DisplayName("Environment array")
+	public void testEnvironmentArray() throws IOException, ParseMetadataException {
+		final LoaderModMetadata modMetadata = parseMetadata(specPath.resolve("environment_array.json"));
+
+		assertEquals(ModEnvironment.UNIVERSAL, modMetadata.getEnvironment());
 	}
 
 	/*

--- a/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
+++ b/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +42,6 @@ import net.fabricmc.loader.impl.metadata.ModMetadataParser;
 import net.fabricmc.loader.impl.metadata.ParseMetadataException;
 import net.fabricmc.loader.impl.metadata.VersionOverrides;
 
-@Disabled // TODO needs fixing.
 final class V1ModJsonParsingTests {
 	private static Path testLocation;
 	private static Path specPath;
@@ -188,7 +186,7 @@ final class V1ModJsonParsingTests {
 
 	private static LoaderModMetadata parseMetadata(Path path) throws IOException, ParseMetadataException {
 		try (InputStream is = Files.newInputStream(path)) {
-			return ModMetadataParser.parseMetadata(null, "dummy", Collections.emptyList(), new VersionOverrides(), new DependencyOverrides(Paths.get("randomMissing")));
+			return ModMetadataParser.parseMetadata(is, "dummy", Collections.emptyList(), new VersionOverrides(), new DependencyOverrides(Paths.get("randomMissing")));
 		}
 	}
 }

--- a/src/test/resources/testing/parsing/v1/spec/environment_array.json
+++ b/src/test/resources/testing/parsing/v1/spec/environment_array.json
@@ -1,0 +1,6 @@
+{
+  "id": "v1-parsing-test",
+  "version": "1.0.0-SNAPSHOT",
+  "schemaVersion": 1,
+  "environment": ["client", "server"]
+}


### PR DESCRIPTION
The spec allows a string or an array of strings but loader only accepts a string so this adds support for an array of strings.