### PR TITLE
Fix forked error window not closing when the parent process is shutdown.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
+++ b/src/main/java/net/fabricmc/loader/impl/gui/FabricGuiEntry.java
@@ -74,6 +74,8 @@ public final class FabricGuiEntry {
 				.redirectError(ProcessBuilder.Redirect.INHERIT)
 				.start();
 
+		Runtime.getRuntime().addShutdownHook(new Thread(process::destroy));
+
 		try (DataOutputStream os = new DataOutputStream(process.getOutputStream())) {
 			tree.writeTo(os);
 		}


### PR DESCRIPTION
Closes #614