### PR TITLE
feat: support conditional dependencies

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -45,6 +45,7 @@ import net.fabricmc.loader.api.LanguageAdapter;
 import net.fabricmc.loader.api.MappingResolver;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.ObjectShare;
+import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import net.fabricmc.loader.impl.discovery.ArgumentModCandidateFinder;
 import net.fabricmc.loader.impl.discovery.ClasspathModCandidateFinder;
@@ -197,10 +198,12 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 			} else {
 				throw FormattedException.ofLocalized("exception.incompatible", exception);
 			}
+		} catch (VersionParsingException exception) {
+			throw new RuntimeException("Failed to parse version", exception);
 		}
 	}
 
-	private void setup() throws ModResolutionException {
+	private void setup() throws ModResolutionException, VersionParsingException {
 		boolean remapRegularMods = isDevelopmentEnvironment();
 		VersionOverrides versionOverrides = new VersionOverrides();
 		DependencyOverrides depOverrides = new DependencyOverrides(configDir);

--- a/src/main/java/net/fabricmc/loader/impl/discovery/DomainObject.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/DomainObject.java
@@ -18,7 +18,7 @@ package net.fabricmc.loader.impl.discovery;
 
 import net.fabricmc.loader.api.Version;
 
-interface DomainObject {
+public interface DomainObject {
 	String getId();
 
 	interface Mod extends DomainObject {

--- a/src/main/java/net/fabricmc/loader/impl/metadata/ModDependencyImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/ModDependencyImpl.java
@@ -16,27 +16,44 @@
 
 package net.fabricmc.loader.impl.metadata;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
 import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModEnvironment;
 import net.fabricmc.loader.api.metadata.version.VersionInterval;
 import net.fabricmc.loader.api.metadata.version.VersionPredicate;
+import net.fabricmc.loader.impl.discovery.DomainObject;
 
 public final class ModDependencyImpl implements ModDependency {
-	private Kind kind;
 	private final String modId;
 	private final List<String> matcherStringList;
-	private final Collection<VersionPredicate> ranges;
+	private Collection<VersionPredicate> ranges;
+	private final ModEnvironment activationEnv;
+	private final List<ModDependency> activationMatchers;
+	private boolean dependencyConditionsResolved;
+	private boolean isActive;
+	private Kind kind;
 
 	public ModDependencyImpl(Kind kind, String modId, List<String> matcherStringList) throws VersionParsingException {
+		this(kind, modId, matcherStringList, ModEnvironment.UNIVERSAL, new ArrayList<>());
+	}
+
+	public ModDependencyImpl(Kind kind, String modId, List<String> matcherStringList, ModEnvironment activationEnv, List<ModDependency> activationMatchers) throws VersionParsingException {
 		this.kind = kind;
 		this.modId = modId;
 		this.matcherStringList = matcherStringList;
 		this.ranges = VersionPredicate.parse(this.matcherStringList);
+		this.activationEnv = activationEnv;
+		this.activationMatchers = activationMatchers;
+		this.dependencyConditionsResolved = false;
+		this.isActive = false;
 	}
 
 	@Override
@@ -63,6 +80,61 @@ public final class ModDependencyImpl implements ModDependency {
 	}
 
 	@Override
+	public boolean isActive() {
+		if (!dependencyConditionsResolved) throw new IllegalStateException("Dependency conditions not resolved");
+		return isActive;
+	}
+
+	@Override
+	public void resolveDependencyConditions(Map<String, List<DomainObject.Mod>> allMods, EnvType envType) throws VersionParsingException {
+		dependencyConditionsResolved = true;
+
+		if (kind == Kind.CONDITION) {
+			isActive = activationEnv.matches(envType);
+			if (!isActive) return;
+
+			for (ModDependency matcher : activationMatchers) {
+				if (matcher.getKind() != Kind.DEPENDS) throw new IllegalStateException("Conditional dependency's matcher must be a DEPENDS dependency");
+				matcher.resolveDependencyConditions(allMods, envType);
+
+				if (!matcher.isActive()) {
+					continue;
+				}
+
+				boolean found = false;
+
+				if (allMods.containsKey(matcher.getModId())) {
+					for (DomainObject.Mod mod : allMods.get(matcher.getModId())) {
+						if (matcher.matches(mod.getVersion())) {
+							found = true;
+							break;
+						}
+					}
+				}
+
+				if (!found) {
+					isActive = false;
+					return;
+				}
+			}
+
+			return;
+		}
+
+		for (ModDependency matcher : activationMatchers) {
+			if (matcher.getKind() != Kind.CONDITION) throw new IllegalStateException("Non-conditional dependency's matcher must be a CONDITION dependency");
+			matcher.resolveDependencyConditions(allMods, envType);
+
+			if (matcher.isActive()) {
+				matcherStringList.addAll(matcher.getMatcherStrings());
+			}
+		}
+
+		ranges = VersionPredicate.parse(matcherStringList);
+		isActive = !ranges.isEmpty();
+	}
+
+	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof ModDependency)) return false;
 
@@ -81,20 +153,72 @@ public final class ModDependencyImpl implements ModDependency {
 	@Override
 	public String toString() {
 		final StringBuilder builder = new StringBuilder("{");
-		builder.append(kind.getKey());
-		builder.append(' ');
-		builder.append(this.modId);
-		builder.append(" @ [");
 
-		for (int i = 0; i < matcherStringList.size(); i++) {
-			if (i > 0) {
-				builder.append(" || ");
+		if (kind == Kind.CONDITION) {
+			builder.append("conditional ");
+
+			if (activationEnv != ModEnvironment.UNIVERSAL) {
+				builder.append(activationEnv.name());
+				builder.append(' ');
 			}
 
-			builder.append(matcherStringList.get(i));
+			builder.append("[");
+
+			for (int i = 0; i < matcherStringList.size(); i++) {
+				if (i > 0) {
+					builder.append(" || ");
+				}
+
+				builder.append(matcherStringList.get(i));
+			}
+
+			builder.append("] ");
+
+			if (!activationMatchers.isEmpty()) {
+				builder.append("[");
+			}
+
+			for (ModDependency matcher : activationMatchers) {
+				if (activationMatchers.indexOf(matcher) > 0) {
+					builder.append(" && ");
+				}
+
+				builder.append(matcher.toString());
+			}
+
+			if (!activationMatchers.isEmpty()) {
+				builder.append("] ");
+			}
+		} else {
+			int i;
+
+			builder.append(kind.getKey());
+			builder.append(' ');
+			builder.append(this.modId);
+			builder.append(" @ [");
+
+			for (i = 0; i < matcherStringList.size(); i++) {
+				if (i > 0) {
+					builder.append(" || ");
+				}
+
+				builder.append(matcherStringList.get(i));
+			}
+
+			if (!dependencyConditionsResolved) {
+				for (ModDependency matcher : activationMatchers) {
+					if (i > 0) {
+						builder.append(" || ");
+					}
+
+					builder.append(matcher.toString());
+				}
+			}
+
+			builder.append("]");
 		}
 
-		builder.append("]}");
+		builder.append("}");
 		return builder.toString();
 	}
 
@@ -112,5 +236,10 @@ public final class ModDependencyImpl implements ModDependency {
 		}
 
 		return ret;
+	}
+
+	@Override
+	public List<String> getMatcherStrings() {
+		return matcherStringList;
 	}
 }

--- a/src/test/resources/testing/parsing/v1/spec/conditional_dependencies.json
+++ b/src/test/resources/testing/parsing/v1/spec/conditional_dependencies.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "id": "v1-parsing-test",
+  "version": "1.0.0-SNAPSHOT",
+  "name": "Example mod 1",
+  "description": "A simple unit test for parsing a \"fabric.mod.json\"",
+  "authors": [
+    {
+      "name": "FabricMC",
+      "contact": {
+        "homepage": "https://fabricmc.net/",
+        "sources": "https://github.com/FabricMC",
+        "discord_link": "https://discord.gg/v6v4pMv"
+      }
+    },
+    "Another author"
+  ],
+  "environment": "client",
+  "entrypoints": {
+    "client": [
+      "net.fabricmc.test.mod.ClientEntrypoint",
+      "net.fabricmc.test.mod.ClientEntrypoint2"
+    ],
+    "custom_entrypoint": [
+      {
+        "value": "net.fabricmc.test.mod.extension.CustomEntrypoint",
+        "adapter": "default"
+      }
+    ]
+  },
+  "icon": "assets/test/mod/icon.png",
+  "contact": {
+    "homepage": "https://fabricmc.net/"
+  },
+  "depends": {
+    "fabricloader": ">=0.2.0",
+    "some_mod": [">=1.12.2", {
+      "version": ">=1.0.0",
+      "if": {
+        "fabricloader": ">=0.4.0"
+      },
+      "environment": "client"
+    }],
+    "another_mod_only_on_server": [{
+      "version": ">=1.12.2",
+      "if": {
+        "fabricloader": ">=0.4.0"
+      },
+      "environment": "server"
+    }, {
+      "version": ">=1.13.0",
+      "environment": "client"
+    }],
+    "very_complex_mod": {
+        "version": ">=1.0.0",
+        "if": {
+          "some_mod": {
+            "version": ">=1.0.0",
+            "if": {
+              "fabricloader": {
+                "version": ">=0.4.0",
+                "if": {
+                  "another_mod_only_on_server": ">=2.6.7",
+                  "mod_i_dont_want": "<0.0.0"
+                }
+              },
+              "another_mod_only_on_server": {
+                "version": ">=1.10.0",
+                "environment": "server"
+              }
+            }
+          },
+          "another_mod_only_on_server": ">=1.14.0"
+        }
+      }
+  }
+}


### PR DESCRIPTION
Fixed #464

1. Made DomainObject class public to improve testability.
2. Added support for conditional dependencies, enabling dynamic dependency resolution.
3. Add some new parsing logic to V1ModMetadataParser and DependencyOverrides.
4. Included a new test case and a dummy JSON file.

New depends field example (also works on breaks, conflicts etc.)
```json
"depends": {
    "fabricloader": ">=0.2.0",
    "some_mod": [">=1.12.2", {
      "version": ">=1.0.0",
      "if": {
        "fabricloader": ">=0.4.0"
      },
      "environment": "client"
    }],
    "another_mod_only_on_server": [{
      "version": ">=1.12.2",
      "if": {
        "fabricloader": ">=0.4.0"
      },
      "environment": "server"
    }, {
      "version": ">=1.13.0",
      "environment": "client"
    }],
    "very_complex_mod": {
        "version": ">=1.0.0",
        "if": {
          "some_mod": {
            "version": ">=1.0.0",
            "if": {
              "fabricloader": {
                "version": ">=0.4.0",
                "if": {
                  "another_mod_only_on_server": ">=2.6.7",
                  "mod_i_dont_want": "<0.0.0"
                }
              },
              "another_mod_only_on_server": {
                "version": ">=1.10.0",
                "environment": "server"
              }
            }
          },
          "another_mod_only_on_server": ">=1.14.0"
        }
      }
  }
```
Which means, this mod needs fabric loader >= 0.2.0;  
some_mod >= 1.12.2, but if it's on client side and fabric loader >= 0.4.0, it only needs >= 1.0.0;  
another_mod_only_on_server needs >=1.12.2 on server, but if fabric loader <0.4.0, you don't need it anymore;
And it needs >= 1.13.0 on client

Please notice:
FabricLoaderImpl#load() will now throw a runtime VersionParsingException if conditional deps version parsing fails.