### PR TITLE
Handle multiple FabricLoaderLauncherSessionListener instances.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ dependencies {
 	testImplementation('org.junit.jupiter:junit-jupiter:5.9.2')
 	testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 
-	testImplementation("org.mockito:mockito-core:5.10.0")
+	testImplementation("org.mockito:mockito-core:5.11.3")
 }
 
 apply from: rootProject.file('gradle/installer-json.gradle')

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -18,7 +18,7 @@ repositories {
 dependencies {
 	api project(":")
 
-	api platform("org.junit:junit-bom:5.10.0")
+	api platform("org.junit:junit-bom:5.11.3")
 	api "org.junit.jupiter:junit-jupiter-engine"
 	implementation "org.junit.platform:junit-platform-launcher"
 }

--- a/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
+++ b/junit/src/main/java/net/fabricmc/loader/impl/junit/FabricLoaderLauncherSessionListener.java
@@ -31,12 +31,20 @@ public class FabricLoaderLauncherSessionListener implements LauncherSessionListe
 		System.setProperty(SystemProperties.UNIT_TEST, "true");
 	}
 
-	private final Knot knot;
-	private final ClassLoader classLoader;
+	private static Knot knot = null;
+	private static ClassLoader classLoader = null;
 
 	private ClassLoader launcherSessionClassLoader;
 
 	public FabricLoaderLauncherSessionListener() {
+		setup();
+	}
+
+	private synchronized static void setup() {
+		if (knot != null) {
+			return;
+		}
+
 		final Thread currentThread = Thread.currentThread();
 		final ClassLoader originalClassLoader = currentThread.getContextClassLoader();
 


### PR DESCRIPTION
It seems that the VSCode test runner will create multiple FabricLoaderLauncherSessionListener instances. We can only ever have one Knot instance so store it statically.

### TODO test:
- [ ] Gradle
- [ ] Gradle via Intelij
- [ ] Intelij (without Gradle)
- [ ] VSCode
- [ ] Eclipse (didnt work last I tried, but it might now)
