### PR TITLE
Rework external library handling.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,31 +54,55 @@ sourceSets {
 }
 
 configurations {
-	include
+	include {
+		transitive = false
+	}
 
 	implementation {
 		extendsFrom include
 	}
+
+	installer {
+		transitive = false
+	}
+	installerLaunchWrapper {
+		transitive = false
+		extendsFrom installer
+	}
+
+	api {
+		extendsFrom installer
+	}
 }
+
+repositories {
+	maven {
+		name = 'Mojang'
+		url = 'https://libraries.minecraft.net/'
+		content {
+			includeGroup "net.minecraft"
+		}
+	}
+}
+
 
 dependencies {
 	// fabric-loader dependencies
-	api "org.ow2.asm:asm:${project.asm_version}"
-	api "org.ow2.asm:asm-analysis:${project.asm_version}"
-	api "org.ow2.asm:asm-commons:${project.asm_version}"
-	api "org.ow2.asm:asm-tree:${project.asm_version}"
-	api "org.ow2.asm:asm-util:${project.asm_version}"
+	installer "org.ow2.asm:asm:${project.asm_version}"
+	installer "org.ow2.asm:asm-analysis:${project.asm_version}"
+	installer "org.ow2.asm:asm-commons:${project.asm_version}"
+	installer "org.ow2.asm:asm-tree:${project.asm_version}"
+	installer "org.ow2.asm:asm-util:${project.asm_version}"
+	installer "net.fabricmc:sponge-mixin:${project.mixin_version}"
+	// removed with mapping-io PR
+	installer "net.fabricmc:tiny-mappings-parser:0.3.0+build.17"
+	installerLaunchWrapper "net.minecraft:launchwrapper:1.12"
 
-	api("net.fabricmc:sponge-mixin:${project.mixin_version}") {
-		exclude module: 'launchwrapper'
-		exclude module: 'guava'
-	}
-	api 'net.fabricmc:tiny-mappings-parser:0.3.0+build.17'
-	api 'net.fabricmc:tiny-remapper:0.8.2'
-	api 'net.fabricmc:access-widener:2.1.0'
-
+	// impl dependencies
 	include 'org.ow2.sat4j:org.ow2.sat4j.core:2.3.6'
 	include 'org.ow2.sat4j:org.ow2.sat4j.pb:2.3.6'
+	include "net.fabricmc:tiny-remapper:0.8.2"
+	include "net.fabricmc:access-widener:2.1.0"
 
 	testCompileOnly 'org.jetbrains:annotations:23.0.0'
 
@@ -86,6 +110,8 @@ dependencies {
 	testImplementation('org.junit.jupiter:junit-jupiter:5.9.2')
 	testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 }
+
+apply from: rootProject.file('gradle/installer-json.gradle')
 
 processResources {
 	inputs.property "version", project.version
@@ -156,6 +182,8 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 	configurations = [project.configurations.include]
 
 	relocate 'org.sat4j', 'net.fabricmc.loader.impl.lib.sat4j'
+	relocate 'net.fabricmc.accesswidener', 'net.fabricmc.loader.impl.lib.accesswidener'
+	relocate 'net.fabricmc.tinyremapper', 'net.fabricmc.loader.impl.lib.tinyremapper'
 
 	exclude 'about.html'
 	exclude 'sat4j.version'

--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,8 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 	exclude 'about.html'
 	exclude 'sat4j.version'
 	exclude 'META-INF/maven/org.ow2.sat4j/*/**'
+	exclude 'META-INF/*.RSA'
+	exclude 'META-INF/*.SF'
 
 	outputs.upToDateWhen { false }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/installer-json.gradle')
+apply from: rootProject.file('gradle/launcher.gradle')
 
 processResources {
 	inputs.property "version", project.version

--- a/gradle/installer-json.gradle
+++ b/gradle/installer-json.gradle
@@ -1,4 +1,6 @@
-tasks.register("generateInstallerJson", GenerateInstallerJson) {
+import groovy.json.JsonOutput
+
+tasks.register("generateInstallerJson", GenerateInstallerJsonTask) {
 	configurations = [ common: "installer" ]
 	outputFile = file("src/main/resources/fabric-installer.json")
 	options = [
@@ -9,7 +11,7 @@ tasks.register("generateInstallerJson", GenerateInstallerJson) {
 	]
 }
 
-tasks.register("generateLaunchWrapperInstallerJson", GenerateInstallerJson) {
+tasks.register("generateLaunchWrapperInstallerJson", GenerateInstallerJsonTask) {
 	configurations = [ common: "installerLaunchWrapper" ]
 	outputFile = file("src/main/resources/fabric-installer.launchwrapper.json")
 	options = [
@@ -33,7 +35,7 @@ tasks.register("generateLaunchWrapperInstallerJson", GenerateInstallerJson) {
 	]
 }
 
-abstract class GenerateInstallerJson extends DefaultTask {
+abstract class GenerateInstallerJsonTask extends DefaultTask {
 	@Input
 	abstract MapProperty<String, String> getConfigurations()
 
@@ -43,7 +45,7 @@ abstract class GenerateInstallerJson extends DefaultTask {
 	@OutputFile
 	abstract RegularFileProperty getOutputFile()
 
-	GenerateInstallerJson() {
+	GenerateInstallerJsonTask() {
 		outputs.upToDateWhen { false }
 	}
 
@@ -72,7 +74,7 @@ abstract class GenerateInstallerJson extends DefaultTask {
 		}
 
 		json.putAll(options.get())
-		getOutputFile().get().asFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(json))
+		getOutputFile().get().asFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(json))
 	}
 
 	Map<String, Object> resolveHashes(String artifact) {

--- a/gradle/installer-json.gradle
+++ b/gradle/installer-json.gradle
@@ -52,6 +52,7 @@ abstract class GenerateInstallerJson extends DefaultTask {
 
 		def json = [
 		    version: 2,
+			min_java_version: 8,
 			libraries: [
 				client: [],
 				common: [],

--- a/gradle/installer-json.gradle
+++ b/gradle/installer-json.gradle
@@ -51,7 +51,7 @@ abstract class GenerateInstallerJson extends DefaultTask {
 	def run() {
 
 		def json = [
-		    version: 1,
+		    version: 2,
 			libraries: [
 				client: [],
 				common: [],

--- a/gradle/installer-json.gradle
+++ b/gradle/installer-json.gradle
@@ -1,0 +1,96 @@
+tasks.register("generateInstallerJson", GenerateInstallerJson) {
+	configurations = [ common: "installer" ]
+	outputFile = file("src/main/resources/fabric-installer.json")
+	options = [
+		mainClasses: [
+			client: "net.fabricmc.loader.impl.launch.knot.KnotClient",
+			server: "net.fabricmc.loader.impl.launch.knot.KnotServer"
+		]
+	]
+}
+
+tasks.register("generateLaunchWrapperInstallerJson", GenerateInstallerJson) {
+	configurations = [ common: "installerLaunchWrapper" ]
+	outputFile = file("src/main/resources/fabric-installer.launchwrapper.json")
+	options = [
+		mainClass: "net.minecraft.launchwrapper.Launch",
+		arguments: [
+			client: [],
+			common: [],
+			server: [],
+		],
+		launchwrapper: [
+			tweakers: [
+				client: [
+					"net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricClientTweaker"
+				],
+				common: [],
+				server: [
+					"net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricServerTweaker"
+				]
+			]
+		]
+	]
+}
+
+abstract class GenerateInstallerJson extends DefaultTask {
+	@Input
+	abstract MapProperty<String, String> getConfigurations()
+
+	@Input
+	abstract MapProperty<String, Object> getOptions()
+
+	@OutputFile
+	abstract RegularFileProperty getOutputFile()
+
+	GenerateInstallerJson() {
+		outputs.upToDateWhen { false }
+	}
+
+	@TaskAction
+	def run() {
+
+		def json = [
+		    version: 1,
+			libraries: [
+				client: [],
+				common: [],
+				server: [],
+				development: [],
+			]
+		]
+
+		configurations.get().each { side, name ->
+			def resolvedArtifacts = project.configurations.getByName(name).resolvedConfiguration.resolvedArtifacts
+			for (final def artifact in resolvedArtifacts) {
+				def library = [name: artifact.moduleVersion.toString(), url: "https://maven.fabricmc.net/"]
+				library.putAll(resolveHashes(artifact.moduleVersion.toString()))
+
+				json.libraries[side].add(library)
+			}
+		}
+
+		json.putAll(options.get())
+		getOutputFile().get().asFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(json))
+	}
+
+	Map<String, String> resolveHashes(String artifact) {
+		if (artifact.startsWith("net.minecraft:launchwrapper")) {
+			// Launch wrapper only has sha1 hashes on its maven.
+			return [
+				md5: resolveHash(artifact, "sha1"),
+			]
+		}
+
+		return [
+			md5: resolveHash(artifact, "md5"),
+			sha1: resolveHash(artifact, "sha1"),
+			sha256: resolveHash(artifact, "sha256"),
+			sha512: resolveHash(artifact, "sha512"),
+		]
+	}
+	String resolveHash(String artifact, String hash) {
+		def config = project.configurations.detachedConfiguration(project.dependencies.create("${artifact}@jar.${hash}"))
+		return config.singleFile.text
+	}
+}

--- a/gradle/installer-json.gradle
+++ b/gradle/installer-json.gradle
@@ -74,11 +74,12 @@ abstract class GenerateInstallerJson extends DefaultTask {
 		getOutputFile().get().asFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(json))
 	}
 
-	Map<String, String> resolveHashes(String artifact) {
+	Map<String, Object> resolveHashes(String artifact) {
 		if (artifact.startsWith("net.minecraft:launchwrapper")) {
 			// Launch wrapper only has sha1 hashes on its maven.
 			return [
 				md5: resolveHash(artifact, "sha1"),
+				size: resolveSize(artifact),
 			]
 		}
 
@@ -87,10 +88,17 @@ abstract class GenerateInstallerJson extends DefaultTask {
 			sha1: resolveHash(artifact, "sha1"),
 			sha256: resolveHash(artifact, "sha256"),
 			sha512: resolveHash(artifact, "sha512"),
+			size: resolveSize(artifact),
 		]
 	}
+
 	String resolveHash(String artifact, String hash) {
 		def config = project.configurations.detachedConfiguration(project.dependencies.create("${artifact}@jar.${hash}"))
 		return config.singleFile.text
+	}
+
+	long resolveSize(String artifact) {
+		def config = project.configurations.detachedConfiguration(project.dependencies.create("${artifact}@jar"))
+		return config.singleFile.size()
 	}
 }

--- a/gradle/launcher.gradle
+++ b/gradle/launcher.gradle
@@ -1,0 +1,88 @@
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+// A task to install the development version of Fabric Loader to the Minecraft launcher
+tasks.register("installDevelopmentVersion", InstallDevelopmentVersionTask) {
+	installerJson = file("src/main/resources/fabric-installer.json")
+	loaderJar = proguardJar.outputs.files.singleFile
+	dependsOn proguardJar
+}
+
+abstract class InstallDevelopmentVersionTask extends DefaultTask {
+	@Input
+	@Option(option = "mc-version", description = "The Minecraft version to install")
+	abstract Property<String> getMinecraftVersion()
+
+	@Input
+	@Option(option = "version-name", description = "The profile name to use")
+	abstract Property<String> getVersionName()
+
+	@InputFile
+	abstract RegularFileProperty getInstallerJson()
+
+	@InputFile
+	abstract RegularFileProperty getLoaderJar()
+
+	@OutputFile
+	abstract RegularFileProperty getVersionJsonFile()
+
+	@OutputFile
+	abstract RegularFileProperty getLoaderLibraryFile()
+
+	InstallDevelopmentVersionTask() {
+		versionName.convention("fabric-loader-${project.version.toString()}")
+		minecraftVersion.convention("1.20.2")
+		versionJsonFile.set(project.layout.file(project.provider {
+			new File(getDotMinecraftDirectory(), "versions/${versionName.get()}/${versionName.get()}.json")
+		}))
+		loaderLibraryFile.set(project.layout.file(project.provider {
+			new File(getDotMinecraftDirectory(), "libraries/net/fabricmc/fabric-loader/${project.version.toString()}/fabric-loader-${project.version.toString()}.jar")
+		}))
+	}
+
+	@TaskAction
+	void runTask() {
+		loaderLibraryFile.get().getAsFile().parentFile.mkdirs()
+		loaderLibraryFile.get().getAsFile().bytes = loaderJar.get().getAsFile().bytes
+
+		def installerJson = new JsonSlurper().parse(installerJson.get().getAsFile())
+
+		// Creates the versions json for the Minecraft launcher
+		def versionMeta = [
+			id: versionName.get(),
+			time: new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+			releaseTime: new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+			type: "release",
+			inheritsFrom: minecraftVersion.get(),
+			mainClass: installerJson.mainClasses.client,
+			libraries: installerJson.libraries.common,
+		]
+
+		versionMeta.libraries.add([
+			name: "net.fabricmc:fabric-loader:${project.version.toString()}",
+			url: "https://maven.fabricmc.net/",
+		])
+
+		versionMeta.libraries.add([
+			name: "net.fabricmc:intermediary:${minecraftVersion.get()}",
+			url: "https://maven.fabricmc.net/",
+		])
+
+		versionJsonFile.get().getAsFile().parentFile.mkdirs()
+		versionJsonFile.get().asFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(versionMeta))
+
+		project.logger.lifecycle("Installed Fabric Loader ${project.version.toString()} for Minecraft ${minecraftVersion.get()} as ${versionName.get()}")
+	}
+
+	static File getDotMinecraftDirectory() {
+		def os = System.getProperty("os.name").toLowerCase(Locale.ROOT)
+		if (os.contains("win")) {
+			return new File(System.getenv("APPDATA"), ".minecraft")
+		} else if (os.contains("mac")) {
+			return new File(System.getProperty("user.home"), "Library/Application Support/minecraft")
+		} else {
+			return new File(System.getProperty("user.home"), ".minecraft")
+		}
+	}
+}
+

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -11,7 +11,8 @@
                 "md5": "6f8bccf756f170d4185bb24c8c2d2020",
                 "sha1": "aa205cf0a06dbd8e04ece91c0b37c3f5d567546a",
                 "sha256": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
-                "sha512": "01a5ea6f5b43bf094c52a50e18325a60af7bb02e74d24f9bc2c727d43e514578fd968b30ff22f9d2720caec071458f9ff82d11a21fbb1ebc42d8203e737c4b52"
+                "sha512": "01a5ea6f5b43bf094c52a50e18325a60af7bb02e74d24f9bc2c727d43e514578fd968b30ff22f9d2720caec071458f9ff82d11a21fbb1ebc42d8203e737c4b52",
+                "size": 123598
             },
             {
                 "name": "org.ow2.asm:asm-analysis:9.6",
@@ -19,7 +20,8 @@
                 "md5": "31c84ef7cc893fb278952ae2d6a2674f",
                 "sha1": "9ce6c7b174bd997fc2552dff47964546bd7a5ec3",
                 "sha256": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
-                "sha512": "e798d451addabbaeace3adf8d8e939430241d9665c81b98b0a7a705c9b91ddbb67ff86b1f7b9a7ef317f225d38da3319ed40e0fd33ddace3d2ac75c3f7b78b02"
+                "sha512": "e798d451addabbaeace3adf8d8e939430241d9665c81b98b0a7a705c9b91ddbb67ff86b1f7b9a7ef317f225d38da3319ed40e0fd33ddace3d2ac75c3f7b78b02",
+                "size": 34041
             },
             {
                 "name": "org.ow2.asm:asm-commons:9.6",
@@ -27,7 +29,8 @@
                 "md5": "9e317c75534bd1da8c00a67c618ab288",
                 "sha1": "f1a9e5508eff490744144565c47326c8648be309",
                 "sha256": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
-                "sha512": "8739143062b0589e3c55d9a8fc67b716cc9b8ce8ecb6f4c1f968b587b3117c6806dae8dba92c79a52eeef05b10b25b01bb26f4e77fd20d2f52ddf2f56438901f"
+                "sha512": "8739143062b0589e3c55d9a8fc67b716cc9b8ce8ecb6f4c1f968b587b3117c6806dae8dba92c79a52eeef05b10b25b01bb26f4e77fd20d2f52ddf2f56438901f",
+                "size": 72194
             },
             {
                 "name": "org.ow2.asm:asm-tree:9.6",
@@ -35,7 +38,8 @@
                 "md5": "6062608f1a98afe1e853d01fa1221a9e",
                 "sha1": "c0cdda9d211e965d2a4448aa3fd86110f2f8c2de",
                 "sha256": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
-                "sha512": "ae0416ae62b9260da5012a3c5b6e12f34f4a0d016ec9cc9a2a1e771af12a9d63e36315c199f85d7a9d424ae39500253def0a0a581befa26d4372b21efec44781"
+                "sha512": "ae0416ae62b9260da5012a3c5b6e12f34f4a0d016ec9cc9a2a1e771af12a9d63e36315c199f85d7a9d424ae39500253def0a0a581befa26d4372b21efec44781",
+                "size": 51935
             },
             {
                 "name": "org.ow2.asm:asm-util:9.6",
@@ -43,7 +47,8 @@
                 "md5": "bd3bc1c176a787373e9a031073c9574b",
                 "sha1": "f77caf84eb93786a749b2baa40865b9613e3eaee",
                 "sha256": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
-                "sha512": "1b92e1fae7d0c082bccf751bdaeae3bf32d28b9e555c9989ad70d3e5156d19e9547232c5886a53af1973da51bf9f61266336f3bcc55ea2cf972b76370a0bd8ba"
+                "sha512": "1b92e1fae7d0c082bccf751bdaeae3bf32d28b9e555c9989ad70d3e5156d19e9547232c5886a53af1973da51bf9f61266336f3bcc55ea2cf972b76370a0bd8ba",
+                "size": 91131
             },
             {
                 "name": "net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5",
@@ -51,7 +56,8 @@
                 "md5": "4cc3ff559cafdc70d9ed80e869d447f0",
                 "sha1": "8d31fb97c3e0cd7c8dad3441851c523bcfae6d8e",
                 "sha256": "43d46bce43e1df1210970ce2e8610c4f617bb4173093eae975f7abd4de1bf0fa",
-                "sha512": "bc177a4c5cfb5605e627bfbd9101ec69df260fc54f0e8792a962e953df9c29a84a3deb8a243dfec91dba3845224b950fac5673e1d98d9ad78badb2394063eafd"
+                "sha512": "bc177a4c5cfb5605e627bfbd9101ec69df260fc54f0e8792a962e953df9c29a84a3deb8a243dfec91dba3845224b950fac5673e1d98d9ad78badb2394063eafd",
+                "size": 1451874
             },
             {
                 "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
@@ -59,7 +65,8 @@
                 "md5": "2ecb50617a3a012062e53ca4cda50936",
                 "sha1": "02f10540a290e382a7cd35c16ec3900046a4e252",
                 "sha256": "ab91038c4b1bff9b0999eb6959e012cd0e0bf116401ebab37001ec325d877ba6",
-                "sha512": "b105efe66ee8404d503db28f98f4b0c53efc04f218a1e115001080ea7c08dfeff38b37fb95757ce8261fc3ecf617007b511b995d3f371e78659f37d154695665"
+                "sha512": "b105efe66ee8404d503db28f98f4b0c53efc04f218a1e115001080ea7c08dfeff38b37fb95757ce8261fc3ecf617007b511b995d3f371e78659f37d154695665",
+                "size": 82671
             }
         ],
         "server": [

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -1,51 +1,76 @@
 {
-  "version": 1,
-  "libraries": {
-    "client": [
-    ],
-    "common": [
-      {
-        "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "net.fabricmc:tiny-remapper:0.8.2",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "net.fabricmc:access-widener:2.1.0",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-analysis:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-commons:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-tree:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-util:9.6",
-        "url": "https://maven.fabricmc.net/"
-      }
-    ],
-    "server": [
-    ]
-  },
-  "mainClass": {
-    "client": "net.fabricmc.loader.impl.launch.knot.KnotClient",
-    "server": "net.fabricmc.loader.impl.launch.knot.KnotServer"
-  }
+    "version": 1,
+    "libraries": {
+        "client": [
+            
+        ],
+        "common": [
+            {
+                "name": "org.ow2.asm:asm:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "6f8bccf756f170d4185bb24c8c2d2020",
+                "sha1": "aa205cf0a06dbd8e04ece91c0b37c3f5d567546a",
+                "sha256": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
+                "sha512": "01a5ea6f5b43bf094c52a50e18325a60af7bb02e74d24f9bc2c727d43e514578fd968b30ff22f9d2720caec071458f9ff82d11a21fbb1ebc42d8203e737c4b52"
+            },
+            {
+                "name": "org.ow2.asm:asm-analysis:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "31c84ef7cc893fb278952ae2d6a2674f",
+                "sha1": "9ce6c7b174bd997fc2552dff47964546bd7a5ec3",
+                "sha256": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
+                "sha512": "e798d451addabbaeace3adf8d8e939430241d9665c81b98b0a7a705c9b91ddbb67ff86b1f7b9a7ef317f225d38da3319ed40e0fd33ddace3d2ac75c3f7b78b02"
+            },
+            {
+                "name": "org.ow2.asm:asm-commons:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "9e317c75534bd1da8c00a67c618ab288",
+                "sha1": "f1a9e5508eff490744144565c47326c8648be309",
+                "sha256": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
+                "sha512": "8739143062b0589e3c55d9a8fc67b716cc9b8ce8ecb6f4c1f968b587b3117c6806dae8dba92c79a52eeef05b10b25b01bb26f4e77fd20d2f52ddf2f56438901f"
+            },
+            {
+                "name": "org.ow2.asm:asm-tree:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "6062608f1a98afe1e853d01fa1221a9e",
+                "sha1": "c0cdda9d211e965d2a4448aa3fd86110f2f8c2de",
+                "sha256": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
+                "sha512": "ae0416ae62b9260da5012a3c5b6e12f34f4a0d016ec9cc9a2a1e771af12a9d63e36315c199f85d7a9d424ae39500253def0a0a581befa26d4372b21efec44781"
+            },
+            {
+                "name": "org.ow2.asm:asm-util:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "bd3bc1c176a787373e9a031073c9574b",
+                "sha1": "f77caf84eb93786a749b2baa40865b9613e3eaee",
+                "sha256": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
+                "sha512": "1b92e1fae7d0c082bccf751bdaeae3bf32d28b9e555c9989ad70d3e5156d19e9547232c5886a53af1973da51bf9f61266336f3bcc55ea2cf972b76370a0bd8ba"
+            },
+            {
+                "name": "net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "4cc3ff559cafdc70d9ed80e869d447f0",
+                "sha1": "8d31fb97c3e0cd7c8dad3441851c523bcfae6d8e",
+                "sha256": "43d46bce43e1df1210970ce2e8610c4f617bb4173093eae975f7abd4de1bf0fa",
+                "sha512": "bc177a4c5cfb5605e627bfbd9101ec69df260fc54f0e8792a962e953df9c29a84a3deb8a243dfec91dba3845224b950fac5673e1d98d9ad78badb2394063eafd"
+            },
+            {
+                "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "2ecb50617a3a012062e53ca4cda50936",
+                "sha1": "02f10540a290e382a7cd35c16ec3900046a4e252",
+                "sha256": "ab91038c4b1bff9b0999eb6959e012cd0e0bf116401ebab37001ec325d877ba6",
+                "sha512": "b105efe66ee8404d503db28f98f4b0c53efc04f218a1e115001080ea7c08dfeff38b37fb95757ce8261fc3ecf617007b511b995d3f371e78659f37d154695665"
+            }
+        ],
+        "server": [
+            
+        ],
+        "development": [
+            
+        ]
+    },
+    "mainClasses": {
+        "client": "net.fabricmc.loader.impl.launch.knot.KnotClient",
+        "server": "net.fabricmc.loader.impl.launch.knot.KnotServer"
+    }
 }

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": 2,
     "libraries": {
         "client": [
             

--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -1,5 +1,6 @@
 {
     "version": 2,
+    "min_java_version": 8,
     "libraries": {
         "client": [
             

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -1,71 +1,102 @@
 {
-  "version": 1,
-  "libraries": {
-    "client": [
-    ],
-    "common": [
-      {
-        "name": "net.minecraft:launchwrapper:1.12"
-      },
-      {
-        "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "net.fabricmc:tiny-remapper:0.8.2",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "net.fabricmc:access-widener:2.1.0",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-analysis:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-commons:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-tree:9.6",
-        "url": "https://maven.fabricmc.net/"
-      },
-      {
-        "name": "org.ow2.asm:asm-util:9.6",
-        "url": "https://maven.fabricmc.net/"
-      }
-    ],
-    "server": [
-    ]
-  },
-  "mainClass": "net.minecraft.launchwrapper.Launch",
-  "arguments": {
-    "client": [
-    ],
-    "common": [
-    ],
-    "server": [
-    ]
-  },
-  "launchwrapper": {
-    "tweakers": {
-      "client": [
-        "net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricClientTweaker"
-      ],
-      "common": [
-      ],
-      "server": [
-        "net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricServerTweaker"
-      ]
+    "version": 1,
+    "libraries": {
+        "client": [
+            
+        ],
+        "common": [
+            {
+                "name": "org.ow2.asm:asm:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "6f8bccf756f170d4185bb24c8c2d2020",
+                "sha1": "aa205cf0a06dbd8e04ece91c0b37c3f5d567546a",
+                "sha256": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
+                "sha512": "01a5ea6f5b43bf094c52a50e18325a60af7bb02e74d24f9bc2c727d43e514578fd968b30ff22f9d2720caec071458f9ff82d11a21fbb1ebc42d8203e737c4b52"
+            },
+            {
+                "name": "org.ow2.asm:asm-analysis:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "31c84ef7cc893fb278952ae2d6a2674f",
+                "sha1": "9ce6c7b174bd997fc2552dff47964546bd7a5ec3",
+                "sha256": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
+                "sha512": "e798d451addabbaeace3adf8d8e939430241d9665c81b98b0a7a705c9b91ddbb67ff86b1f7b9a7ef317f225d38da3319ed40e0fd33ddace3d2ac75c3f7b78b02"
+            },
+            {
+                "name": "org.ow2.asm:asm-commons:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "9e317c75534bd1da8c00a67c618ab288",
+                "sha1": "f1a9e5508eff490744144565c47326c8648be309",
+                "sha256": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
+                "sha512": "8739143062b0589e3c55d9a8fc67b716cc9b8ce8ecb6f4c1f968b587b3117c6806dae8dba92c79a52eeef05b10b25b01bb26f4e77fd20d2f52ddf2f56438901f"
+            },
+            {
+                "name": "org.ow2.asm:asm-tree:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "6062608f1a98afe1e853d01fa1221a9e",
+                "sha1": "c0cdda9d211e965d2a4448aa3fd86110f2f8c2de",
+                "sha256": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
+                "sha512": "ae0416ae62b9260da5012a3c5b6e12f34f4a0d016ec9cc9a2a1e771af12a9d63e36315c199f85d7a9d424ae39500253def0a0a581befa26d4372b21efec44781"
+            },
+            {
+                "name": "org.ow2.asm:asm-util:9.6",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "bd3bc1c176a787373e9a031073c9574b",
+                "sha1": "f77caf84eb93786a749b2baa40865b9613e3eaee",
+                "sha256": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
+                "sha512": "1b92e1fae7d0c082bccf751bdaeae3bf32d28b9e555c9989ad70d3e5156d19e9547232c5886a53af1973da51bf9f61266336f3bcc55ea2cf972b76370a0bd8ba"
+            },
+            {
+                "name": "net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "4cc3ff559cafdc70d9ed80e869d447f0",
+                "sha1": "8d31fb97c3e0cd7c8dad3441851c523bcfae6d8e",
+                "sha256": "43d46bce43e1df1210970ce2e8610c4f617bb4173093eae975f7abd4de1bf0fa",
+                "sha512": "bc177a4c5cfb5605e627bfbd9101ec69df260fc54f0e8792a962e953df9c29a84a3deb8a243dfec91dba3845224b950fac5673e1d98d9ad78badb2394063eafd"
+            },
+            {
+                "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "2ecb50617a3a012062e53ca4cda50936",
+                "sha1": "02f10540a290e382a7cd35c16ec3900046a4e252",
+                "sha256": "ab91038c4b1bff9b0999eb6959e012cd0e0bf116401ebab37001ec325d877ba6",
+                "sha512": "b105efe66ee8404d503db28f98f4b0c53efc04f218a1e115001080ea7c08dfeff38b37fb95757ce8261fc3ecf617007b511b995d3f371e78659f37d154695665"
+            },
+            {
+                "name": "net.minecraft:launchwrapper:1.12",
+                "url": "https://maven.fabricmc.net/",
+                "md5": "111e7bea9c968cdb3d06ef4632bf7ff0824d0f36"
+            }
+        ],
+        "server": [
+            
+        ],
+        "development": [
+            
+        ]
+    },
+    "mainClass": "net.minecraft.launchwrapper.Launch",
+    "arguments": {
+        "client": [
+            
+        ],
+        "common": [
+            
+        ],
+        "server": [
+            
+        ]
+    },
+    "launchwrapper": {
+        "tweakers": {
+            "client": [
+                "net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricClientTweaker"
+            ],
+            "common": [
+                
+            ],
+            "server": [
+                "net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricServerTweaker"
+            ]
+        }
     }
-  }
 }

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": 2,
     "libraries": {
         "client": [
             

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -1,5 +1,6 @@
 {
     "version": 2,
+    "min_java_version": 8,
     "libraries": {
         "client": [
             

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -11,7 +11,8 @@
                 "md5": "6f8bccf756f170d4185bb24c8c2d2020",
                 "sha1": "aa205cf0a06dbd8e04ece91c0b37c3f5d567546a",
                 "sha256": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
-                "sha512": "01a5ea6f5b43bf094c52a50e18325a60af7bb02e74d24f9bc2c727d43e514578fd968b30ff22f9d2720caec071458f9ff82d11a21fbb1ebc42d8203e737c4b52"
+                "sha512": "01a5ea6f5b43bf094c52a50e18325a60af7bb02e74d24f9bc2c727d43e514578fd968b30ff22f9d2720caec071458f9ff82d11a21fbb1ebc42d8203e737c4b52",
+                "size": 123598
             },
             {
                 "name": "org.ow2.asm:asm-analysis:9.6",
@@ -19,7 +20,8 @@
                 "md5": "31c84ef7cc893fb278952ae2d6a2674f",
                 "sha1": "9ce6c7b174bd997fc2552dff47964546bd7a5ec3",
                 "sha256": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
-                "sha512": "e798d451addabbaeace3adf8d8e939430241d9665c81b98b0a7a705c9b91ddbb67ff86b1f7b9a7ef317f225d38da3319ed40e0fd33ddace3d2ac75c3f7b78b02"
+                "sha512": "e798d451addabbaeace3adf8d8e939430241d9665c81b98b0a7a705c9b91ddbb67ff86b1f7b9a7ef317f225d38da3319ed40e0fd33ddace3d2ac75c3f7b78b02",
+                "size": 34041
             },
             {
                 "name": "org.ow2.asm:asm-commons:9.6",
@@ -27,7 +29,8 @@
                 "md5": "9e317c75534bd1da8c00a67c618ab288",
                 "sha1": "f1a9e5508eff490744144565c47326c8648be309",
                 "sha256": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
-                "sha512": "8739143062b0589e3c55d9a8fc67b716cc9b8ce8ecb6f4c1f968b587b3117c6806dae8dba92c79a52eeef05b10b25b01bb26f4e77fd20d2f52ddf2f56438901f"
+                "sha512": "8739143062b0589e3c55d9a8fc67b716cc9b8ce8ecb6f4c1f968b587b3117c6806dae8dba92c79a52eeef05b10b25b01bb26f4e77fd20d2f52ddf2f56438901f",
+                "size": 72194
             },
             {
                 "name": "org.ow2.asm:asm-tree:9.6",
@@ -35,7 +38,8 @@
                 "md5": "6062608f1a98afe1e853d01fa1221a9e",
                 "sha1": "c0cdda9d211e965d2a4448aa3fd86110f2f8c2de",
                 "sha256": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
-                "sha512": "ae0416ae62b9260da5012a3c5b6e12f34f4a0d016ec9cc9a2a1e771af12a9d63e36315c199f85d7a9d424ae39500253def0a0a581befa26d4372b21efec44781"
+                "sha512": "ae0416ae62b9260da5012a3c5b6e12f34f4a0d016ec9cc9a2a1e771af12a9d63e36315c199f85d7a9d424ae39500253def0a0a581befa26d4372b21efec44781",
+                "size": 51935
             },
             {
                 "name": "org.ow2.asm:asm-util:9.6",
@@ -43,7 +47,8 @@
                 "md5": "bd3bc1c176a787373e9a031073c9574b",
                 "sha1": "f77caf84eb93786a749b2baa40865b9613e3eaee",
                 "sha256": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
-                "sha512": "1b92e1fae7d0c082bccf751bdaeae3bf32d28b9e555c9989ad70d3e5156d19e9547232c5886a53af1973da51bf9f61266336f3bcc55ea2cf972b76370a0bd8ba"
+                "sha512": "1b92e1fae7d0c082bccf751bdaeae3bf32d28b9e555c9989ad70d3e5156d19e9547232c5886a53af1973da51bf9f61266336f3bcc55ea2cf972b76370a0bd8ba",
+                "size": 91131
             },
             {
                 "name": "net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5",
@@ -51,7 +56,8 @@
                 "md5": "4cc3ff559cafdc70d9ed80e869d447f0",
                 "sha1": "8d31fb97c3e0cd7c8dad3441851c523bcfae6d8e",
                 "sha256": "43d46bce43e1df1210970ce2e8610c4f617bb4173093eae975f7abd4de1bf0fa",
-                "sha512": "bc177a4c5cfb5605e627bfbd9101ec69df260fc54f0e8792a962e953df9c29a84a3deb8a243dfec91dba3845224b950fac5673e1d98d9ad78badb2394063eafd"
+                "sha512": "bc177a4c5cfb5605e627bfbd9101ec69df260fc54f0e8792a962e953df9c29a84a3deb8a243dfec91dba3845224b950fac5673e1d98d9ad78badb2394063eafd",
+                "size": 1451874
             },
             {
                 "name": "net.fabricmc:tiny-mappings-parser:0.3.0+build.17",
@@ -59,12 +65,14 @@
                 "md5": "2ecb50617a3a012062e53ca4cda50936",
                 "sha1": "02f10540a290e382a7cd35c16ec3900046a4e252",
                 "sha256": "ab91038c4b1bff9b0999eb6959e012cd0e0bf116401ebab37001ec325d877ba6",
-                "sha512": "b105efe66ee8404d503db28f98f4b0c53efc04f218a1e115001080ea7c08dfeff38b37fb95757ce8261fc3ecf617007b511b995d3f371e78659f37d154695665"
+                "sha512": "b105efe66ee8404d503db28f98f4b0c53efc04f218a1e115001080ea7c08dfeff38b37fb95757ce8261fc3ecf617007b511b995d3f371e78659f37d154695665",
+                "size": 82671
             },
             {
                 "name": "net.minecraft:launchwrapper:1.12",
                 "url": "https://maven.fabricmc.net/",
-                "md5": "111e7bea9c968cdb3d06ef4632bf7ff0824d0f36"
+                "md5": "111e7bea9c968cdb3d06ef4632bf7ff0824d0f36",
+                "size": 32999
             }
         ],
         "server": [


### PR DESCRIPTION
- Generate installer jsons
- Add library hashes + file size
- Shade + repackage tiny-remapper and access-widener these are not part of the public API. (TMP is removed as part of the MIO PR)
- Library hashes are pulled from maven and are commited to the repo.
- Bump installer.json to version 2 for added hashes and `development` library key.
- Add min java version to installer.json