### PR TITLE
Fix icon objects in mod metadata not being parsed correctly

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/V1ModMetadataParser.java
@@ -595,10 +595,6 @@ final class V1ModMetadataParser {
 			final SortedMap<Integer, String> iconMap = new TreeMap<>(Comparator.naturalOrder());
 
 			while (reader.hasNext()) {
-				if (reader.peek() != JsonToken.STRING) {
-					throw new ParseMetadataException("Icon path must be a string", reader);
-				}
-
 				String key = reader.nextName();
 
 				int size;
@@ -612,6 +608,12 @@ final class V1ModMetadataParser {
 				if (size < 1) {
 					throw new ParseMetadataException("Size must be positive!", reader);
 				}
+
+				if (reader.peek() != JsonToken.STRING) {
+					throw new ParseMetadataException("Icon path must be a string", reader);
+				}
+
+				iconMap.put(size, reader.nextString());
 			}
 
 			reader.endObject();

--- a/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
+++ b/src/test/java/net/fabricmc/test/V1ModJsonParsingTests.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -156,6 +157,42 @@ final class V1ModJsonParsingTests {
 		if (modMetadata.getDependencies().isEmpty()) {
 			throw new RuntimeException("Incorrect amount of dependencies");
 		}
+	}
+
+	@Test
+	@DisplayName("Any icon size test file")
+	public void testAnyIconSizeFile() throws IOException, ParseMetadataException {
+		final LoaderModMetadata metadata = parseMetadata(specPath.resolve("any_icon_size.json"));
+
+		validateIconPath(metadata, 32, 64);
+		validateIconPath(metadata, 64, 64);
+		validateIconPath(metadata, 128, 64);
+	}
+
+	@Test
+	@DisplayName("No icon test file")
+	public void testNoIconFile() throws IOException, ParseMetadataException {
+		final LoaderModMetadata metadata = parseMetadata(specPath.resolve("no_icon.json"));
+		assertEquals(Optional.empty(), metadata.getIconPath(32));
+	}
+
+	@Test
+	@DisplayName("Icon sizes test file")
+	public void testIconSizesFile() throws IOException, ParseMetadataException {
+		final LoaderModMetadata metadata = parseMetadata(specPath.resolve("icon_sizes.json"));
+
+		validateIconPath(metadata, 32, 64);
+		validateIconPath(metadata, 64, 64);
+		validateIconPath(metadata, 128, 128);
+		validateIconPath(metadata, 256, 256);
+		validateIconPath(metadata, 512, 256);
+	}
+
+	private void validateIconPath(LoaderModMetadata metadata, int preferredSize, int expectedSize) {
+		Optional<String> expected = Optional.of("assets/testing/icon-" + expectedSize + ".png");
+		Optional<String> actual = metadata.getIconPath(preferredSize);
+
+		assertEquals(expected, actual, "Found " + actual.orElse("no icon") + " for preferred size " + preferredSize + " instead of expected size " + expectedSize);
 	}
 
 	/*

--- a/src/test/resources/testing/parsing/v1/spec/any_icon_size.json
+++ b/src/test/resources/testing/parsing/v1/spec/any_icon_size.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "id": "v1-parsing-test",
+  "version": "1.0.0-SNAPSHOT",
+  "icon": "assets/testing/icon-64.png"
+}

--- a/src/test/resources/testing/parsing/v1/spec/icon_sizes.json
+++ b/src/test/resources/testing/parsing/v1/spec/icon_sizes.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "id": "v1-parsing-test",
+  "version": "1.0.0-SNAPSHOT",
+  "icon": {
+    "64": "assets/testing/icon-64.png",
+    "128": "assets/testing/icon-128.png",
+    "256": "assets/testing/icon-256.png"
+  }
+}

--- a/src/test/resources/testing/parsing/v1/spec/no_icon.json
+++ b/src/test/resources/testing/parsing/v1/spec/no_icon.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "id": "v1-parsing-test",
+  "version": "1.0.0-SNAPSHOT"
+}


### PR DESCRIPTION
Fixes #741

This pull request also adds tests to verify that icons are parsed and chosen based on a preferred size correctly.