### PR TITLE
Regex Dependency Support

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/version/VersionPredicateParser.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/VersionPredicateParser.java
@@ -38,6 +38,10 @@ public final class VersionPredicateParser {
 	public static VersionPredicate parse(String predicate) throws VersionParsingException {
 		List<SingleVersionPredicate> predicateList = new ArrayList<>();
 
+		if (predicate.startsWith("/") && predicate.endsWith("/")) {
+			return new RegexVersionPredicate(predicate);
+		}
+
 		for (String s : predicate.split(" ")) {
 			s = s.trim();
 
@@ -267,4 +271,51 @@ public final class VersionPredicateParser {
 			return ret.toString();
 		}
 	}
+
+	static class RegexVersionPredicate implements VersionPredicate {
+		private final String regex;
+
+		RegexVersionPredicate(String regex) {
+			this.regex = regex.substring(1, regex.length() - 1);
+		}
+
+		@Override
+		public boolean test(Version version) {
+			Objects.requireNonNull(version, "null version");
+
+			return version.toString().matches(regex);
+		}
+
+		@Override
+		public Collection<? extends PredicateTerm> getTerms() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public VersionInterval getInterval() {
+			return null;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof RegexVersionPredicate) {
+				RegexVersionPredicate o = (RegexVersionPredicate) obj;
+
+				return Objects.equals(regex, o.regex);
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			return regex.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return regex;
+		}
+	}
+
 }

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -93,6 +93,13 @@ public class VersionParsingTests {
 		testTrue(tryParseSemantic("1.0.0+20130313144700", false));
 		testTrue(tryParseSemantic("1.0.0-beta+exp.sha.5114f85", false));
 
+		// Test: Regex version
+		{
+			Predicate<Version> predicate = VersionPredicateParser.parse("/0\\.5\\.1-f-.+/");
+			testTrue(predicate.test(new SemanticVersionImpl("0.5.1-f-build.1417+mc1.20.1", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("0.5.1-g-build.1417+mc1.20.1", false)));
+		}
+
 		// Test: comparator range with pre-releases.
 		{
 			Predicate<Version> predicate = VersionPredicateParser.parse(">=0.3.1-beta.2 <0.4.0");


### PR DESCRIPTION
This PR aims to make depending on or breaking with mods not conforming to semver easier.

Currently if you need to depend on something that has a version string like `x.x.x-a-build.xxxx` (a being a letter) you are fully out of luck and must hard depend on the whole string, with no way to ignore the build number part. After a lot of dicussion in `#toolchain-other` (https://discord.com/channels/507304429255393322/566418023372816394/1229888975880060959) the best solution is just regex being a side option, it's helpful for other cases like this at the cost of not cleanly being able to provide suggestions in solver, which is a good sacrifice for not having to reimplement a version check yourself that aborts loading ^^. This also gives people more control over semver and just generally lets people depend/break with mods/libs not using semver.

Any dependency starting and ending with a `/` (slash) will be treated as a regex depenendency and will use `String#matches(yourRegex)` instead of the semver match.

TODO:
- Support for adding a explanation
- Force opt in? technically having a dependency string as `/abc/` is valid right now, maybe someone out there has their mod version as that?