### PR TITLE
Add Git commit hash version comparing

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/metadata/version/VersionComparisonOperator.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/version/VersionComparisonOperator.java
@@ -18,6 +18,7 @@ package net.fabricmc.loader.api.metadata.version;
 
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.impl.util.version.CommitHashVersion;
 import net.fabricmc.loader.impl.util.version.SemanticVersionImpl;
 
 public enum VersionComparisonOperator {
@@ -26,6 +27,11 @@ public enum VersionComparisonOperator {
 		@Override
 		public boolean test(SemanticVersion a, SemanticVersion b) {
 			return a.compareTo((Version) b) >= 0;
+		}
+
+		@Override
+		public boolean test(CommitHashVersion a, CommitHashVersion b) {
+			return a.compareTo(b) >= 0;
 		}
 
 		@Override
@@ -40,6 +46,11 @@ public enum VersionComparisonOperator {
 		}
 
 		@Override
+		public boolean test(CommitHashVersion a, CommitHashVersion b) {
+			return a.compareTo(b) <= 0;
+		}
+
+		@Override
 		public SemanticVersion maxVersion(SemanticVersion version) {
 			return version;
 		}
@@ -48,6 +59,11 @@ public enum VersionComparisonOperator {
 		@Override
 		public boolean test(SemanticVersion a, SemanticVersion b) {
 			return a.compareTo((Version) b) > 0;
+		}
+
+		@Override
+		public boolean test(CommitHashVersion a, CommitHashVersion b) {
+			return a.compareTo(b) > 0;
 		}
 
 		@Override
@@ -62,6 +78,11 @@ public enum VersionComparisonOperator {
 		}
 
 		@Override
+		public boolean test(CommitHashVersion a, CommitHashVersion b) {
+			return a.compareTo(b) < 0;
+		}
+
+		@Override
 		public SemanticVersion maxVersion(SemanticVersion version) {
 			return version;
 		}
@@ -70,6 +91,11 @@ public enum VersionComparisonOperator {
 		@Override
 		public boolean test(SemanticVersion a, SemanticVersion b) {
 			return a.compareTo((Version) b) == 0;
+		}
+
+		@Override
+		public boolean test(CommitHashVersion a, CommitHashVersion b) {
+			return a.compareTo(b) == 0;
 		}
 
 		@Override
@@ -91,6 +117,11 @@ public enum VersionComparisonOperator {
 		}
 
 		@Override
+		public boolean test(CommitHashVersion a, CommitHashVersion b) {
+			throw new UnsupportedOperationException("This operator is not supported for Git hash string versions");
+		}
+
+		@Override
 		public SemanticVersion minVersion(SemanticVersion version) {
 			return version;
 		}
@@ -105,6 +136,11 @@ public enum VersionComparisonOperator {
 		public boolean test(SemanticVersion a, SemanticVersion b) {
 			return a.compareTo((Version) b) >= 0
 					&& a.getVersionComponent(0) == b.getVersionComponent(0);
+		}
+
+		@Override
+		public boolean test(CommitHashVersion a, CommitHashVersion b) {
+			throw new UnsupportedOperationException("This operator is not supported for Git hash string versions");
 		}
 
 		@Override
@@ -143,6 +179,8 @@ public enum VersionComparisonOperator {
 	public final boolean test(Version a, Version b) {
 		if (a instanceof SemanticVersion && b instanceof SemanticVersion) {
 			return test((SemanticVersion) a, (SemanticVersion) b);
+		} else if (a instanceof CommitHashVersion && b instanceof CommitHashVersion) {
+			return test((CommitHashVersion) a, (CommitHashVersion) b);
 		} else if (minInclusive || maxInclusive) {
 			return a.getFriendlyString().equals(b.getFriendlyString());
 		} else {
@@ -151,6 +189,8 @@ public enum VersionComparisonOperator {
 	}
 
 	public abstract boolean test(SemanticVersion a, SemanticVersion b);
+
+	public abstract boolean test(CommitHashVersion a, CommitHashVersion b);
 
 	public SemanticVersion minVersion(SemanticVersion version) {
 		return null;

--- a/src/main/java/net/fabricmc/loader/impl/metadata/V1ModMetadataParser.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/V1ModMetadataParser.java
@@ -115,7 +115,7 @@ final class V1ModMetadataParser {
 				}
 
 				try {
-					version = VersionParser.parse(reader.nextString(), false);
+					version = VersionParser.parse(reader.nextString(), false, contact);
 				} catch (VersionParsingException e) {
 					throw new ParseMetadataException("Failed to parse version", e);
 				}

--- a/src/main/java/net/fabricmc/loader/impl/util/version/CommitHashVersion.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/CommitHashVersion.java
@@ -1,0 +1,105 @@
+package net.fabricmc.loader.impl.util.version;
+
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.impl.lib.gson.JsonReader;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CommitHashVersion implements Version {
+	private static final Pattern GIT_COMMIT_HASH_PATTERN = Pattern.compile("^[0-9a-fA-F]{40}$");
+	private static final Pattern SOURCES_PATTERN = Pattern.compile("^(?:https?://)?github\\.com/([\\w-]+)/([\\w-]+)/?$");
+
+	private final String commitHash;
+	private final Instant commitDate;
+
+	public CommitHashVersion(String commitHash, String sources) throws VersionParsingException {
+		if (!GIT_COMMIT_HASH_PATTERN.matcher(commitHash).matches()) {
+			throw new VersionParsingException("Invalid Git commit hash");
+		}
+
+		this.commitHash = commitHash;
+
+		Matcher matcher = SOURCES_PATTERN.matcher(sources);
+		if (!matcher.matches()) {
+			throw new VersionParsingException("Unsupported or invalid sources link");
+		}
+
+		String apiUrlString = String.format("https://api.github.com/repos/%s/%s/git/commits/%s", matcher.group(1), matcher.group(2), this.commitHash);
+		URL apiUrl;
+		try {
+			apiUrl = new URL(apiUrlString);
+		} catch (MalformedURLException e) {
+			throw new VersionParsingException("Sources URL is malformed");
+		}
+
+		String dateString;
+		try (JsonReader reader = new JsonReader(new InputStreamReader(apiUrl.openStream()))) {
+			reader.beginObject();
+
+			// skip sha, node id, url, HTML url, author
+			for (int i = 0; i < 5; i++) {
+				reader.nextName();
+				reader.skipValue();
+			}
+
+			reader.nextName();
+			reader.beginObject();
+			// skip name, email
+			for (int i = 0; i < 2; i++) {
+				reader.nextName();
+				reader.skipValue();
+			}
+			reader.nextName();
+			dateString = reader.nextString();
+		} catch (IOException e) {
+			throw new VersionParsingException("Could not connect to GitHub's API");
+		}
+
+		Instant date;
+		try {
+			date = Instant.parse(dateString);
+		} catch (DateTimeParseException e) {
+			throw new VersionParsingException("Date could not be parsed");
+		}
+
+		this.commitDate = date;
+	}
+
+	@Override
+	public String getFriendlyString() {
+		return String.format("%s (%s)", this.commitHash.substring(0, 7), this.commitDate.toString());
+	}
+
+	@Override
+	public int compareTo(@NotNull Version other) {
+		if (!(other instanceof CommitHashVersion)) {
+			return this.getFriendlyString().compareTo(other.getFriendlyString());
+		}
+
+		return this.commitDate.compareTo(((CommitHashVersion) other).commitDate);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof CommitHashVersion) {
+			return this.commitHash.equals(((CommitHashVersion) obj).commitHash);
+		}
+
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return this.getFriendlyString();
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/util/version/CommitHashVersion.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/CommitHashVersion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.loader.impl.util.version;
 
 import net.fabricmc.loader.api.Version;

--- a/src/main/java/net/fabricmc/loader/impl/util/version/CommitHashVersion.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/CommitHashVersion.java
@@ -16,12 +16,6 @@
 
 package net.fabricmc.loader.impl.util.version;
 
-import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.VersionParsingException;
-import net.fabricmc.loader.impl.lib.gson.JsonReader;
-
-import org.jetbrains.annotations.NotNull;
-
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
@@ -30,6 +24,12 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.impl.lib.gson.JsonReader;
 
 public class CommitHashVersion implements Version {
 	private static final Pattern GIT_COMMIT_HASH_PATTERN = Pattern.compile("^[0-9a-fA-F]{40}$");
@@ -46,12 +46,14 @@ public class CommitHashVersion implements Version {
 		this.commitHash = commitHash;
 
 		Matcher matcher = SOURCES_PATTERN.matcher(sources);
+
 		if (!matcher.matches()) {
 			throw new VersionParsingException("Unsupported or invalid sources link");
 		}
 
 		String apiUrlString = String.format("https://api.github.com/repos/%s/%s/git/commits/%s", matcher.group(1), matcher.group(2), this.commitHash);
 		URL apiUrl;
+
 		try {
 			apiUrl = new URL(apiUrlString);
 		} catch (MalformedURLException e) {
@@ -59,6 +61,7 @@ public class CommitHashVersion implements Version {
 		}
 
 		String dateString;
+
 		try (JsonReader reader = new JsonReader(new InputStreamReader(apiUrl.openStream()))) {
 			reader.beginObject();
 
@@ -70,11 +73,13 @@ public class CommitHashVersion implements Version {
 
 			reader.nextName();
 			reader.beginObject();
+
 			// skip name, email
 			for (int i = 0; i < 2; i++) {
 				reader.nextName();
 				reader.skipValue();
 			}
+
 			reader.nextName();
 			dateString = reader.nextString();
 		} catch (IOException e) {
@@ -82,6 +87,7 @@ public class CommitHashVersion implements Version {
 		}
 
 		Instant date;
+
 		try {
 			date = Instant.parse(dateString);
 		} catch (DateTimeParseException e) {

--- a/src/main/java/net/fabricmc/loader/impl/util/version/VersionParser.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/VersionParser.java
@@ -19,9 +19,14 @@ package net.fabricmc.loader.impl.util.version;
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 
 public final class VersionParser {
 	public static Version parse(String s, boolean storeX) throws VersionParsingException {
+		return parse(s, storeX, null);
+	}
+
+	public static Version parse(String s, boolean storeX, ContactInformation contact) throws VersionParsingException {
 		if (s == null || s.isEmpty()) {
 			throw new VersionParsingException("Version must be a non-empty string!");
 		}
@@ -31,7 +36,16 @@ public final class VersionParser {
 		try {
 			version = new SemanticVersionImpl(s, storeX);
 		} catch (VersionParsingException e) {
-			version = new StringVersion(s);
+			String sources;
+			if (contact != null && (sources = contact.get("sources").orElse(null)) != null) {
+				try {
+					version = new CommitHashVersion(s, sources);
+				} catch (VersionParsingException ex) {
+					version = new StringVersion(s);
+				}
+			} else {
+				version = new StringVersion(s);
+			}
 		}
 
 		return version;

--- a/src/main/java/net/fabricmc/loader/impl/util/version/VersionParser.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/VersionParser.java
@@ -37,6 +37,7 @@ public final class VersionParser {
 			version = new SemanticVersionImpl(s, storeX);
 		} catch (VersionParsingException e) {
 			String sources;
+
 			if (contact != null && (sources = contact.get("sources").orElse(null)) != null) {
 				try {
 					version = new CommitHashVersion(s, sources);

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -340,11 +340,8 @@ public class VersionParsingTests {
 		testTrue(tryParseCommitHash("d9a000670180e73569a6983c423dd4299278afda", "github.com/fabricMC/fabric-loader/"));
 
 		// Test: Comparing Commit Hash versions.
-		Map<String, String> contactMap = new HashMap<String, String>() {
-			{
-				put("sources", "https://github.com/fabricMC/fabric-loader/");
-			}
-		};
+		Map<String, String> contactMap = new HashMap<>();
+		contactMap.put("sources", "https://github.com/fabricMC/fabric-loader/");
 		ContactInformation contact = new ContactInformationImpl(contactMap);
 
 		{

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -22,12 +22,11 @@ import java.util.function.Predicate;
 
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.impl.metadata.ContactInformationImpl;
 import net.fabricmc.loader.impl.util.version.CommitHashVersion;
-
-import net.fabricmc.loader.api.Version;
-import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.impl.util.version.SemanticVersionImpl;
 import net.fabricmc.loader.impl.util.version.VersionPredicateParser;
 

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -20,11 +20,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.fabricmc.loader.impl.metadata.ContactInformationImpl;
 import net.fabricmc.loader.impl.util.version.CommitHashVersion;
-
-import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -341,9 +341,11 @@ public class VersionParsingTests {
 		testTrue(tryParseCommitHash("d9a000670180e73569a6983c423dd4299278afda", "github.com/fabricMC/fabric-loader/"));
 
 		// Test: Comparing Commit Hash versions.
-		Map<String, String> contactMap = new HashMap<String, String>() {{
-			put("sources", "https://github.com/fabricMC/fabric-loader/");
-		}};
+		Map<String, String> contactMap = new HashMap<String, String>() {
+			{
+				put("sources", "https://github.com/fabricMC/fabric-loader/");
+			}
+		};
 		ContactInformation contact = new ContactInformationImpl(contactMap);
 
 		{

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -345,14 +345,17 @@ public class VersionParsingTests {
 			put("sources", "https://github.com/fabricMC/fabric-loader/");
 		}};
 		ContactInformation contact = new ContactInformationImpl(contactMap);
+
 		{
 			Predicate<Version> predicate = VersionPredicateParser.parse("d9a000670180e73569a6983c423dd4299278afda", contact);
 			testTrue(predicate.test(new CommitHashVersion("d9a000670180e73569a6983c423dd4299278afda", "https://github.com/fabricMC/fabric-loader/")));
 		}
+
 		{
 			Predicate<Version> predicate = VersionPredicateParser.parse(">=4dbcb72dcce4e4034f58ed3839da41aae097c901", contact);
 			testTrue(predicate.test(new CommitHashVersion("d9a000670180e73569a6983c423dd4299278afda", "https://github.com/fabricMC/fabric-loader/")));
 		}
+
 		{
 			Predicate<Version> predicate = VersionPredicateParser.parse("<4dbcb72dcce4e4034f58ed3839da41aae097c901", contact);
 			testFalse(predicate.test(new CommitHashVersion("d9a000670180e73569a6983c423dd4299278afda", "https://github.com/fabricMC/fabric-loader/")));
@@ -364,6 +367,7 @@ public class VersionParsingTests {
 		} catch (UnsupportedOperationException e) {
 			testFalse(e);
 		}
+
 		try {
 			VersionPredicateParser.parse("^4dbcb72dcce4e4034f58ed3839da41aae097c901", contact);
 		} catch (UnsupportedOperationException e) {


### PR DESCRIPTION
This PR proposes the addition of a new method to compare version strings that are commit hashes. It is very common for snapshot releases to set their version to the commit hash. Before they were not comparable, and would just use `String#compare` instead, which is completely arbitrary.

The comparison is done by extracting the commit metadata from GitHub's API. For this it must be the case that a `sources` entry is present in the `contact` object of the `fabric.mod.json`, and that it is set before the JSON reader reaches the `version` entry. Mod developers would have to be made aware of this. Note that due to the nature of this comparison, it will not be available when not connected to the internet.