### PR TITLE
Read "fabric-loader-junit.properties" to allow passing system properties in unit tests.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -64,6 +64,8 @@ public final class SystemProperties {
 	public static final String DEBUG_REPLACE_VERSION = "fabric.debug.replaceVersion";
 	// whether fabric loader is running in a unit test, this affects logging classpath setup
 	public static final String UNIT_TEST = "fabric.unitTest";
+	// the env passed to Knot when running the unit tests
+	public static final String UNIT_TEST_ENV = "fabric.unitTest.env";
 
 	private SystemProperties() {
 	}


### PR DESCRIPTION
There is no common way to pass system properties to junit tests (Especially when running single tests via the IDE), this is needed to allow loom to correctly setup the classpath groups. Loom will generate a jar with this properties file and place it on the test classpath. 

A new property was also added to allow setting the env type.