### PR TITLE
Allow fabric-loader-junit EnvType to be changed

### DIFF
--- a/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
+++ b/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
@@ -17,7 +17,6 @@
 package net.fabricmc.loader.impl.junit;
 
 import java.util.Locale;
-import java.util.Optional;
 
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;

--- a/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
+++ b/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
@@ -42,8 +42,7 @@ public class FabricLoaderLauncherSessionListener implements LauncherSessionListe
 		final ClassLoader originalClassLoader = currentThread.getContextClassLoader();
 
 		// parse the test environment type, defaults to client
-		final EnvType envType = Optional.ofNullable(System.getProperty(SystemProperties.SIDE))
-				.map(FabricLoaderLauncherSessionListener::parseEnvType).orElse(EnvType.CLIENT);
+		final EnvType envType = EnvType.valueOf(System.getProperty(SystemProperties.SIDE, EnvType.CLIENT.name()).toUpperCase(Locale.ROOT));
 
 		try {
 			knot = new Knot(envType);

--- a/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
+++ b/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
@@ -64,15 +64,4 @@ public class FabricLoaderLauncherSessionListener implements LauncherSessionListe
 		final Thread currentThread = Thread.currentThread();
 		currentThread.setContextClassLoader(launcherSessionClassLoader);
 	}
-
-	private static EnvType parseEnvType(String side) {
-		switch (side.toLowerCase(Locale.ROOT)) {
-		case "client":
-			return EnvType.CLIENT;
-		case "server":
-			return EnvType.SERVER;
-		default:
-			throw new RuntimeException("Invalid side provided: must be \"client\" or \"server\"!");
-		}
-	}
 }


### PR DESCRIPTION
This allows the EnvType in `FabricLoaderLauncherSessionListener` to be tweaked via the `fabric.side` system property.
With this, server-only mods can also be unit tested.
Closes #804.

Minor detail: It would be better to introduce a utility method somewhere that parses the `fabric.side` property.
I essentially use the same switch block as in `Knot#init`. However, introducing the method to the `fabric-loader` subproject would also require a new version of `fabric-loader` for such a minor feature. Therefore, I've duplicated the parser for now.

## Usage
One way to tweak the unit-test EnvType, in Gradle buildscripts:
```groovy
tasks {
    test {
        systemProperty("fabric.side", "server")
    }
}
```

I will also open a pull request on loom for automatically adding the property when `loom.serverOnlyMinecraftJar()` is configured.