### PR TITLE
Fix call to findResources returns empty.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -61,6 +61,10 @@ final class KnotClassLoader extends SecureClassLoader implements ClassLoaderAcce
 		return delegate;
 	}
 
+	public DynamicURLClassLoader getUrlLoader() {
+		return urlLoader;
+	}
+
 	@Override
 	public URL getResource(String name) {
 		Objects.requireNonNull(name);
@@ -79,6 +83,13 @@ final class KnotClassLoader extends SecureClassLoader implements ClassLoaderAcce
 		Objects.requireNonNull(name);
 
 		return urlLoader.findResource(name);
+	}
+
+	@Override
+	public Enumeration<URL> findResources(String name) throws IOException {
+		Objects.requireNonNull(name);
+
+		return urlLoader.findResources(name);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -61,10 +61,6 @@ final class KnotClassLoader extends SecureClassLoader implements ClassLoaderAcce
 		return delegate;
 	}
 
-	public DynamicURLClassLoader getUrlLoader() {
-		return urlLoader;
-	}
-
 	@Override
 	public URL getResource(String name) {
 		Objects.requireNonNull(name);


### PR DESCRIPTION
Fix the issue that findResources returns empty due to not overriding findResources.
Added getUrlLoader() to allow developers to access other URLClassLoader methods that are not overridden by KnotClassLoader.