### PR TITLE
Skip synthetic methods in entrypoints

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/DefaultLanguageAdapter.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/DefaultLanguageAdapter.java
@@ -70,6 +70,11 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 					continue;
 				}
 
+				// Skip synthetic methods, such as the main(String[]) method added by kotlin when using top-level functions
+				if (m.isSynthetic()) {
+					continue;
+				}
+
 				methodList.add(m);
 			}
 


### PR DESCRIPTION
Skip synthetic methods in entrypoints, such as the main(String[]) method added by kotlin when using top-level functions.

Im not sure if I like this, and it technically is a breaking change (although I doubt anyone is using this?)