### PR TITLE
Add support for 25w14craftmine dedicated servers

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
@@ -47,6 +47,7 @@ import net.fabricmc.loader.impl.util.version.VersionPredicateParser;
 
 public class EntrypointPatch extends GamePatch {
 	private static final VersionPredicate VERSION_1_19_4 = createVersionPredicate(">=1.19.4-");
+	private static final VersionPredicate VERSION_25w14craftmine = createVersionPredicate("1.21.6-alpha.25.14.craftmine");
 
 	private final MinecraftGameProvider gameProvider;
 
@@ -304,7 +305,8 @@ public class EntrypointPatch extends GamePatch {
 				// If we do not find this, then we are certain this is 20w22a.
 				MethodNode serverStartMethod = findMethod(mainClass, method -> {
 					if ((method.access & Opcodes.ACC_SYNTHETIC) == 0 // reject non-synthetic
-							|| method.name.equals("main") && method.desc.equals("([Ljava/lang/String;)V")) { // reject main method (theoretically superfluous now)
+							|| method.name.equals("main") && method.desc.equals("([Ljava/lang/String;)V") // reject main method (theoretically superfluous now)
+							|| VERSION_25w14craftmine.test(gameVersion) && method.parameters.size() < 10) { // reject problematic extra methods
 						return false;
 					}
 


### PR DESCRIPTION
Extra synthetic methods were introduced in `net/minecraft/server/Main` and the restrictions to get `serverStartMethod` became a bit too loose so I added a special case.