### PR TITLE
add a system property to enable fixing package access regardless of target namespace

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
@@ -30,6 +30,7 @@ import java.util.zip.ZipError;
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.loader.impl.util.ManifestUtil;
+import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 import net.fabricmc.loader.impl.util.mappings.FilteringMappingVisitor;
@@ -41,6 +42,8 @@ import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class MappingConfiguration {
+	private static final boolean FIX_PACKAGE_ACCESS = System.getProperty(SystemProperties.FIX_PACKAGE_ACCESS) != null;
+
 	private boolean initializedMetadata;
 	private boolean initializedMappings;
 
@@ -93,7 +96,7 @@ public final class MappingConfiguration {
 
 	public boolean requiresPackageAccessHack() {
 		// TODO
-		return getTargetNamespace().equals("named");
+		return FIX_PACKAGE_ACCESS || getTargetNamespace().equals("named");
 	}
 
 	private void initializeMetadata() {

--- a/src/main/java/net/fabricmc/loader/impl/transformer/FabricTransformer.java
+++ b/src/main/java/net/fabricmc/loader/impl/transformer/FabricTransformer.java
@@ -24,11 +24,14 @@ import net.fabricmc.accesswidener.AccessWidenerClassVisitor;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
+import net.fabricmc.loader.impl.util.SystemProperties;
 
 public final class FabricTransformer {
+	private static final boolean FIX_PACKAGE_ACCESS = System.getProperty(SystemProperties.FIX_PACKAGE_ACCESS) != null;
+
 	public static byte[] transform(boolean isDevelopment, EnvType envType, String name, byte[] bytes) {
 		boolean isMinecraftClass = name.startsWith("net.minecraft.") || name.startsWith("com.mojang.blaze3d.") || name.indexOf('.') < 0;
-		boolean transformAccess = isMinecraftClass && FabricLauncherBase.getLauncher().getMappingConfiguration().requiresPackageAccessHack();
+		boolean transformAccess = isMinecraftClass && (FIX_PACKAGE_ACCESS || FabricLauncherBase.getLauncher().getMappingConfiguration().requiresPackageAccessHack());
 		boolean environmentStrip = !isMinecraftClass || isDevelopment;
 		boolean applyAccessWidener = isMinecraftClass && FabricLoaderImpl.INSTANCE.getAccessWidener().getTargets().contains(name);
 

--- a/src/main/java/net/fabricmc/loader/impl/transformer/FabricTransformer.java
+++ b/src/main/java/net/fabricmc/loader/impl/transformer/FabricTransformer.java
@@ -24,14 +24,11 @@ import net.fabricmc.accesswidener.AccessWidenerClassVisitor;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
-import net.fabricmc.loader.impl.util.SystemProperties;
 
 public final class FabricTransformer {
-	private static final boolean FIX_PACKAGE_ACCESS = System.getProperty(SystemProperties.FIX_PACKAGE_ACCESS) != null;
-
 	public static byte[] transform(boolean isDevelopment, EnvType envType, String name, byte[] bytes) {
 		boolean isMinecraftClass = name.startsWith("net.minecraft.") || name.startsWith("com.mojang.blaze3d.") || name.indexOf('.') < 0;
-		boolean transformAccess = isMinecraftClass && (FIX_PACKAGE_ACCESS || FabricLauncherBase.getLauncher().getMappingConfiguration().requiresPackageAccessHack());
+		boolean transformAccess = isMinecraftClass && FabricLauncherBase.getLauncher().getMappingConfiguration().requiresPackageAccessHack();
 		boolean environmentStrip = !isMinecraftClass || isDevelopment;
 		boolean applyAccessWidener = isMinecraftClass && FabricLoaderImpl.INSTANCE.getAccessWidener().getTargets().contains(name);
 

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -42,6 +42,8 @@ public final class SystemProperties {
 	public static final String REMAP_CLASSPATH_FILE = "fabric.remapClasspathFile";
 	// class path groups to map multiple class path entries to a mod (paths separated by path separator, groups by double path separator)
 	public static final String PATH_GROUPS = "fabric.classPathGroups";
+	// enable the fixing of package access errors in the game jar(s)
+	public static final String FIX_PACKAGE_ACCESS = "fabric.fixPackageAccess";
 	// system level libraries, matching code sources will not be assumed to be part of the game or mods and remain on the system class path (paths separated by path separator)
 	public static final String SYSTEM_LIBRARIES = "fabric.systemLibraries";
 	// throw exceptions from entrypoints, discovery etc. directly instead of gathering and attaching as suppressed


### PR DESCRIPTION
- independent of game provider
- the launch arg is parsed after the game provider is initialized (so that the mapping configuration is loaded)