### PR TITLE
Expose getting GameProvider in FabricLoader interface

### DIFF
--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import net.fabricmc.loader.impl.FabricLoaderImpl;
+import net.fabricmc.loader.impl.game.GameProvider;
 
 /**
  * The public-facing FabricLoader instance.
@@ -220,6 +221,8 @@ public interface FabricLoader {
 
 	@Deprecated
 	File getConfigDirectory();
+
+	GameProvider getGameProvider();
 
 	/**
 	 * Gets the command line arguments used to launch the game.


### PR DESCRIPTION
@Earthcomputer @modmuss50 a follow-up to the conversation we had. I really just need a way to get the raw server version
```
        GameProvider gameProvider = ((FabricLoaderImpl) FabricLoader.getInstance()).getGameProvider();
        String mcVersion = gameProvider.getRawGameVersion();
        for (ServerVersion version : ServerVersion.reversedValues()) {
            if (mcVersion.equals(version.getReleaseName())) {
                return version;
            }
        }
 ```