### PR TITLE
Fix: Duplicate class definition in rare cases

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -159,6 +159,13 @@ public final class Knot extends FabricLauncherBase {
 		unlocked = true;
 
 		try {
+			classLoader.loadIntoTarget("net.fabricmc.loader.impl.launch.knot.UnusedEmptyTargetClass");
+		} catch (ClassNotFoundException e) {
+			Log.warn(LogCategory.KNOT, "Early non-mixin-config related class failed to load!");
+			Log.warn(LogCategory.KNOT, "If you get a 'LinkageError' of 'attempted duplicated * definition' after this then this error is the cause!", e);
+		}
+
+		try {
 			EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
 		} catch (RuntimeException e) {
 			throw new FormattedException("A mod crashed on startup!", e);

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/UnusedEmptyTargetClass.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/UnusedEmptyTargetClass.java
@@ -1,0 +1,9 @@
+package net.fabricmc.loader.impl.launch.knot;
+
+/**
+ * If the very first class transformed by mixin is also referenced by a mixin config then we'll crash due to an
+ * "attempted duplicate class definition". To avoid this, {@link Knot} loads this class instead - since it's *very
+ * unlikely* to be referenced by mixin plugin.
+ */
+final class UnusedEmptyTargetClass {
+}


### PR DESCRIPTION
If the very first class transformed by mixin is also referenced by a mixin config then we'll crash due to an `"attempted duplicate class definition"`. To avoid this, Knot loads a dummy class instead - since it's *very unlikely* to be referenced by mixin plugin.

This is a frequent problem when mods use Mixin Extras.