### PR TITLE
Implement locating pre-classic versions of Minecraft

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -20,7 +20,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.LibClassifier.LibraryType;
 
 enum McLibrary implements LibraryType {
-	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class"),
+	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class", "com/mojang/rubydung/RubyDung.class"),
 	MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
 	MC_COMMON("net/minecraft/server/MinecraftServer.class"),
 	MC_ASSETS_ROOT("assets/.mcassetsroot"),


### PR DESCRIPTION
In pre-classic versions the `com/mojang/rubydung/RubyDung` class contains the main method.