### PR TITLE
Opt of Loom 1.1 remapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,8 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 
 	manifest {
 		attributes (
-			'Main-Class': 'net.fabricmc.loader.impl.launch.server.FabricServerLauncher'
+			'Main-Class': 'net.fabricmc.loader.impl.launch.server.FabricServerLauncher',
+			'Fabric-Loom-Remap': 'false'
 		)
 	}
 


### PR DESCRIPTION
Loom 1.1 allows mods to out of of remapping if its not required, this change will stop loom from remapping fabric loader when used as a dependency.

Needs testing before release.