### PR TITLE
Don't wrap FormattedExceptions throwns by mods during preLaunch

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -160,6 +160,8 @@ public final class Knot extends FabricLauncherBase {
 
 		try {
 			EntrypointUtils.invoke("preLaunch", PreLaunchEntrypoint.class, PreLaunchEntrypoint::onPreLaunch);
+		} catch (FormattedException e) {
+		  	throw e;
 		} catch (RuntimeException e) {
 			throw new FormattedException("A mod crashed on startup!", e);
 		}


### PR DESCRIPTION
I'm writing a mod that does a lot of stuff during preLaunch and it would be cool if I could customize the 'A mod crashed on startup!' message and remove the wrapper Runtime Exception from this UI:
![image](https://user-images.githubusercontent.com/27910867/205775450-5c91552e-32ea-4d9f-8262-c950787c319f.png)

Right now that is not possible because any `FormattedException` thrown by mods get wrapped here
https://github.com/FabricMC/fabric-loader/blob/354af34127e52378410d182dd7b458e8c9b893d5/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java#L163-L165

This PR removes that wrapping for `FormattedException`s, so mods that directly throw a `FormattedException` will have it  displayed in the UI.