### PR TITLE
Fix crash when starting 1.2.5 server

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/BrandingPatch.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/BrandingPatch.java
@@ -20,7 +20,6 @@ import java.util.ListIterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -35,12 +34,12 @@ import net.fabricmc.loader.impl.util.log.LogCategory;
 
 public final class BrandingPatch extends GamePatch {
 	@Override
-	public void process(FabricLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
+	public void process(FabricLauncher launcher, Function<String, ClassNode> classSource, Consumer<ClassNode> classEmitter) {
 		for (String brandClassName : new String[] {
 				"net.minecraft.client.ClientBrandRetriever",
 				"net.minecraft.server.MinecraftServer"
 		}) {
-			ClassNode brandClass = readClass(classSource.apply(brandClassName));
+			ClassNode brandClass = classSource.apply(brandClassName);
 
 			if (brandClass != null) {
 				if (applyBrandingPatch(brandClass)) {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
@@ -21,7 +21,6 @@ import java.util.ListIterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -62,7 +61,7 @@ public class EntrypointPatch extends GamePatch {
 	}
 
 	@Override
-	public void process(FabricLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
+	public void process(FabricLauncher launcher, Function<String, ClassNode> classSource, Consumer<ClassNode> classEmitter) {
 		EnvType type = launcher.getEnvironmentType();
 		String entrypoint = launcher.getEntrypoint();
 		Version gameVersion = getGameVersion();
@@ -74,7 +73,7 @@ public class EntrypointPatch extends GamePatch {
 		String gameEntrypoint = null;
 		boolean serverHasFile = true;
 		boolean isApplet = entrypoint.contains("Applet");
-		ClassNode mainClass = readClass(classSource.apply(entrypoint));
+		ClassNode mainClass = classSource.apply(entrypoint);
 
 		if (mainClass == null) {
 			throw new RuntimeException("Could not load main class " + entrypoint + "!");
@@ -189,7 +188,7 @@ public class EntrypointPatch extends GamePatch {
 		if (gameEntrypoint.equals(entrypoint) || is20w22aServerOrHigher) {
 			gameClass = mainClass;
 		} else {
-			gameClass = readClass(classSource.apply(gameEntrypoint));
+			gameClass = classSource.apply(gameEntrypoint);
 			if (gameClass == null) throw new RuntimeException("Could not load game class " + gameEntrypoint + "!");
 		}
 
@@ -527,22 +526,22 @@ public class EntrypointPatch extends GamePatch {
 		}
 	}
 
-	private boolean hasSuperClass(String cls, String superCls, Function<String, ClassReader> classSource) {
+	private boolean hasSuperClass(String cls, String superCls, Function<String, ClassNode> classSource) {
 		if (cls.contains("$") || (!cls.startsWith("net/minecraft") && cls.contains("/"))) {
 			return false;
 		}
 
-		ClassReader reader = classSource.apply(cls);
+		ClassNode classNode = classSource.apply(cls);
 
-		return reader != null && reader.getSuperName().equals(superCls);
+		return classNode != null && classNode.superName.equals(superCls);
 	}
 
-	private boolean hasStrInMethod(String cls, String methodName, String methodDesc, String str, Function<String, ClassReader> classSource) {
+	private boolean hasStrInMethod(String cls, String methodName, String methodDesc, String str, Function<String, ClassNode> classSource) {
 		if (cls.contains("$") || (!cls.startsWith("net/minecraft") && cls.contains("/"))) {
 			return false;
 		}
 
-		ClassNode node = readClass(classSource.apply(cls));
+		ClassNode node = classSource.apply(cls);
 		if (node == null) return false;
 
 		for (MethodNode method : node.methods) {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatchFML125.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatchFML125.java
@@ -40,7 +40,7 @@ public class EntrypointPatchFML125 extends GamePatch {
 	private static final String TO_INTERNAL = "cpw/mods/fml/common/ModClassLoader";
 
 	@Override
-	public void process(FabricLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
+	public void process(FabricLauncher launcher, Function<String, ClassNode> classSource, Consumer<ClassNode> classEmitter) {
 		if (classSource.apply(TO) != null
 				&& classSource.apply("cpw.mods.fml.relauncher.FMLRelauncher") == null) {
 			if (!(launcher instanceof Knot)) {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
@@ -20,7 +20,6 @@ import java.util.ListIterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -47,7 +46,7 @@ public final class TinyFDPatch extends GamePatch {
 	private static final String DIALOG_TITLE = "Select settings file (.json)";
 
 	@Override
-	public void process(FabricLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
+	public void process(FabricLauncher launcher, Function<String, ClassNode> classSource, Consumer<ClassNode> classEmitter) {
 		if (launcher.getEnvironmentType() != EnvType.CLIENT) {
 			// Fix should only be applied to clients.
 			return;
@@ -61,7 +60,7 @@ public final class TinyFDPatch extends GamePatch {
 			className = FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", MORE_OPTIONS_DIALOG_CLASS_NAME);
 		}
 
-		final ClassNode classNode = readClass(classSource.apply(className));
+		final ClassNode classNode = classSource.apply(className);
 
 		if (classNode == null) {
 			// Class is not present in this version, nothing to do.

--- a/src/main/java/net/fabricmc/loader/impl/game/patch/GamePatch.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/patch/GamePatch.java
@@ -23,7 +23,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -33,14 +32,6 @@ import org.objectweb.asm.tree.MethodNode;
 import net.fabricmc.loader.impl.launch.FabricLauncher;
 
 public abstract class GamePatch {
-	protected static ClassNode readClass(ClassReader reader) {
-		if (reader == null) return null;
-
-		ClassNode node = new ClassNode();
-		reader.accept(node, 0);
-		return node;
-	}
-
 	protected FieldNode findField(ClassNode node, Predicate<FieldNode> predicate) {
 		return node.fields.stream().filter(predicate).findAny().orElse(null);
 	}
@@ -128,5 +119,5 @@ public abstract class GamePatch {
 		return ((access & 0x0F) == (Opcodes.ACC_PUBLIC | 0 /* non-static */));
 	}
 
-	public abstract void process(FabricLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter);
+	public abstract void process(FabricLauncher launcher, Function<String, ClassNode> classSource, Consumer<ClassNode> classEmitter);
 }


### PR DESCRIPTION
This allows multiple GamePatches to patch the same class by reusing the emitted ClassNode from previous patches. Previously in all but one place the ClassNode was used, so this change should have minimal overhead.

Fixes #819 Blocks #861