### PR TITLE
Check if cached remapped jar file is valid before trying to use it

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -200,7 +200,17 @@ public final class GameProviderHelper {
 			Path outputFile = deobfJarDir.resolve(deobfJarFilename);
 			Path tmpFile = deobfJarDir.resolve(deobfJarFilename + ".tmp");
 
-			if (Files.exists(tmpFile)) { // previous unfinished remap attempt
+			boolean corrupted = false;
+			if (Files.exists(outputFile)) {
+				//noinspection EmptyTryBlock
+                try (JarFile ignored = new JarFile(outputFile.toFile())) {
+                    // The constructor will throw if the file is invalid
+                } catch (IOException e) {
+                    corrupted = true;
+                }
+            }
+
+			if (Files.exists(tmpFile) || corrupted) { // previous unfinished remap attempt
 				Log.warn(LogCategory.GAME_REMAP, "Incomplete remapped file found! This means that the remapping process failed on the previous launch. If this persists, make sure to let us at Fabric know!");
 
 				try {


### PR DESCRIPTION
### Issue
If a cached remapped JAR file (stored in `%GAMEDIR%/.fabric/remappedJars`) is corrupted in any way, it'll still be used by the loader. However, this will cause a game crash at startup.
<details>
<summary>Crash stacktrace</summary>

```
[10:42:39] [main/ERROR] (FabricLoader) Uncaught exception in thread "main"
 net.fabricmc.loader.impl.util.ExceptionUtil$WrappedException: java.io.IOException: error opening C:\Users\Octol1ttle\IdeaProjects\fabric-loader\minecraft\minecraft-test\run\.fabric\remappedJars\minecraft-1.20.2-0.14.23\client-named.jar: java.util.zip.ZipException: zip file is empty
	at net.fabricmc.loader.impl.util.ExceptionUtil.wrap(ExceptionUtil.java:51) ~[main/:?]
	at net.fabricmc.loader.impl.game.patch.GameTransformer.lambda$locateEntrypoints$0(GameTransformer.java:87) ~[main/:?]
	at net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatch.process(EntrypointPatch.java:77) ~[main/:?]
	at net.fabricmc.loader.impl.game.patch.GameTransformer.locateEntrypoints(GameTransformer.java:92) ~[main/:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.initialize(MinecraftGameProvider.java:347) ~[main/:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:140) ~[main/:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:68) ~[main/:?]
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28) ~[main/:?]
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86) ~[dev-launch-injector-0.2.1+build.8.jar:?]
Caused by: java.io.IOException: error opening C:\Users\Octol1ttle\IdeaProjects\fabric-loader\minecraft\minecraft-test\run\.fabric\remappedJars\minecraft-1.20.2-0.14.23\client-named.jar: java.util.zip.ZipException: zip file is empty
	at net.fabricmc.loader.impl.util.SimpleClassPath.getEntry(SimpleClassPath.java:80) ~[main/:?]
	at net.fabricmc.loader.impl.game.patch.GameTransformer.lambda$locateEntrypoints$0(GameTransformer.java:78) ~[main/:?]
	... 7 more
Caused by: java.util.zip.ZipException: zip file is empty
	at java.util.zip.ZipFile$Source.zerror(ZipFile.java:1598) ~[?:?]
	at java.util.zip.ZipFile$Source.findEND(ZipFile.java:1382) ~[?:?]
	at java.util.zip.ZipFile$Source.initCEN(ZipFile.java:1477) ~[?:?]
	at java.util.zip.ZipFile$Source.<init>(ZipFile.java:1315) ~[?:?]
	at java.util.zip.ZipFile$Source.get(ZipFile.java:1277) ~[?:?]
	at java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:709) ~[?:?]
	at java.util.zip.ZipFile.<init>(ZipFile.java:243) ~[?:?]
	at java.util.zip.ZipFile.<init>(ZipFile.java:172) ~[?:?]
	at java.util.zip.ZipFile.<init>(ZipFile.java:186) ~[?:?]
	at net.fabricmc.loader.impl.util.SimpleClassPath.getEntry(SimpleClassPath.java:78) ~[main/:?]
	at net.fabricmc.loader.impl.game.patch.GameTransformer.lambda$locateEntrypoints$0(GameTransformer.java:78) ~[main/:?]
	... 7 more
```
</details>

### Proposed solution
Verify that the cached JAR is valid by attempting to construct an instance of `JarFile`. The constructor will throw an `IOException` if the file is invalid. If that exception is caught, the file is deleted from disk and rebuilt.