### PR TITLE
Support non-semver game versions

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
@@ -43,7 +43,6 @@ import net.fabricmc.loader.impl.game.patch.GamePatch;
 import net.fabricmc.loader.impl.launch.FabricLauncher;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
-import net.fabricmc.loader.impl.util.version.VersionParser;
 import net.fabricmc.loader.impl.util.version.VersionPredicateParser;
 
 public class EntrypointPatch extends GamePatch {
@@ -567,7 +566,7 @@ public class EntrypointPatch extends GamePatch {
 
 	private Version getGameVersion() {
 		try {
-			return VersionParser.parseSemantic(gameProvider.getNormalizedGameVersion());
+			return Version.parse(gameProvider.getNormalizedGameVersion());
 		} catch (VersionParsingException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/net/fabricmc/loader/impl/metadata/BuiltinModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/BuiltinModMetadata.java
@@ -33,7 +33,6 @@ import net.fabricmc.loader.api.metadata.ModDependency;
 import net.fabricmc.loader.api.metadata.ModEnvironment;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.api.metadata.Person;
-import net.fabricmc.loader.impl.util.version.VersionParser;
 
 public final class BuiltinModMetadata extends AbstractModMetadata {
 	private final String id;
@@ -172,7 +171,7 @@ public final class BuiltinModMetadata extends AbstractModMetadata {
 			this.name = this.id = id;
 
 			try {
-				this.version = VersionParser.parseSemantic(version);
+				this.version = Version.parse(version);
 			} catch (VersionParsingException e) {
 				throw new RuntimeException(e);
 			}


### PR DESCRIPTION
This should allow running Loader for weird MC releases, with limited mod -> game version range comparison support of course.

It logs a warning in production, but throws an error in-dev since devs are more able to use the system property and we don't want to miss the limited normalization support.