### PR TITLE
Suppress asm library bundled with the MC server jar (24w33a)

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/BundlerClassPathCapture.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/BundlerClassPathCapture.java
@@ -16,8 +16,11 @@
 
 package net.fabricmc.loader.impl.game.minecraft;
 
+import java.io.IOException;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
 import java.util.concurrent.CompletableFuture;
 
 public final class BundlerClassPathCapture {
@@ -26,9 +29,42 @@ public final class BundlerClassPathCapture {
 	public static void main(String[] args) { // invoked by the bundler on a thread
 		try {
 			URLClassLoader cl = (URLClassLoader) Thread.currentThread().getContextClassLoader();
-			FUTURE.complete(cl.getURLs());
+			URL[] urls = cl.getURLs();
+
+			// suppress asm library since it conflicts with Loader's, needed for MC 24w33a
+
+			URL asmUrl = cl.findResource("org/objectweb/asm/ClassReader.class");
+
+			if (asmUrl != null && (asmUrl = getJarUrl(asmUrl)) != null) {
+				for (int i = 0; i < urls.length; i++) {
+					if (urls[i].equals(asmUrl)) {
+						URL[] newUrls = new URL[urls.length - 1];
+						System.arraycopy(urls, 0, newUrls, 0, i);
+						System.arraycopy(urls, i + 1, newUrls, i, urls.length - i - 1);
+						urls = newUrls;
+						break;
+					}
+				}
+			}
+
+			FUTURE.complete(urls);
 		} catch (Throwable t) {
 			FUTURE.completeExceptionally(t);
 		}
+	}
+
+	/**
+	 * Transform jar:file url to its outer file url.
+	 *
+	 * <p>jar:file:/path/to.jar!/pkg/Cls.class -> file:/path/to.jar
+	 */
+	private static URL getJarUrl(URL url) throws IOException {
+		URLConnection connection = url.openConnection();
+
+		if (connection instanceof JarURLConnection) {
+			return ((JarURLConnection) connection).getJarFileURL();
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
This strips the bogus asm jar from the gathered URLs before passing them back to Loader. The code avoids using Loader's classes due to the specific class loader setup.