### PR TITLE
Print mod list as tree

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.objectweb.asm.Opcodes;
 
@@ -223,26 +224,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		modCandidates = ModResolver.resolve(modCandidates, getEnvironmentType(), envDisabledMods);
 
-		// dump mod list
-
-		StringBuilder modListText = new StringBuilder();
-
-		for (ModCandidate mod : modCandidates) {
-			if (modListText.length() > 0) modListText.append('\n');
-
-			modListText.append("\t- ");
-			modListText.append(mod.getId());
-			modListText.append(' ');
-			modListText.append(mod.getVersion().getFriendlyString());
-
-			if (!mod.getParentMods().isEmpty()) {
-				modListText.append(" via ");
-				modListText.append(mod.getParentMods().iterator().next().getId());
-			}
-		}
-
-		int count = modCandidates.size();
-		Log.info(LogCategory.GENERAL, "Loading %d mod%s:%n%s", count, count != 1 ? "s" : "", modListText);
+		dumpModList(modCandidates);
 
 		Path cacheDir = gameDir.resolve(CACHE_DIR_NAME);
 		Path outputdir = cacheDir.resolve(PROCESSED_MODS_DIR_NAME);
@@ -294,6 +276,61 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		}
 
 		modCandidates = null;
+	}
+
+	private void dumpModList(List<ModCandidate> mods) {
+		StringBuilder modListText = new StringBuilder();
+
+		boolean[] lastItemOfNestLevel = new boolean[mods.size()];
+		List<ModCandidate> topLevelMods = mods.stream()
+				.filter(mod -> mod.getParentMods().isEmpty())
+				.collect(Collectors.toList());
+		int topLevelModsCount = topLevelMods.size();
+
+		for (int i = 0; i < topLevelModsCount; i++) {
+			boolean lastItem = i == topLevelModsCount - 1;
+
+			if (lastItem) lastItemOfNestLevel[0] = true;
+
+			dumpModList0(topLevelMods.get(i), modListText, 0, lastItemOfNestLevel);
+		}
+
+		int modsCount = mods.size();
+		Log.info(LogCategory.GENERAL, "Loading %d mod%s:%n%s", modsCount, modsCount != 1 ? "s" : "", modListText);
+	}
+
+	private void dumpModList0(ModCandidate mod, StringBuilder log, int nestLevel, boolean[] lastItemOfNestLevel) {
+		if (log.length() > 0) log.append('\n');
+
+		for (int i = 0; i < nestLevel; i++) {
+			log.append(lastItemOfNestLevel[i] ? "    " : "   │");
+		}
+
+		log.append("   ");
+		log.append(lastItemOfNestLevel[nestLevel] ? "└──" : "├──");
+		log.append(' ');
+		log.append(mod.getId());
+		log.append(' ');
+		log.append(mod.getVersion().getFriendlyString());
+
+		Collection<ModCandidate> nestedMods = mod.getNestedMods();
+
+		if (!nestedMods.isEmpty()) {
+			Iterator<ModCandidate> iterator = nestedMods.iterator();
+			ModCandidate nestedMod;
+			boolean lastItem;
+
+			while (iterator.hasNext()) {
+				nestedMod = iterator.next();
+				lastItem = !iterator.hasNext();
+
+				if (lastItem) lastItemOfNestLevel[nestLevel+1] = true;
+
+				dumpModList0(nestedMod, log, nestLevel + 1, lastItemOfNestLevel);
+
+				if (lastItem) lastItemOfNestLevel[nestLevel+1] = false;
+			}
+		}
 	}
 
 	private void finishModLoading() {


### PR DESCRIPTION
Instead of printing the usual list, which hasn't seen any improvements since 0.12:
```
[14:00:00] [main/INFO] (FabricLoader) Loading 15 mods:
	- animatica 0.5+1.19
	- antighost 1.19.3-fabric0.68.1-1.1.5+
	- bettermounthud 1.2.1
	- borderlessmining 1.1.6+1.19.3
	- cloth-basic-math 0.6.1 via cloth-config
	- completeconfig-gui-cloth 2.2.0 via cem
	- conditional-mixin 0.3.2 via moreculling
	- crowdin-translate 1.4+1.19.3 via antighost
	- ...
```

Fabric Loader now prints this list in a tree-style format, so you can more easily see how mods are nested in each other, removing the annoying to search through `via <modid>` appendix.

<details>
  <summary>Output for loading Fabric API, Cloth Config and Too Many Binds</summary>

```
[14:00:00] [main/INFO] (FabricLoader) Loading 63 mods:
   ├── cloth-config 9.0.94
   │   └── cloth-basic-math 0.6.1
   ├── fabric-api 0.73.2+1.19.3
   │   ├── fabric-resource-conditions-api-v1 2.2.3+1134c5b885
   │   ├── fabric-loot-tables-v1 1.1.24+9e7660c685
   │   ├── fabric-networking-v0 0.3.34+df3654b385
   │   ├── fabric-convention-tags-v1 1.2.2+8e4e694f85
   │   ├── fabric-containers-v0 0.1.47+df3654b385
   │   ├── fabric-rendering-fluids-v1 3.0.18+f1e4495b85
   │   ├── fabric-transfer-api-v1 2.1.15+ccd377ba85
   │   ├── fabric-command-api-v1 1.2.22+f71b366f85
   │   ├── fabric-data-generation-api-v1 11.2.1+06937c4b85
   │   ├── fabric-particles-v1 1.0.20+f1e4495b85
   │   ├── fabric-renderer-indigo 0.7.1+9f179aa185
   │   ├── fabric-item-api-v1 2.1.10+312c329485
   │   ├── fabric-sound-api-v1 1.0.8+75e9821185
   │   ├── fabric-blockrenderlayer-v1 1.1.30+c6af733c85
   │   ├── fabric-crash-report-info-v1 0.2.14+aeb40ebe85
   │   ├── fabric-mining-level-api-v1 2.1.31+49abcf7e85
   │   ├── fabric-key-binding-api-v1 1.0.31+bc01e09785
   │   ├── fabric-events-interaction-v0 0.4.40+3baeb27a85
   │   ├── fabric-screen-handler-api-v1 1.3.13+99f9db8085
   │   ├── fabric-transitive-access-wideners-v1 2.3.1+5b9a588b85
   │   ├── fabric-renderer-registries-v1 3.2.30+df3654b385
   │   ├── fabric-registry-sync-v0 2.0.5+1134c5b885
   │   ├── fabric-networking-api-v1 1.2.17+4017a8cb85
   │   ├── fabric-keybindings-v0 0.2.29+df3654b385
   │   ├── fabric-rendering-v0 1.1.33+df3654b385
   │   ├── fabric-client-tags-api-v1 1.0.12+1134c5b885
   │   ├── fabric-screen-api-v1 1.0.41+f1e4495b85
   │   ├── fabric-game-rule-api-v1 1.0.30+99f9db8085
   │   ├── fabric-rendering-v1 1.12.1+eb2a3ba985
   │   ├── fabric-loot-api-v2 1.1.20+75e9821185
   │   ├── fabric-rendering-data-attachment-v1 0.3.25+afca2f3e85
   │   ├── fabric-command-api-v2 2.2.1+3fc4752e85
   │   ├── fabric-api-lookup-api-v1 1.6.20+49abcf7e85
   │   ├── fabric-renderer-api-v1 2.2.1+9f179aa185
   │   ├── fabric-biome-api-v1 12.1.1+b5d379b085
   │   ├── fabric-events-lifecycle-v0 0.2.44+df3654b385
   │   ├── fabric-entity-events-v1 1.5.7+b83334a085
   │   ├── fabric-api-base 0.4.21+70be179c85
   │   ├── fabric-dimensions-v1 2.1.41+48349a3f85
   │   ├── fabric-commands-v0 0.2.39+df3654b385
   │   ├── fabric-item-group-api-v1 2.1.12+1134c5b885
   │   ├── fabric-models-v0 0.3.27+11ba9c3b85
   │   ├── fabric-recipe-api-v1 1.0.1+5176f73d85
   │   ├── fabric-object-builder-api-v1 5.4.1+eb2a3ba985
   │   ├── fabric-message-api-v1 5.0.14+6ede1da985
   │   ├── fabric-content-registries-v0 3.5.1+1d37d50285
   │   ├── fabric-resource-loader-v0 0.10.5+a91e48b785
   │   ├── fabric-lifecycle-events-v1 2.2.10+23a79c8a85
   │   └── fabric-block-api-v1 1.0.5+e022e5d185
   ├── fabricloader 0.14.13
   ├── java 17
   ├── minecraft 1.19.3
   ├── modmenu 5.0.2
   └── toomanybinds 0.3.3+1.19.3
       └── toomanybinds-compat-1-19-3 0.3.3
           └── toomanybinds-compat-1-19 0.3.3
               └── toomanybinds-compat-1-18-2 0.3.3
                   └── toomanybinds-compat-1-17 0.3.3
                       └── toomanybinds-compat-1-16 0.3.3
                           └── toomanybinds-core 0.3.3
```
</details>
<details>
  <summary>Output for loading the Fabulously Optimized 4.6.0-beta.6 modpack</summary>

```
[14:00:00] [main/INFO] (FabricLoader) Loading 148 mods:
   ├── advancementinfo 1.19.3-fabric0.68.1-1.3.1
   ├── animatica 0.5+1.19
   ├── antighost 1.19.3-fabric0.68.1-1.1.5
   │   └── crowdin-translate 1.4+1.19.3
   ├── betterbeds 1.3.0
   ├── bettermounthud 1.2.1
   ├── borderlessmining 1.1.6+1.19.3
   ├── capes 1.5.1+1.19.3
   │   └── omega-config 1.2.3-1.18.1
   ├── cem 0.7.1
   │   ├── completeconfig-gui-cloth 2.2.0
   │   └── completeconfig-base 2.2.0
   ├── citresewn 1.1.3+1.19.3
   │   └── citresewn-defaults 1.1.3+1.19.3
   ├── cloth-config 9.0.94
   │   └── cloth-basic-math 0.6.1
   ├── debugify 1.19.3+1.1
   │   └── com_github_llamalad7_mixinextras 0.1.1
   ├── dynamicfps 2.2.0
   │   └── com_moandjiezana_toml_toml4j 0.7.2
   ├── entity_texture_features 4.3.1
   │   └── org_apache_httpcomponents_httpmime 4.5.10
   ├── entityculling 1.5.2-mc1.19.3
   │   └── com_logisticscraft_occlusionculling 0.0.6-SNAPSHOT
   ├── fabric-api 0.73.2+1.19.3
   │   ├── fabric-networking-api-v1 1.2.17+4017a8cb85
   │   ├── fabric-containers-v0 0.1.47+df3654b385
   │   ├── fabric-resource-loader-v0 0.10.5+a91e48b785
   │   ├── fabric-client-tags-api-v1 1.0.12+1134c5b885
   │   ├── fabric-api-base 0.4.21+70be179c85
   │   ├── fabric-key-binding-api-v1 1.0.31+bc01e09785
   │   ├── fabric-lifecycle-events-v1 2.2.10+23a79c8a85
   │   ├── fabric-command-api-v2 2.2.1+3fc4752e85
   │   ├── fabric-object-builder-api-v1 5.4.1+eb2a3ba985
   │   ├── fabric-data-generation-api-v1 11.2.1+06937c4b85
   │   ├── fabric-dimensions-v1 2.1.41+48349a3f85
   │   ├── fabric-keybindings-v0 0.2.29+df3654b385
   │   ├── fabric-loot-api-v2 1.1.20+75e9821185
   │   ├── fabric-blockrenderlayer-v1 1.1.30+c6af733c85
   │   ├── fabric-game-rule-api-v1 1.0.30+99f9db8085
   │   ├── fabric-commands-v0 0.2.39+df3654b385
   │   ├── fabric-api-lookup-api-v1 1.6.20+49abcf7e85
   │   ├── fabric-networking-v0 0.3.34+df3654b385
   │   ├── fabric-item-api-v1 2.1.10+312c329485
   │   ├── fabric-recipe-api-v1 1.0.1+5176f73d85
   │   ├── fabric-renderer-registries-v1 3.2.30+df3654b385
   │   ├── fabric-particles-v1 1.0.20+f1e4495b85
   │   ├── fabric-message-api-v1 5.0.14+6ede1da985
   │   ├── fabric-events-lifecycle-v0 0.2.44+df3654b385
   │   ├── fabric-crash-report-info-v1 0.2.14+aeb40ebe85
   │   ├── fabric-rendering-fluids-v1 3.0.18+f1e4495b85
   │   ├── fabric-command-api-v1 1.2.22+f71b366f85
   │   ├── fabric-renderer-api-v1 2.2.1+9f179aa185
   │   ├── fabric-transfer-api-v1 2.1.15+ccd377ba85
   │   ├── fabric-screen-handler-api-v1 1.3.13+99f9db8085
   │   ├── fabric-block-api-v1 1.0.5+e022e5d185
   │   ├── fabric-item-group-api-v1 2.1.12+1134c5b885
   │   ├── fabric-registry-sync-v0 2.0.5+1134c5b885
   │   ├── fabric-mining-level-api-v1 2.1.31+49abcf7e85
   │   ├── fabric-rendering-v0 1.1.33+df3654b385
   │   ├── fabric-renderer-indigo 0.7.1+9f179aa185
   │   ├── fabric-convention-tags-v1 1.2.2+8e4e694f85
   │   ├── fabric-events-interaction-v0 0.4.40+3baeb27a85
   │   ├── fabric-rendering-data-attachment-v1 0.3.25+afca2f3e85
   │   ├── fabric-loot-tables-v1 1.1.24+9e7660c685
   │   ├── fabric-sound-api-v1 1.0.8+75e9821185
   │   ├── fabric-biome-api-v1 12.1.1+b5d379b085
   │   ├── fabric-transitive-access-wideners-v1 2.3.1+5b9a588b85
   │   ├── fabric-rendering-v1 1.12.1+eb2a3ba985
   │   ├── fabric-entity-events-v1 1.5.7+b83334a085
   │   ├── fabric-models-v0 0.3.27+11ba9c3b85
   │   ├── fabric-screen-api-v1 1.0.41+f1e4495b85
   │   ├── fabric-content-registries-v0 3.5.1+1d37d50285
   │   └── fabric-resource-conditions-api-v1 2.2.3+1134c5b885
   ├── fabric-language-kotlin 1.9.0+kotlin.1.8.0
   │   ├── org_jetbrains_kotlin_kotlin-reflect 1.8.0
   │   ├── org_jetbrains_kotlinx_atomicfu-jvm 0.18.5
   │   ├── org_jetbrains_kotlin_kotlin-stdlib-jdk8 1.8.0
   │   ├── org_jetbrains_kotlinx_kotlinx-datetime-jvm 0.4.0
   │   ├── org_jetbrains_kotlinx_kotlinx-coroutines-jdk8 1.6.4
   │   ├── org_jetbrains_kotlin_kotlin-stdlib 1.8.0
   │   ├── org_jetbrains_kotlinx_kotlinx-coroutines-core-jvm 1.6.4
   │   ├── org_jetbrains_kotlinx_kotlinx-serialization-json-jvm 1.4.1
   │   ├── org_jetbrains_kotlinx_kotlinx-serialization-cbor-jvm 1.4.1
   │   ├── org_jetbrains_kotlin_kotlin-stdlib-jdk7 1.8.0
   │   └── org_jetbrains_kotlinx_kotlinx-serialization-core-jvm 1.4.1
   ├── fabricloader 0.14.13
   ├── fabricskyboxes 0.6.2+mc1.19.3
   ├── fabrishot 1.9.1
   ├── fastquit 2.1.0+1.19.3
   ├── ferritecore 5.1.0
   ├── fsb-interop 1.1.4+mc1.19.3-build.30
   ├── holdthatchunk 2.0.1
   ├── indium 1.0.12+mc1.19.3
   ├── iris 1.5.1
   │   ├── io_github_douira_glsl-transformer 2.0.0-pre8
   │   ├── org_antlr_antlr4-runtime 4.11.1
   │   └── org_anarres_jcpp 1.4.14
   ├── isxander-main-menu-credits 1.1.1
   ├── java 17
   ├── lambdynlights 2.2.0+1.19.3
   │   ├── pride 1.2.0+1.19.3
   │   └── spruceui 4.1.0+1.19.3
   ├── languagereload 1.5.4+1.19.3
   ├── lazydfu 0.1.3
   ├── lithium 0.10.4
   ├── memoryleakfix 1.19.3-0.7.0
   ├── midnightcontrols 1.7.3+1.19.3
   │   ├── midnightlib 1.1.0
   │   ├── org_aperlambda_lambdajcommon 1.8.1
   │   └── spruceui 4.1.0+1.19.3
   ├── minecraft 1.19.3
   ├── minecraft-test 1.0.0
   ├── mixin-conflict-helper 1.2.0
   ├── mixintrace 1.1.1+1.17
   ├── modelfix 1.10
   ├── modmenu 5.0.2
   ├── morechathistory 1.1.1
   ├── moreculling 1.19.3-0.15.0
   │   └── conditional-mixin 0.3.2
   ├── nochatreports 1.19.3-v2.0.0
   ├── nofade 1.18-2.0.1
   ├── optigui 1.1.6
   │   └── org_apache_commons_commons-text 1.9
   ├── puzzle 1.4.2-1.19.3
   │   ├── puzzle-base 1.4.2-1.19.3
   │   ├── puzzle-splashscreen 1.4.2-1.19.3
   │   ├── puzzle-models 1.4.2-1.19.3
   │   ├── midnightlib 1.1.0
   │   └── puzzle-gui 1.4.2-1.19.3
   ├── reeses-sodium-options 1.4.9+mc1.19.2-build.67
   ├── sodium 0.4.8+build.22
   ├── sodium-extra 0.4.16+mc1.19.3-build.91
   │   └── caffeineconfig 1.0.0+1.17
   ├── starlight 1.1.1+fabric.ae22326
   ├── toomanybinds 0.3.3+1.19.3
   │   └── toomanybinds-compat-1-19-3 0.3.3
   │       └── toomanybinds-compat-1-19 0.3.3
   │           └── toomanybinds-compat-1-18-2 0.3.3
   │               └── toomanybinds-compat-1-17 0.3.3
   │                   └── toomanybinds-compat-1-16 0.3.3
   │                       └── toomanybinds-core 0.3.3
   ├── yet-another-config-lib 2.2.0
   ├── yosbr 0.1.1
   └── zoomify 2.9.2
       ├── com_akuleshov7_ktoml-core-jvm 0.3.0
       ├── dev_isxander_settxi_settxi-gui 2.10.6
       ├── dev_isxander_settxi_settxi-kotlinx-serialization 2.10.6
       ├── settxi-gui-yacl 2.10.6
       └── dev_isxander_settxi_settxi-core 2.10.6
```
</details>