### PR TITLE
Allow game provider to specify mod directories

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -150,6 +150,13 @@ public class MinecraftGameProvider implements GameProvider {
 	}
 
 	@Override
+	public List<Path> getModDirectories() {
+		String directory = System.getProperty(SystemProperties.MODS_FOLDER);
+
+		return directory != null ? Collections.singletonList(Paths.get(directory)) : Collections.singletonList(getLaunchDirectory().resolve("mods"));
+	}
+	
+	@Override
 	public boolean isObfuscated() {
 		return true; // generally yes...
 	}
@@ -482,4 +489,5 @@ public class MinecraftGameProvider implements GameProvider {
 			throw FormattedException.ofLocalized("exception.minecraft.generic", t);
 		}
 	}
+
 }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -150,13 +150,6 @@ public class MinecraftGameProvider implements GameProvider {
 	}
 
 	@Override
-	public List<Path> getModDirectories() {
-		String directory = System.getProperty(SystemProperties.MODS_FOLDER);
-
-		return directory != null ? Collections.singletonList(Paths.get(directory)) : Collections.singletonList(getLaunchDirectory().resolve("mods"));
-	}
-	
-	@Override
 	public boolean isObfuscated() {
 		return true; // generally yes...
 	}
@@ -489,5 +482,4 @@ public class MinecraftGameProvider implements GameProvider {
 			throw FormattedException.ofLocalized("exception.minecraft.generic", t);
 		}
 	}
-
 }

--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -209,7 +208,9 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		ModDiscoverer discoverer = new ModDiscoverer(versionOverrides, depOverrides);
 		discoverer.addCandidateFinder(new ClasspathModCandidateFinder());
-		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(getModsDirectory0(), remapRegularMods));
+		for(Path dir : getModDirectories0()) {
+			discoverer.addCandidateFinder(new DirectoryModCandidateFinder(dir, remapRegularMods));
+		}
 		discoverer.addCandidateFinder(new ArgumentModCandidateFinder(remapRegularMods));
 
 		Map<String, Set<ModCandidateImpl>> envDisabledMods = new HashMap<>();
@@ -610,13 +611,6 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 		return getGameProvider().getLaunchArguments(sanitize);
 	}
 
-	@Override
-	protected Path getModsDirectory0() {
-		String directory = System.getProperty(SystemProperties.MODS_FOLDER);
-
-		return directory != null ? Paths.get(directory) : gameDir.resolve("mods");
-	}
-
 	/**
 	 * Provides singleton for static init assignment regardless of load order.
 	 */
@@ -632,5 +626,10 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 	static {
 		LoaderUtil.verifyNotInTargetCl(FabricLoaderImpl.class);
+	}
+
+	@Override
+	public List<Path> getModDirectories0() {
+		return provider.getModDirectories();
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -17,7 +17,9 @@
 package net.fabricmc.loader.impl.game;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -26,6 +28,7 @@ import net.fabricmc.loader.impl.game.patch.GameTransformer;
 import net.fabricmc.loader.impl.launch.FabricLauncher;
 import net.fabricmc.loader.impl.util.Arguments;
 import net.fabricmc.loader.impl.util.LoaderUtil;
+import net.fabricmc.loader.impl.util.SystemProperties;
 
 public interface GameProvider { // name directly referenced in net.fabricmc.loader.impl.launch.knot.Knot.findEmbedddedGameProvider() and service loader records
 	String getGameId();
@@ -36,7 +39,11 @@ public interface GameProvider { // name directly referenced in net.fabricmc.load
 
 	String getEntrypoint();
 	Path getLaunchDirectory();
-	List<Path> getModDirectories();
+	default List<Path> getModDirectories() {
+		String directory = System.getProperty(SystemProperties.MODS_FOLDER);
+
+		return directory != null ? Collections.singletonList(Paths.get(directory)) : Collections.singletonList(getLaunchDirectory().resolve("mods"));
+	}
 	boolean isObfuscated();
 	boolean requiresUrlClassLoader();
 

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -36,6 +36,7 @@ public interface GameProvider { // name directly referenced in net.fabricmc.load
 
 	String getEntrypoint();
 	Path getLaunchDirectory();
+	List<Path> getModDirectories();
 	boolean isObfuscated();
 	boolean requiresUrlClassLoader();
 

--- a/src/main/legacyJava/net/fabricmc/loader/FabricLoader.java
+++ b/src/main/legacyJava/net/fabricmc/loader/FabricLoader.java
@@ -37,8 +37,16 @@ public abstract class FabricLoader implements net.fabricmc.loader.api.FabricLoad
 	@Deprecated
 	public static final FabricLoader INSTANCE = FabricLoaderImpl.InitHelper.get();
 
+	/**
+	 * @deprecated Use {@link getModDirectories()} instead
+	 */
+	@Deprecated
 	public File getModsDirectory() {
-		return getModsDirectory0().toFile();
+		return getModDirectories0().get(0).toFile();
+	}
+	
+	public List<Path> getModDirectories() {
+		return getModDirectories0();
 	}
 
 	@Override
@@ -54,5 +62,5 @@ public abstract class FabricLoader implements net.fabricmc.loader.api.FabricLoad
 		return (List) getAllMods();
 	}
 
-	protected abstract Path getModsDirectory0();
+	protected abstract List<Path> getModDirectories0();
 }


### PR DESCRIPTION
Some games can load mods from multiple directories. Fabric loader should be able to handle this. See https://github.com/WilderForge/WilderForge/issues/53

This PR Aims to add 2 new features:

1. The ability to load mods from multiple directories
2. Game providers are now responsible for specifying which directories to load mods from

I'm seeking feedback on this PR, specifically relating on how to deprecate the `SystemProperties.MODS_FOLDER` system property. 

I'm not sure if a `MOD_FOLDERS` replacement system property is even desirable. I think the implementation could possibly just be up to game providers to implement.