### PR TITLE
MinecraftGameProvider: Support split assets jar

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -23,6 +23,7 @@ enum McLibrary implements LibraryType {
 	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class"),
 	MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
 	MC_COMMON("net/minecraft/server/MinecraftServer.class"),
+	MC_ASSETS_ROOT("assets/.mcassetsroot"),
 	MC_BUNDLER(EnvType.SERVER, "net/minecraft/bundler/Main.class"),
 	REALMS(EnvType.CLIENT, "realmsVersion", "com/mojang/realmsclient/RealmsVersion.class"),
 	MODLOADER("ModLoader"),

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -205,6 +205,12 @@ public class MinecraftGameProvider implements GameProvider {
 				gameJars.add(commonGameJar);
 			}
 
+			Path assetsJar = classifier.getOrigin(McLibrary.MC_ASSETS_ROOT);
+
+			if (assetsJar != null && !assetsJar.equals(commonGameJar) && !assetsJar.equals(envGameJar)) {
+				gameJars.add(assetsJar);
+			}
+
 			entrypoint = classifier.getClassName(envGameLib);
 			realmsJar = classifier.getOrigin(McLibrary.REALMS);
 			hasModLoader = classifier.has(McLibrary.MODLOADER);


### PR DESCRIPTION
Companion PR to #790. The older one is needed for ModLauncher support, this one is needed for running on ML together with Forge. Forge splits the MC assets into a separate jar on modern versions, so it needs to be recognised as an MC jar as well.

(If it's not recognised, random things like the detected MC version break.)