### PR TITLE
Fixes MixinIntermediaryDevRemapper.mapMethodName unable to map ambiguous values

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
@@ -138,7 +138,7 @@ public class MixinIntermediaryDevRemapper extends MixinRemapper {
 			}
 		}
 
-		ClassInfo classInfo = ClassInfo.forName(owner);
+		ClassInfo classInfo = ClassInfo.forName(map(owner));
 
 		if (classInfo == null) { // unknown class?
 			return name;


### PR DESCRIPTION
This PR fixes [this mixin from lithium](https://github.com/CaffeineMC/lithium-fabric/blob/f8e1b8dd95dd3239c7345b427d6da60a132a5f8d/src/main/java/me/jellysquid/mods/lithium/mixin/ai/task/launch/BrainMixin.java#L159) unable to be applied cleanly in 1.19.3 devlaunch using `1.19.3+build.2` yarn mappings. 