### PR TITLE
Update build.yml to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: modmuss50/xvfb-action@v1
         with:
           run: ./gradlew :minecraft:minecraft-test:runProductionAutoTestClient --stacktrace --warning-mode=fail
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Client Test Screenshots


### PR DESCRIPTION
As discussed on the Fabric Discord server (`#toolchain-other`).

Bumping `actions/upload-artifact` to `v4` to prepare for the [deprecation of v3](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/).