### PR TITLE
No longer use java.applet as it's scheduled for removal.

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -42,6 +42,7 @@ import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.game.GameProviderHelper;
 import net.fabricmc.loader.impl.game.LibClassifier;
+import net.fabricmc.loader.impl.game.minecraft.patch.AppletPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.BrandingPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatch;
 import net.fabricmc.loader.impl.game.minecraft.patch.EntrypointPatchFML125;
@@ -91,7 +92,8 @@ public class MinecraftGameProvider implements GameProvider {
 			new EntrypointPatch(this),
 			new BrandingPatch(),
 			new EntrypointPatchFML125(),
-			new TinyFDPatch());
+			new TinyFDPatch(),
+			new AppletPatch());
 
 	@Override
 	public String getGameId() {

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletLauncher.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletLauncher.java
@@ -16,8 +16,6 @@
 
 package net.fabricmc.loader.impl.game.minecraft.applet;
 
-import java.applet.Applet;
-import java.applet.AppletStub;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.io.File;
@@ -28,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.fabricmc.loader.impl.game.minecraft.Hooks;
+import net.fabricmc.loader.impl.game.minecraft.applet.stub.Applet;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 
 /**
@@ -38,8 +37,7 @@ import net.fabricmc.loader.impl.launch.FabricLauncherBase;
  *
  * <p>It has been adapted here for the purposes of the Fabric loader.
  */
-@SuppressWarnings("serial")
-public class AppletLauncher extends Applet implements AppletStub {
+public class AppletLauncher extends Applet {
 	public static File gameDir;
 
 	private final Map<String, String> params;
@@ -93,11 +91,6 @@ public class AppletLauncher extends Applet implements AppletStub {
 			start();
 			validate();
 		}
-	}
-
-	@Override
-	public void appletResize(int width, int height) {
-		mcApplet.resize(width, height);
 	}
 
 	@Override

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/stub/Applet.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/stub/Applet.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.game.minecraft.applet.stub;
+
+import net.fabricmc.loader.impl.game.minecraft.applet.AppletLauncher;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+import java.net.URL;
+import java.util.Locale;
+
+/**
+ * A minimal stub implementation of an Applet, just enough to make Minecraft happy.
+ */
+public class Applet extends Panel {
+    private @Nullable AppletLauncher appletLauncher;
+
+    public final void setStub(AppletLauncher appletLauncher) {
+        this.appletLauncher = appletLauncher;
+    }
+
+    public boolean isActive() {
+        if (appletLauncher != null) {
+            return appletLauncher.isActive();
+        } else {        // If stub field not filled in, applet never active
+            return false;
+        }
+    }
+
+    public URL getDocumentBase() {
+        return appletLauncher.getDocumentBase();
+    }
+
+    public URL getCodeBase() {
+        return appletLauncher.getCodeBase();
+    }
+
+    public String getParameter(String name) {
+        return appletLauncher.getParameter(name);
+    }
+
+    @SuppressWarnings("deprecation")
+	@Override
+    public void resize(int width, int height) {
+        Dimension d = size();
+        if ((d.width != width) || (d.height != height)) {
+            super.resize(width, height);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+	@Override
+    public void resize(Dimension d) {
+        resize(d.width, d.height);
+    }
+
+    @Override
+    public boolean isValidateRoot() {
+        return true;
+    }
+
+	@Override
+    public Locale getLocale() {
+        Locale locale = super.getLocale();
+        if (locale == null) {
+            return Locale.getDefault();
+        }
+        return locale;
+    }
+
+    public void init() {
+    }
+
+    public void start() {
+    }
+
+    public void stop() {
+    }
+
+    public void destroy() {
+    }
+}

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/stub/Applet.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/stub/Applet.java
@@ -37,7 +37,7 @@ public class Applet extends Panel {
     public boolean isActive() {
         if (appletLauncher != null) {
             return appletLauncher.isActive();
-        } else {        // If stub field not filled in, applet never active
+        } else {
             return false;
         }
     }

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/AppletPatch.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/AppletPatch.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.game.minecraft.patch;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import net.fabricmc.loader.impl.game.patch.GamePatch;
+import net.fabricmc.loader.impl.launch.FabricLauncher;
+
+/**
+ * Redirect the Minecraft applet to use our stub implementation of Applet.
+ */
+public class AppletPatch extends GamePatch {
+	private static final String FROM_PACKAGE = "java/applet/";
+	private static final String TO_PACKAGE = "net/fabricmc/loader/impl/game/minecraft/applet/stub/";
+
+	@Override
+	public void process(FabricLauncher launcher, Function<String, ClassNode> classSource, Consumer<ClassNode> classEmitter) {
+		for (String appletClassName: new String[]{
+				"net/minecraft/client/MinecraftApplet",
+				"com/mojang/minecraft/MinecraftApplet"
+		}) {
+			ClassNode appletClass = classSource.apply(appletClassName);
+
+			if (appletClass != null) {
+				if (applyAppletPatch(appletClass)) {
+					classEmitter.accept(appletClass);
+				}
+			}
+		}
+	}
+
+	private static String replaceWithStub(String name) {
+		return name.replace(FROM_PACKAGE, TO_PACKAGE);
+	}
+
+	private boolean applyAppletPatch(ClassNode classNode) {
+		classNode.superName = replaceWithStub(classNode.superName);
+
+		for (MethodNode method : classNode.methods) {
+			for (AbstractInsnNode instruction : method.instructions) {
+				if (instruction instanceof MethodInsnNode) {
+					MethodInsnNode methodInsnNode = (MethodInsnNode) instruction;
+					methodInsnNode.owner = replaceWithStub(methodInsnNode.owner);
+				}
+			}
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
Seems to work, and wasnt too crazy, this should help ensure future java version support, see: https://openjdk.org/jeps/8345525

Tested only in b1.8.1 so far, needs testing in a wide range of versions.

Can we take this opertunity to fix some of the bugs with the applet versions, especially the incorrectly sized windows?