### PR TITLE
Upstream tiny-remapper and other libraries.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
 		exclude module: 'guava'
 	}
 	api 'net.fabricmc:tiny-mappings-parser:0.3.0+build.17'
-	api 'net.fabricmc:tiny-remapper:0.8.2'
+	api 'net.fabricmc:tiny-remapper:0.8.6'
 	api 'net.fabricmc:access-widener:2.1.0'
 
 	include 'org.ow2.sat4j:org.ow2.sat4j.core:2.3.6'
@@ -84,7 +84,7 @@ dependencies {
 	testCompileOnly 'org.jetbrains:annotations:23.0.0'
 
 	// Unit testing for mod metadata
-	testImplementation('org.junit.jupiter:junit-jupiter:5.8.2')
+	testImplementation('org.junit.jupiter:junit-jupiter:5.9.1')
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 	include 'org.ow2.sat4j:org.ow2.sat4j.core:2.3.6'
 	include 'org.ow2.sat4j:org.ow2.sat4j.pb:2.3.6'
 
-	testCompileOnly 'org.jetbrains:annotations:23.0.0'
+	testCompileOnly 'org.jetbrains:annotations:23.1.0'
 
 	// Unit testing for mod metadata
 	testImplementation('org.junit.jupiter:junit-jupiter:5.9.1')

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath 'org.kohsuke:github-api:1.135'
+		classpath 'org.kohsuke:github-api:1.313'
 		classpath 'com.guardsquare:proguard-gradle:' + (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '7.3.0' : '7.1.0')
 	}
 }
@@ -84,7 +84,7 @@ dependencies {
 	testCompileOnly 'org.jetbrains:annotations:23.1.0'
 
 	// Unit testing for mod metadata
-	testImplementation('org.junit.jupiter:junit-jupiter:5.9.1')
+	testImplementation('org.junit.jupiter:junit-jupiter:5.8.2')
 }
 
 processResources {

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -13,7 +13,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:tiny-remapper:0.8.2",
+        "name": "net.fabricmc:tiny-remapper:0.8.6",
         "url": "https://maven.fabricmc.net/"
       },
       {

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -16,7 +16,7 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "net.fabricmc:tiny-remapper:0.8.2",
+        "name": "net.fabricmc:tiny-remapper:0.8.6",
         "url": "https://maven.fabricmc.net/"
       },
       {


### PR DESCRIPTION
Upstreams tiny-remapper from 0.8.2 -> 0.8.6,
Annotations from 23.0.0 -> 23.1.0,
GitHub API from 1.135 -> 1.313,
~~and junit-jupiter from 5.8.2 -> 5.9.1.~~ 