### PR TITLE
Use TR's MixinExtension to remap jars built without refmaps in dev.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
 	// impl dependencies
 	include 'org.ow2.sat4j:org.ow2.sat4j.core:2.3.6'
 	include 'org.ow2.sat4j:org.ow2.sat4j.pb:2.3.6'
-	include "net.fabricmc:tiny-remapper:0.8.2"
+	include "net.fabricmc:tiny-remapper:0.10.0"
 	include "net.fabricmc:access-widener:2.1.0"
 	include ('net.fabricmc:mapping-io:0.5.0') {
 		// Mapping-io depends on ASM, dont bundle


### PR DESCRIPTION
Tested with a mix of mods using both old and new.