### PR TITLE
Update to ASM 9.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,13 @@ allprojects {
 			name = 'Fabric'
 			url = 'https://maven.fabricmc.net/'
 		}
-		mavenCentral()
+		mavenCentral() {
+			content {
+				// Force ASM to come from the fabric maven.
+				// This ensures that the ASM version has been mirrored for use by the launcher/installer.
+				excludeGroupByRegex "org.ow2.asm"
+			}
+		}
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ group = net.fabricmc
 description = The mod loading component of Fabric
 url = https://github.com/FabricMC/fabric-loader
 
-asm_version = 9.3
+asm_version = 9.4
 mixin_version = 0.11.4+mixin.0.8.5

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -21,23 +21,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:9.3",
+        "name": "org.ow2.asm:asm:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:9.3",
+        "name": "org.ow2.asm:asm-analysis:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:9.3",
+        "name": "org.ow2.asm:asm-commons:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:9.3",
+        "name": "org.ow2.asm:asm-tree:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:9.3",
+        "name": "org.ow2.asm:asm-util:9.4",
         "url": "https://maven.fabricmc.net/"
       }
     ],

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -24,23 +24,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:9.3",
+        "name": "org.ow2.asm:asm:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:9.3",
+        "name": "org.ow2.asm:asm-analysis:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:9.3",
+        "name": "org.ow2.asm:asm-commons:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:9.3",
+        "name": "org.ow2.asm:asm-tree:9.4",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:9.3",
+        "name": "org.ow2.asm:asm-util:9.4",
         "url": "https://maven.fabricmc.net/"
       }
     ],


### PR DESCRIPTION
Ensure ASM is fetched from the fabric maven, this ensures that the ASM version has been mirrored for use by the launcher/installer.

No major rush to merge (Just here to go in alongside the next version), just nice to keep on top of. Supports Java 20 classes.