### PR TITLE
Add Automatic-Module-Name to jar manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,8 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 	manifest {
 		attributes (
 			'Main-Class': 'net.fabricmc.loader.impl.launch.server.FabricServerLauncher',
-			'Fabric-Loom-Remap': 'false'
+			'Fabric-Loom-Remap': 'false',
+			'Automatic-Module-Name': 'net.fabricmc.loader'
 		)
 	}
 

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -27,6 +27,12 @@ java {
 	withSourcesJar()
 }
 
+jar {
+	manifest {
+		attributes 'Automatic-Module-Name': 'net.fabricmc.loader.junit'
+	}
+}
+
 if (signingEnabled) {
 	remoteSign {
 		requestUrl = ENV.SIGNING_SERVER


### PR DESCRIPTION
This allows modular apps and libraries to depend on Loader in their module-info files without relying on the file name.

Companion PR to #790 and #793 – being able to use a module-info makes developing for ModLauncher a bit nicer.