### PR TITLE
Don't initialize MappingResolver for access widener load

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -436,7 +436,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 			if (path == null) throw new RuntimeException(String.format("Missing accessWidener file %s from mod %s", accessWidener, modContainer.getMetadata().getId()));
 
 			try (BufferedReader reader = Files.newBufferedReader(path)) {
-				accessWidenerReader.read(reader, getMappingResolver().getCurrentRuntimeNamespace());
+				accessWidenerReader.read(reader, FabricLauncherBase.getLauncher().getTargetNamespace());
 			} catch (Exception e) {
 				throw new RuntimeException("Failed to read accessWidener file from mod " + modMetadata.getId(), e);
 			}


### PR DESCRIPTION
This PR prevents access widener load from initializing the MappingResolver just to get the current runtime namespace.

Initializing the MappingResolver causes all mappings to be loaded into memory (if they weren't already, currently they are in earlier init, see #694), but access widener doesn't use anything from them, just the current runtime namespace, that comes from FabricLauncher directly.