### PR TITLE
Added support for 1.20.5 in 2024 in McVersionLookup

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McVersionLookup.java
@@ -287,7 +287,7 @@ public final class McVersionLookup {
 			int year = Integer.parseInt(matcher.group(1));
 			int week = Integer.parseInt(matcher.group(2));
 
-			if (year >= 23 && week >= 51) {
+			if (year == 23 && week >= 51 || year >= 24) {
 				return "1.20.5";
 			} else if (year == 23 && week >= 40 && week <= 46) {
 				return "1.20.3";


### PR DESCRIPTION
This fixes version lookup of 1.20.5 breaking with latest snapshot (24w03a)