### PR TITLE
Update to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./gradlew build publishToMavenLocal --stacktrace --warning-mode fail
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - run: ./gradlew build publishToMavenLocal --stacktrace --warning-mode fail
       - uses: actions/upload-artifact@v4
         with:
-          name: Artifacts
+          name: Artifacts ${{ matrix.java }}
           path: build/libs/
 
   client_test:


### PR DESCRIPTION
A small followup to #1001 which missed to update one of the upload actions.

Also creates two different artifact uploads, before the build task which finished last just overwrote the first artifact.