### PR TITLE
Add Property for recursive mod loading

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/DirectoryModCandidateFinder.java
@@ -26,6 +26,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.EnumSet;
 
 import net.fabricmc.loader.impl.util.LoaderUtil;
+import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 
@@ -54,10 +55,12 @@ public class DirectoryModCandidateFinder implements ModCandidateFinder {
 		}
 
 		try {
-			Files.walkFileTree(this.path, EnumSet.of(FileVisitOption.FOLLOW_LINKS), 1, new SimpleFileVisitor<Path>() {
+			Files.walkFileTree(this.path, EnumSet.of(FileVisitOption.FOLLOW_LINKS), System.getProperty(SystemProperties.LOAD_MODS_RECURSIVELY) != null ? Integer.MAX_VALUE : 1, new SimpleFileVisitor<Path>() {
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-					if (isValidFile(file)) {
+					if (file.getParent() != null && file.getParent().toString().contains("disabled")) {
+						return FileVisitResult.SKIP_SUBTREE;
+					} else if (isValidFile(file)) {
 						out.accept(file, requiresRemap);
 					}
 

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -34,6 +34,8 @@ public final class SystemProperties {
 	public static final String LOG_LEVEL = "fabric.log.level";
 	// a path to a directory to replace the default mod search directory
 	public static final String MODS_FOLDER = "fabric.modsFolder";
+	// whether to load mods recursively from the mods folder. Paths that contain "disabled" are ignored
+	public static final String LOAD_MODS_RECURSIVELY = "fabric.loadModsRecursively";
 	// additional mods to load (path separator separated paths, @ prefix for meta-file with each line referencing an actual file)
 	public static final String ADD_MODS = "fabric.addMods";
 	// a comma-separated list of mod ids to disable, even if they're discovered. mostly useful for unit testing.


### PR DESCRIPTION
fixes #81 
This pr adds the `-Dfabric.loadModsRecursively` system property which will cause the default mods folder to be loaded recursively. Paths containing "disabled" are ignored. This way we don't break existing setups which use a subfolder with any name to make sure mods are not loaded but provide users with an option to easily categorize their mods