### PR TITLE
Fix crash when trying to remap methods in Object.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
@@ -154,7 +154,7 @@ public class MixinIntermediaryDevRemapper extends MixinRemapper {
 				return s;
 			}
 
-			if (!classInfo.getSuperName().startsWith("java/")) {
+			if (classInfo.getSuperName() != null && !classInfo.getSuperName().startsWith("java/")) {
 				ClassInfo cSuper = classInfo.getSuperClass();
 
 				if (cSuper != null) {
@@ -221,7 +221,7 @@ public class MixinIntermediaryDevRemapper extends MixinRemapper {
 				return s;
 			}
 
-			if (c.getSuperName().startsWith("java/")) {
+			if (c.getSuperName() == null || c.getSuperName().startsWith("java/")) {
 				break;
 			}
 


### PR DESCRIPTION
Closes #745

Object has no super class, this fixes a crash when mixin tries to remap `Ljava/lang/Object;equals(Ljava/lang/Object;)Z`

Im not a massive fan of the use of checking the classname starts with `java/`, maybe one to revist when moving to mapping-io?

Test mod for future refrence [fabric-example-mod-1.0.0.zip](https://github.com/FabricMC/fabric-loader/files/10170664/fabric-example-mod-1.0.0.zip) (Rename to .jar)
