### PR TITLE
Specify full entrypoint name on crash

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
@@ -36,9 +36,9 @@ public interface EntrypointContainer<T> {
 	ModContainer getProvider();
 
 	/**
-	 * Returns a string representation of the entrypoint.
+	 * Returns a string representation of the entrypoint's definition.
 	 */
-	default String getEntrypointName() {
-		return getProvider().getMetadata().getId();
+	default String getDefinition() {
+		return "";
 	}
 }

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
@@ -34,4 +34,9 @@ public interface EntrypointContainer<T> {
 	 * Returns the mod that provided this entrypoint.
 	 */
 	ModContainer getProvider();
+
+	/**
+	 * Returns a string representation of the entrypoint.
+	 */
+	String getEntrypointName();
 }

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
@@ -38,5 +38,7 @@ public interface EntrypointContainer<T> {
 	/**
 	 * Returns a string representation of the entrypoint.
 	 */
-	String getEntrypointName();
+	default String getEntrypointName() {
+		return getProvider().getMetadata().getId();
+	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -385,8 +385,8 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 			} catch (Throwable t) {
 				exception = ExceptionUtil.gatherExceptions(t,
 						exception,
-						exc -> new RuntimeException(String.format("Could not execute entrypoint stage '%s' due to errors, provided by '%s'!",
-								key, container.getEntrypointName()),
+						exc -> new RuntimeException(String.format("Could not execute entrypoint stage '%s' due to errors, provided by '%s' at '%s'!",
+								key, container.getProvider().getMetadata().getId(), container.getDefinition()),
 								exc));
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -386,7 +386,7 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 				exception = ExceptionUtil.gatherExceptions(t,
 						exception,
 						exc -> new RuntimeException(String.format("Could not execute entrypoint stage '%s' due to errors, provided by '%s'!",
-								key, container.getProvider().getMetadata().getId()),
+								key, container.getEntrypointName()),
 								exc));
 			}
 		}

--- a/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointContainerImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointContainerImpl.java
@@ -64,4 +64,9 @@ public final class EntrypointContainerImpl<T> implements EntrypointContainer<T> 
 	public ModContainer getProvider() {
 		return entry.getModContainer();
 	}
+
+	@Override
+	public String getEntrypointName() {
+		return entry.toString();
+	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointContainerImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointContainerImpl.java
@@ -66,7 +66,7 @@ public final class EntrypointContainerImpl<T> implements EntrypointContainer<T> 
 	}
 
 	@Override
-	public String getEntrypointName() {
-		return entry.toString();
+	public String getDefinition() {
+		return entry.getDefinition();
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointStorage.java
+++ b/src/main/java/net/fabricmc/loader/impl/entrypoint/EntrypointStorage.java
@@ -39,6 +39,8 @@ public final class EntrypointStorage {
 		boolean isOptional();
 
 		ModContainerImpl getModContainer();
+
+		String getDefinition();
 	}
 
 	@SuppressWarnings("deprecation")
@@ -87,6 +89,11 @@ public final class EntrypointStorage {
 		public ModContainerImpl getModContainer() {
 			return mod;
 		}
+
+		@Override
+		public String getDefinition() {
+			return value;
+		}
 	}
 
 	private static final class NewEntry implements Entry {
@@ -131,6 +138,11 @@ public final class EntrypointStorage {
 		@Override
 		public ModContainerImpl getModContainer() {
 			return mod;
+		}
+
+		@Override
+		public String getDefinition() {
+			return value;
 		}
 	}
 


### PR DESCRIPTION
Due to the way I use entrypoints in my projects I tend to encounter entrypoint crashes often while developing.
The current logging makes it hard to distinguish which entrypoint is being problematic at a glance.

This small change in fabric loader specifies in the log the exact entrypoint that caused the game to crash.

Essentially changes:
```
 java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'minecraft-test'!
	at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$2(FabricLoaderImpl.java:388) ~[main/:?]
```
into:
```
 java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'minecraft-test->(0.3.x)net.fabricmc.minecraft.test.TestEntrypoint::makeCrashPlz'!
	at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$2(FabricLoaderImpl.java:388) ~[main/:?]
```