### PR TITLE
Add Spanish translation and make `StringUtil` capitalize the first letter, not character

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/StringUtil.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/StringUtil.java
@@ -20,13 +20,24 @@ public final class StringUtil {
 	public static String capitalize(String s) {
 		if (s.isEmpty()) return s;
 
-		int cp = s.codePointAt(0);
+		int pos;
+
+		for (pos = 0; pos < s.length(); pos++) {
+			if (Character.isLetterOrDigit(s.codePointAt(pos))) {
+				break;
+			}
+		}
+
+		if (pos == s.length()) return s;
+
+		int cp = s.codePointAt(pos);
 		int cpUpper = Character.toUpperCase(cp);
 		if (cpUpper == cp) return s;
 
 		StringBuilder ret = new StringBuilder(s.length());
+		ret.append(s, 0, pos);
 		ret.appendCodePoint(cpUpper);
-		ret.append(s, Character.charCount(cp), s.length());
+		ret.append(s, pos + Character.charCount(cp), s.length());
 
 		return ret.toString();
 	}

--- a/src/main/resources/net/fabricmc/loader/Messages_es.properties
+++ b/src/main/resources/net/fabricmc/loader/Messages_es.properties
@@ -1,0 +1,126 @@
+# translation keys used by Fabric Loader
+# comments starting with # describe entries, those with ## describe the available arguments
+
+environment.client=cliente
+environment.server=servidor dedicado
+
+# mod resolution errors
+
+resolution.solutionHeader=Hemos encontrado una solución prometedora:
+resolution.depListHeader=Dependencias no satisfechas:
+resolution.inactiveMods=Mods inactivos:
+
+# solution to install a mod: Install someMod, any version.
+## mod versionRange
+resolution.solution.addMod=Instala {0}, {1}.
+## mod version path
+resolution.solution.removeMod=Quita {0} {1} ({2}).
+## oldMods newMod newVersionRange
+resolution.solution.replaceMod=Cambia {0} por {1}, {2}.
+## oldMod newVersionRange
+resolution.solution.replaceModVersion=Cambia {0} por {1}.
+## oldMod newVersion
+resolution.solution.replaceModVersionDifferent=Cambia {0} por {1} que sea compatible con:
+## mod version
+resolution.solution.replaceModVersionDifferent.reqSupportedModVersion={0} {1}
+## mod versionRange
+resolution.solution.replaceModVersionDifferent.reqSupportedModVersions={0}, {1}
+##
+resolution.solution.replaceModVersionDifferent.unknown=Otros problemas que no se pueden determinar automáticamente
+# solution to install a mod that can load in the current environment: Install someMod, any version.
+## oldMod newMod versionRange env
+resolution.solution.replaceModEnvDisabled=Cambia {0} por {2} en {1} que pueda cargar en el entorno actual ({3}) o actualiza/quita los mods que dependen en él. Esto pasa porque un mod quiere cargar en un entorno de {3} pero depende de otro que no carga en el entorno de {3}.
+## mod version path
+resolution.solution.replaceMod.oldMod={0} {1} ({2})
+## mod version
+resolution.solution.replaceMod.oldModNoPath={0} {1}
+
+## mod version dep depVersionRange presentVersions presentVersionCount
+
+resolution.depends.envDisabled=¡{0} {1} necesita {3} de {2}, que no se activa en este entorno (sólo en cliente/servidor)!
+resolution.depends.missing=¡{0} {1} necesita {3} de {2}, que no tienes!
+resolution.depends.mismatch=¡{0} {1} necesita {3} de {2}, pero sólo tienes{5, choice, 1# una versión incorrecta|2#s varias versiones incorrectas}: {4}!
+resolution.depends.invalid=¡{0} {1} necesita {3} de {2}, que no puede cargarse por otras restricciones!
+resolution.depends.suggestion=Tienes que instalar {3} de {2}.
+
+resolution.recommends.envDisabled=¡{0} {1} recomienda la versión {3} de {2}, que no carga en este entorno (sólo en cliente/servidor)!
+resolution.recommends.missing=¡{0} {1} recomienda {3} de {2}, que no tienes!
+resolution.recommends.mismatch=¡{0} {1} recomienda {3} de {2}, pero sólo {5, choice, 1#una incorrecta está presente|2#algunas incorrectas están presentes}: {4}!
+resolution.recommends.invalid=¡{0} {1} recomienda {3} de {2}, que no puede cargarse por otras restricciones!
+resolution.recommends.suggestion=Debería instalar {3} de {2} para una experiencia óptima.
+
+resolution.breaks.invalid=¡{0} {1} no es compatible con {3} de {2}, pero tienes{5, choice, 1# una versión coincidente presente|2#varias versiones coincidentes presentes} : {4}!
+resolution.breaks.suggestion=El/los desarrollador/es de {0} han encontrado que esta combinación no funciona. Debes eliminar uno de los mods o buscar actualizaciones que puedan resolver el problema.
+
+resolution.conflicts.invalid=¡{0} {1} puede dar problemas con la versión {3} de {2}, que está presente en la{5, choice, 1# siguiente versión|2#s siguientes versiones}: {4}!
+resolution.conflicts.suggestion=Si bien esto no te evitará arrancar el juego, el/los desarrollador/es de {0} han visto que esta combinación puede causar problemas. Deberías eliminar uno de los mods o buscar actualizaciones que resuelvan el problema.
+
+## mod version
+resolution.jij.builtin={0} {1} es una referencia al entorno y suele necesitar instalación o cambios en el launcher para ajustarse
+## (no args)
+resolution.jij.builtinNoMention=referencia al entorno, suele necesitar instalación o cambios en el launcher para ajustarse
+## mod version path
+resolution.jij.root={0} {1} está siendo cargado desde {2}
+## path
+resolution.jij.rootNoMention=cargado desde {0}
+## mod version path
+resolution.jij.normal={0} {1} viene incluido por e.g. {2}
+## path
+resolution.jij.normalNoMention=incluido por e.g. {0}
+
+## mod version reason
+resolution.inactive={0} {1}, razón: {2}
+## (no args)
+resolution.inactive.inactive_parent=mod padre inactivo (jar incluido)
+resolution.inactive.incompatible=incompatible
+resolution.inactive.newer_active=nueva versión activa
+resolution.inactive.same_active=misma versión activa
+resolution.inactive.to_remove=por eliminar
+resolution.inactive.to_replace=por cambiar
+resolution.inactive.unknown=desconocido
+resolution.inactive.wrong_environment=entorno incorrecto (sólo cliente/servidor)
+
+resolution.type.mod=el mod
+
+resolution.version.any=cualquier versión
+resolution.version.none=un rango de versiones imposible
+## version
+resolution.version.equal=la versión {0}
+## lowerBound
+resolution.version.greater=cualquier versión tras {0}
+## lowerBound
+resolution.version.greaterEqual=la versión {0} o posterior
+## upperBound
+resolution.version.less=cualquier versión anterior a {0}
+## upperBound
+resolution.version.lessEqual=la versión {0} o una anterior
+## majorVersion
+resolution.version.major=cualquier versión {0}.x
+## majorVersion minorVersion
+resolution.version.majorMinor=cualquier versión {0}.{1}.x
+## lowerBound upperBound
+resolution.version.rangeMinIncMaxInc=cualquier versión entre {0} (incluida) y {1} (incluida)
+resolution.version.rangeMinIncMaxExc=cualquier versión entre {0} (incluida) y {1} (excluida)
+resolution.version.rangeMinExcMaxInc=cualquier versión entre {0} (excluida) y {1} (incluida)
+resolution.version.rangeMinExcMaxExc=cualquier versión entre {0} (excluida) y {1} (excluida)
+
+## a b
+enumerationAnd.2={0} y {1}
+## a b c
+enumerationAnd.3={0}, {1} y {2}
+## first
+enumerationAnd.nPrefix={0}
+## allPrev cur
+enumerationAnd.n={0}, {1}
+## allPrev last
+enumerationAnd.nSuffix={0} y {1}
+## a b
+enumerationOr.2={0} o {1}
+## a b c
+enumerationOr.3={0}, {1} o {2}
+## first
+enumerationOr.nPrefix={0}
+## allPrev cur
+enumerationOr.n={0}, {1}
+## allPrev last
+enumerationOr.nSuffix={0} o {1}


### PR DESCRIPTION
This pull request adds a Spanish translation, and adapts `StringUtil.capitalize` slightly to be able to support its leading punctuation (`¡`).

`StringUtil` will now search for the first letter or number instead of choosing always the first character, meaning that strings leaded by punctuation (such as `¡` in my case) will still be capitalized. Number is also checked because I believe `5 mods` is the correct spelling, not `5 Mods`.

I was not able to get JiJ-related strings to trigger.

Also, I think the title "Incompatible mod set!" (and probably the button texts) should be translatable.