### PR TITLE
Avoid jar cache when reading Manifest, reserve URL based method for special cases only

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -52,7 +52,6 @@ import net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.FabricMixinBootstrap;
 import net.fabricmc.loader.impl.util.Arguments;
-import net.fabricmc.loader.impl.util.FileSystemUtil;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.ManifestUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
@@ -237,13 +236,7 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 	@Override
 	public Manifest getManifest(Path originPath) {
 		try {
-			if (Files.isDirectory(originPath)) {
-				return ManifestUtil.readManifest(originPath);
-			} else {
-				try (FileSystemUtil.FileSystemDelegate jarFs = FileSystemUtil.getJarFileSystem(originPath, false)) {
-					return ManifestUtil.readManifest(jarFs.get().getRootDirectories().iterator().next());
-				}
-			}
+			return ManifestUtil.readManifest(originPath);
 		} catch (IOException e) {
 			Log.warn(LOG_CATEGORY, "Error reading Manifest", e);
 			return null;

--- a/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
@@ -222,8 +222,9 @@ public final class RuntimeModRemapper {
 	}
 
 	private static boolean requiresMixinRemap(Path inputPath) throws IOException, URISyntaxException {
-		final Manifest manifest = ManifestUtil.readManifest(inputPath.toUri().toURL());
+		final Manifest manifest = ManifestUtil.readManifest(inputPath);
 		final Attributes mainAttributes = manifest.getMainAttributes();
+
 		return REMAP_TYPE_STATIC.equalsIgnoreCase(mainAttributes.getValue(REMAP_TYPE_MANIFEST_KEY));
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -371,7 +371,7 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 
 			try {
 				if (Files.isDirectory(path)) {
-					manifest = ManifestUtil.readManifest(path);
+					manifest = ManifestUtil.readManifestFromBasePath(path);
 				} else {
 					URLConnection connection = new URL("jar:" + path.toUri().toString() + "!/").openConnection();
 
@@ -382,7 +382,7 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 
 					if (manifest == null) {
 						try (FileSystemUtil.FileSystemDelegate jarFs = FileSystemUtil.getJarFileSystem(path, false)) {
-							manifest = ManifestUtil.readManifest(jarFs.get().getRootDirectories().iterator().next());
+							manifest = ManifestUtil.readManifestFromBasePath(jarFs.get().getRootDirectories().iterator().next());
 						}
 					}
 


### PR DESCRIPTION
This bypasses the URL connection for cases where the jar file may not be used after startup.

Needs testing

(hopefully) fixes https://github.com/FabricMC/fabric-loader/issues/920