### PR TITLE
Unbreak EntrypointPatchFML125, again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 !/minecraft
 !/junit
+
+# MacOS junk files
+.DS_Store

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatchFML125.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatchFML125.java
@@ -49,6 +49,7 @@ public class EntrypointPatchFML125 extends GamePatch {
 
 			Log.debug(LogCategory.GAME_PATCH, "Detected 1.2.5 FML - Knotifying ModClassLoader...");
 
+			// ModClassLoader_125_FML isn't in the game's class path, so it's loaded from the launcher's class path instead
 			ClassNode patchedClassLoader = new ClassNode();
 
 			try (InputStream stream = launcher.getResourceAsStream(LoaderUtil.getClassFileName(FROM))) {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatchFML125.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatchFML125.java
@@ -49,21 +49,18 @@ public class EntrypointPatchFML125 extends GamePatch {
 
 			Log.debug(LogCategory.GAME_PATCH, "Detected 1.2.5 FML - Knotifying ModClassLoader...");
 
-			ClassReader patchedClassLoaderReader = null;
+			ClassNode patchedClassLoader = new ClassNode();
 
 			try (InputStream stream = launcher.getResourceAsStream(LoaderUtil.getClassFileName(FROM))) {
-				patchedClassLoaderReader = new ClassReader(stream);
+				if (stream != null) {
+					ClassReader patchedClassLoaderReader = new ClassReader(stream);
+					patchedClassLoaderReader.accept(patchedClassLoader, 0);
+				} else {
+					throw new IOException("Could not find class " + FROM + " in the launcher classpath while transforming ModClassLoader");
+				}
 			} catch (IOException e) {
-				String errorText = String.format("An error occurred while reading %s", FROM);
-				Log.error(LogCategory.GAME_PATCH, errorText, e);
+				throw new RuntimeException("An error occurred while reading class " + FROM + " while transforming ModClassLoader", e);
 			}
-
-			if (patchedClassLoaderReader == null) {
-				throw new RuntimeException(String.format("Somehow, %s wasn't loaded", FROM));
-			}
-
-			ClassNode patchedClassLoader = new ClassNode();
-			patchedClassLoaderReader.accept(patchedClassLoader, 0);
 
 			ClassNode remappedClassLoader = new ClassNode();
 


### PR DESCRIPTION
The changes in c2a0a0e3491617999cd09d4dcecfff3a2748cd47 broke EntrypointPatchFML125 due to it now only being able to search for ModClassLoader_125_FML in the game jar files, which doesn't work, as ModClassLoader_125_FML is part of Fabric. I've attempted to get around this by just loading ModClassLoader_125_FML from the launcher's class path.

Disclaimer: I'm not very experienced in using ASM, so this might not be the best way of doing this.