### PR TITLE
Only apply Fabric Mixin services on platforms that need them

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -308,4 +308,9 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 	public boolean isDevelopment() {
 		return isDevelopment;
 	}
+
+	@Override
+	public boolean useFabricMixinServices() {
+		return false;
+	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
@@ -62,4 +62,8 @@ public interface FabricLauncher {
 	String getTargetNamespace();
 
 	List<Path> getClassPath();
+
+	// Mixin ships with its own for LaunchWrapper etc.,
+	// so we can skip our implementations on such platforms.
+	boolean useFabricMixinServices();
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/FabricGlobalPropertyService.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/FabricGlobalPropertyService.java
@@ -22,6 +22,14 @@ import org.spongepowered.asm.service.IPropertyKey;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 
 public class FabricGlobalPropertyService implements IGlobalPropertyService {
+	public FabricGlobalPropertyService() {
+		if (!FabricLauncherBase.getLauncher().useFabricMixinServices()) {
+			// If an exception is thrown here, Mixin is designed to skip over this service.
+			// This also happens with its bundled LaunchWrapper and ModLauncher implementations.
+			throw new UnsupportedOperationException("FabricGlobalPropertyService is not supported on this launch platform.");
+		}
+	}
+
 	@Override
 	public IPropertyKey resolveKey(String name) {
 		return new MixinStringPropertyKey(name);

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/Knot.java
@@ -338,6 +338,11 @@ public final class Knot extends FabricLauncherBase {
 		return provider.getEntrypoint();
 	}
 
+	@Override
+	public boolean useFabricMixinServices() {
+		return true;
+	}
+
 	public static void main(String[] args) {
 		new Knot(null).init(args);
 	}

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/MixinServiceKnot.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/MixinServiceKnot.java
@@ -108,7 +108,7 @@ public class MixinServiceKnot implements IMixinService, IClassProvider, IClassBy
 
 	@Override
 	public boolean isValid() {
-		return true;
+		return FabricLauncherBase.getLauncher().useFabricMixinServices();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/MixinServiceKnotBootstrap.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/MixinServiceKnotBootstrap.java
@@ -18,7 +18,17 @@ package net.fabricmc.loader.impl.launch.knot;
 
 import org.spongepowered.asm.service.IMixinServiceBootstrap;
 
+import net.fabricmc.loader.impl.launch.FabricLauncherBase;
+
 public class MixinServiceKnotBootstrap implements IMixinServiceBootstrap {
+	public MixinServiceKnotBootstrap() {
+		if (!FabricLauncherBase.getLauncher().useFabricMixinServices()) {
+			// If an exception is thrown here, Mixin is designed to skip over this service.
+			// This also happens with its bundled LaunchWrapper and ModLauncher implementations.
+			throw new UnsupportedOperationException("MixinServiceKnotBootstrap is not supported on this launch platform.");
+		}
+	}
+
 	@Override
 	public String getName() {
 		return "Knot";


### PR DESCRIPTION
Mixin provides its own bundled implementations on some other platforms (LaunchWrapper, ModLauncher) that can be used instead. As far as I can tell, this was the behaviour with LaunchWrapper before Knot was introduced in #37.