### PR TITLE
Use less path normalization due to poor performance on Windows

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ClasspathModCandidateFinder.java
@@ -54,7 +54,8 @@ public class ClasspathModCandidateFinder implements ModCandidateFinder {
 					URL url = mods.nextElement();
 
 					try {
-						Path path = LoaderUtil.normalizeExistingPath(UrlUtil.getCodeSource(url, "fabric.mod.json"));
+						Path path = UrlUtil.getCodeSource(url, "fabric.mod.json");
+						assert path.equals(LoaderUtil.normalizeExistingPath(path));
 						List<Path> paths = pathGroups.get(path);
 
 						if (paths == null) {

--- a/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
@@ -25,6 +25,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.EnumSet;
 
+import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 
@@ -33,7 +34,7 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 	private final boolean requiresRemap;
 
 	public DirectoryModCandidateFinder(Path path, boolean requiresRemap) {
-		this.path = path;
+		this.path = LoaderUtil.normalizePath(path);
 		this.requiresRemap = requiresRemap;
 	}
 
@@ -42,6 +43,7 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 		if (!Files.exists(path)) {
 			try {
 				Files.createDirectory(path);
+				return;
 			} catch (IOException e) {
 				throw new RuntimeException("Could not create directory " + path, e);
 			}

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
@@ -92,24 +92,17 @@ public final class ModDiscoverer {
 		List<Future<ModCandidateImpl>> futures = new ArrayList<>();
 
 		ModCandidateConsumer taskSubmitter = (paths, requiresRemap) -> {
-			if (paths.size() == 1) {
-				Path path = LoaderUtil.normalizeExistingPath(paths.get(0));
+			List<Path> pendingPaths = new ArrayList<>(paths.size());
+
+			for (Path path : paths) {
+				assert path.equals(LoaderUtil.normalizeExistingPath(path));
 
 				if (processedPaths.add(path)) {
-					futures.add(pool.submit(new ModScanTask(Collections.singletonList(path), requiresRemap)));
-				}
-			} else {
-				List<Path> normalizedPaths = new ArrayList<>(paths.size());
-
-				for (Path path : paths) {
-					normalizedPaths.add(LoaderUtil.normalizeExistingPath(path));
-				}
-
-				if (!processedPaths.containsAll(normalizedPaths)) {
-					processedPaths.addAll(normalizedPaths);
-					futures.add(pool.submit(new ModScanTask(normalizedPaths, requiresRemap)));
+					pendingPaths.add(path);
 				}
 			}
+
+			futures.add(pool.submit(new ModScanTask(pendingPaths, requiresRemap)));
 		};
 
 		for (ModCandidateFinder finder : candidateFinders) {

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -512,7 +512,10 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 
 	private static Path getCodeSource(URL url, String fileName) {
 		try {
-			return LoaderUtil.normalizeExistingPath(UrlUtil.getCodeSource(url, fileName));
+			Path ret = UrlUtil.getCodeSource(url, fileName);
+			assert ret.equals(LoaderUtil.normalizeExistingPath(ret)); // ret should already be normalized
+
+			return ret;
 		} catch (UrlConversionException e) {
 			throw ExceptionUtil.wrap(e);
 		}

--- a/src/test/java/net/fabricmc/loader/impl/discovery/GetNonFabricModsTest.java
+++ b/src/test/java/net/fabricmc/loader/impl/discovery/GetNonFabricModsTest.java
@@ -38,6 +38,7 @@ import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.launch.FabricLauncher;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
+import net.fabricmc.loader.impl.util.LoaderUtil;
 
 public class GetNonFabricModsTest {
 	private FabricLoaderImpl loader;
@@ -102,8 +103,8 @@ public class GetNonFabricModsTest {
 	public static class MockCandidateFinder implements ModCandidateFinder {
 		@Override
 		public void findCandidates(ModCandidateConsumer out) {
-			out.accept(Paths.get("./src/test/resources/testing/discovery/dummyFabricMod.jar"), false);
-			out.accept(Paths.get("./src/test/resources/testing/discovery/dummyNonFabricMod.jar"), false);
+			out.accept(LoaderUtil.normalizePath(Paths.get("src/test/resources/testing/discovery/dummyFabricMod.jar")), false);
+			out.accept(LoaderUtil.normalizePath(Paths.get("src/test/resources/testing/discovery/dummyNonFabricMod.jar")), false);
 		}
 	}
 }


### PR DESCRIPTION
This removes some theoretically redundant path normalization, only doing some extra validation with asserts enabled (`-ea`)

Fixes https://github.com/FabricMC/fabric-loader/issues/970