### PR TITLE
Add cache directory API

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -212,6 +212,13 @@ public interface FabricLoader {
 	File getGameDirectory();
 
 	/**
+	 * Get the current directory for temporary files.
+	 *
+	 * @return the cache directory
+	 */
+	Path getCacheDir();
+
+	/**
 	 * Get the current directory for game configuration files.
 	 *
 	 * @return the configuration directory

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -248,7 +248,11 @@ public final class GameProviderHelper {
 	}
 
 	private static Path getDeobfJarDir(Path gameDir, String gameId, String gameVersion) {
-		Path ret = gameDir.resolve(FabricLoaderImpl.CACHE_DIR_NAME).resolve(FabricLoaderImpl.REMAPPED_JARS_DIR_NAME);
+		FabricLoaderImpl loader = FabricLoaderImpl.INSTANCE;
+
+		loader.setGameDir(gameDir);
+		Path ret = loader.getCacheDir().resolve(FabricLoaderImpl.MOD_ID).resolve(FabricLoaderImpl.REMAPPED_JARS_DIR_NAME);
+
 		StringBuilder versionDirName = new StringBuilder();
 
 		if (!gameId.isEmpty()) {


### PR DESCRIPTION
Adds a standardized cache directory API for mods (and loader) to use.

I'd like to see Fabric Loader (and hopefully also mods) adopt the usage of a standardized cache directory to remove clutter of temporary files mixed with regular game and config files, as well as allowing modpack tooling to ignore these files across the board.

Previously I've added a similar feature to Quilt Loader which has been adopted by some mods, and have contributed to Prism Launcher to ignore this folder when exporting instances or modpacks, which I believe especially helps new modpack creators decide which files they should and shouldn't include in their pack.
