### PR TITLE
Create and run applet on AWT EventQueue thread

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
@@ -18,8 +18,12 @@ package net.fabricmc.loader.impl.game.minecraft.applet;
 
 import java.io.File;
 
-public final class AppletMain {
-	private AppletMain() { }
+public final class AppletMain implements Runnable {
+    
+        final String[] args;
+	private AppletMain(String[] args) { 
+                this.args = args;
+        }
 
 	public static File hookGameDir(File file) {
 		File proposed = AppletLauncher.gameDir;
@@ -32,7 +36,12 @@ public final class AppletMain {
 	}
 
 	public static void main(String[] args) {
-		AppletFrame me = new AppletFrame("Minecraft", null);
-		me.launch(args);
+                java.awt.EventQueue.invokeLater(new AppletMain(args));
 	}
+
+        @Override
+        public void run() {
+                AppletFrame me = new AppletFrame("Minecraft", null);
+		me.launch(args);
+        }
 }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
@@ -19,11 +19,11 @@ package net.fabricmc.loader.impl.game.minecraft.applet;
 import java.io.File;
 
 public final class AppletMain implements Runnable {
-    
-        final String[] args;
+
+	final String[] args;
 	private AppletMain(String[] args) { 
-                this.args = args;
-        }
+		this.args = args;
+	}
 
 	public static File hookGameDir(File file) {
 		File proposed = AppletLauncher.gameDir;
@@ -36,12 +36,12 @@ public final class AppletMain implements Runnable {
 	}
 
 	public static void main(String[] args) {
-                java.awt.EventQueue.invokeLater(new AppletMain(args));
+		java.awt.EventQueue.invokeLater(new AppletMain(args));
 	}
 
-        @Override
-        public void run() {
-                AppletFrame me = new AppletFrame("Minecraft", null);
+	@Override
+	public void run() {
+		AppletFrame me = new AppletFrame("Minecraft", null);
 		me.launch(args);
-        }
+	}
 }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
@@ -19,9 +19,8 @@ package net.fabricmc.loader.impl.game.minecraft.applet;
 import java.io.File;
 
 public final class AppletMain implements Runnable {
-
 	final String[] args;
-	private AppletMain(String[] args) { 
+	private AppletMain(String[] args) {
 		this.args = args;
 	}
 


### PR DESCRIPTION
This fixes sometimes occuring race conditions and changes the current behavior to what's suggested by the [AWT/Swing documentation](https://docs.oracle.com/javase/tutorial/uiswing/concurrency/initial.html)