### PR TITLE
Switch to ASCII characters for mod list tree formatting

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -304,11 +304,11 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		if (log.length() > 0) log.append('\n');
 
 		for (int depth = 0; depth < nestLevel; depth++) {
-			log.append(depth == 0 ? "\t" : lastItemOfNestLevel[depth] ? "    " : "   │");
+			log.append(depth == 0 ? "\t" : lastItemOfNestLevel[depth] ? "     " : "   | ");
 		}
 
-		log.append(nestLevel == 0 ? "\t" : "   ");
-		log.append(nestLevel == 0 ? "─" : lastItemOfNestLevel[nestLevel] ? "└──" : "├──");
+		log.append(nestLevel == 0 ? "\t" : "  ");
+		log.append(nestLevel == 0 ? "-" : lastItemOfNestLevel[nestLevel] ? " \\--" : " |--");
 		log.append(' ');
 		log.append(mod.getId());
 		log.append(' ');


### PR DESCRIPTION
MultiMC and its forks apparently don't have Unicode support in their log window, so the mod list dump appears broken:

<details>
  <summary>Broken table formatting</summary>

  ![uXFxEr1r](https://user-images.githubusercontent.com/48808497/220635831-7da5999b-e714-48cf-b4e1-0220038af906.png)
</details>

This PR makes the table use ASCII characters instead, so it displays correctly on all systems.

<details>
  <summary>New ASCII-only formatting</summary>
  
   ```
[14:15:11] [INFO] [FabricLoader/]: Loading 78 mods:
	- bettersleeping 0.6.0+1.19
	   |-- bettersleeping-core 0.6.0
	   \-- org_apache_commons_commons-text 1.9
	- cloth-config 9.0.93
	   \-- cloth-basic-math 0.6.1
	- fabric-api 0.68.1+1.19.3
	   |-- fabric-api-base 0.4.19+8d1895cf72
	   |-- fabric-api-lookup-api-v1 1.6.18+49abcf7e72
	   |-- fabric-biome-api-v1 12.0.0+689f5e7172
	   |-- fabric-block-api-v1 1.0.3+12bfe4ea72
	   |-- fabric-blockrenderlayer-v1 1.1.28+c6af733c72
	   |-- fabric-client-tags-api-v1 1.0.9+49abcf7e72
	   |-- fabric-command-api-v1 1.2.19+f71b366f72
	   |-- fabric-command-api-v2 2.1.15+49abcf7e72
	   |-- fabric-commands-v0 0.2.36+df3654b372
	   |-- fabric-containers-v0 0.1.44+df3654b372
	   |-- fabric-content-registries-v0 3.4.11+49abcf7e72
	   |-- fabric-convention-tags-v1 1.1.9+2894d6df72
	   |-- fabric-crash-report-info-v1 0.2.12+aeb40ebe72
	   |-- fabric-data-generation-api-v1 11.0.1+65e415cb72
	   |-- fabric-dimensions-v1 2.1.39+48349a3f72
	   |-- fabric-entity-events-v1 1.5.5+b83334a072
	   |-- fabric-events-interaction-v0 0.4.37+422b77fb72
	   |-- fabric-events-lifecycle-v0 0.2.38+df3654b372
	   |-- fabric-game-rule-api-v1 1.0.28+2894d6df72
	   |-- fabric-item-api-v1 2.1.4+fa25da9972
	   |-- fabric-item-group-api-v1 2.1.6+b7096da872
	   |-- fabric-key-binding-api-v1 1.0.28+aaaf9d3372
	   |-- fabric-keybindings-v0 0.2.26+df3654b372
	   |-- fabric-lifecycle-events-v1 2.2.8+2894d6df72
	   |-- fabric-loot-api-v2 1.1.17+75e9821172
	   \-- fabric-transitive-access-wideners-v1 2.1.0+0efcd39b72
	- fabricloader 0.14.15
	- java 17
	- lazydfu 0.1.3
	- microdurability 0.3.3+1.19
	   \-- microdurability-core 0.3.3
	- minecraft 1.19.3
	- minecraft-test 1.0.0
	- modmenu 5.0.0-alpha.4
	- smoothboot 1.19-1.7.1
	- sodium 0.4.5-rc.2
	- starlight 1.1.1+fabric.ae22326
	- testmod 0.3.3+1.19.3
	   |-- malilib 0.14.0
	   |    \-- fabric-resource-loader-v0 0.10.2+f6c919d672
	   |-- toomanybinds-compat-1-19-3 0.3.3
	   |    \-- toomanybinds-compat-1-19 0.3.3
	   |         \-- toomanybinds-compat-1-18-2 0.3.3
	   |              \-- toomanybinds-compat-1-17 0.3.3
	   |                   \-- toomanybinds-compat-1-16 0.3.3
	   |                        \-- toomanybinds-core 0.3.3
	   \-- tweakeroo 0.15.0
	- unsaddle 0.2.1
	   |-- unsaddle-compat-1-15 0.2.1
	   |-- unsaddle-compat-1-16 0.2.1
	   \-- unsaddle-core 0.2.1
```
</details>
</center>