### PR TITLE
Dont debof with classpath by default.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -274,12 +274,14 @@ public final class GameProviderHelper {
 
 		Set<Path> depPaths = new HashSet<>();
 
-		for (Path path : launcher.getClassPath()) {
-			if (!inputFiles.contains(path)) {
-				depPaths.add(path);
+		if (System.getProperty(SystemProperties.DEBUG_DEOBFUSCATE_WITH_CLASSPATH) != null) {
+			for (Path path : launcher.getClassPath()) {
+				if (!inputFiles.contains(path)) {
+					depPaths.add(path);
 
-				Log.debug(LogCategory.GAME_REMAP, "Appending '%s' to remapper classpath", path);
-				remapper.readClassPathAsync(path);
+					Log.debug(LogCategory.GAME_REMAP, "Appending '%s' to remapper classpath", path);
+					remapper.readClassPathAsync(path);
+				}
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -66,6 +66,8 @@ public final class SystemProperties {
 	public static final String DEBUG_RESOLUTION_TIMEOUT = "fabric.debug.resolutionTimeout";
 	// replace mod versions (modA:versionA,modB:versionB,...)
 	public static final String DEBUG_REPLACE_VERSION = "fabric.debug.replaceVersion";
+	// deobfuscate the game jar with the classpath
+	public static final String DEBUG_DEOBFUSCATE_WITH_CLASSPATH = "fabric.debug.deobfuscateWithClasspath";
 	// whether fabric loader is running in a unit test, this affects logging classpath setup
 	public static final String UNIT_TEST = "fabric.unitTest";
 


### PR DESCRIPTION
This saves a considerable amount of memory on the first startup. Left a system prob to enable this again if required.