### PR TITLE
Allow foreign programs to discover and resolve mods without launching the game

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -207,13 +207,13 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		// discover mods
 
-		ModDiscoverer discoverer = new ModDiscoverer(versionOverrides, depOverrides);
+		ModDiscoverer discoverer = new ModDiscoverer(this.provider, this.isDevelopmentEnvironment(), this.getEnvironmentType(), versionOverrides, depOverrides);
 		discoverer.addCandidateFinder(new ClasspathModCandidateFinder());
 		discoverer.addCandidateFinder(new DirectoryModCandidateFinder(getModsDirectory0(), remapRegularMods));
 		discoverer.addCandidateFinder(new ArgumentModCandidateFinder(remapRegularMods));
 
 		Map<String, Set<ModCandidateImpl>> envDisabledMods = new HashMap<>();
-		modCandidates = discoverer.discoverMods(this, envDisabledMods);
+		modCandidates = discoverer.discoverMods(envDisabledMods);
 
 		// dump version and dependency overrides info
 

--- a/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/ModDiscoverer.java
@@ -49,9 +49,9 @@ import java.util.zip.ZipInputStream;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.metadata.ModMetadata;
-import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.discovery.ModCandidateFinder.ModCandidateConsumer;
+import net.fabricmc.loader.impl.game.GameDefinition;
 import net.fabricmc.loader.impl.game.GameProvider.BuiltinMod;
 import net.fabricmc.loader.impl.metadata.BuiltinModMetadata;
 import net.fabricmc.loader.impl.metadata.DependencyOverrides;
@@ -71,21 +71,26 @@ public final class ModDiscoverer {
 	private final VersionOverrides versionOverrides;
 	private final DependencyOverrides depOverrides;
 	private final List<ModCandidateFinder> candidateFinders = new ArrayList<>();
-	private final EnvType envType = FabricLoaderImpl.INSTANCE.getEnvironmentType();
+	private final EnvType envType;
 	private final Map<Long, ModScanTask> jijDedupMap = new ConcurrentHashMap<>(); // avoids reading the same jar twice
 	private final List<NestedModInitData> nestedModInitDatas = Collections.synchronizedList(new ArrayList<>()); // breaks potential cycles from deduplication
 	private final List<Path> nonFabricMods = Collections.synchronizedList(new ArrayList<>());
+	private final GameDefinition gameDefinition;
+	private final boolean isDevelopment;
 
-	public ModDiscoverer(VersionOverrides versionOverrides, DependencyOverrides depOverrides) {
+	public ModDiscoverer(GameDefinition gameDefinition, boolean isDevelopment, EnvType environment, VersionOverrides versionOverrides, DependencyOverrides depOverrides) {
 		this.versionOverrides = versionOverrides;
 		this.depOverrides = depOverrides;
+		this.envType = environment;
+		this.gameDefinition = gameDefinition;
+		this.isDevelopment = isDevelopment;
 	}
 
 	public void addCandidateFinder(ModCandidateFinder f) {
 		candidateFinders.add(f);
 	}
 
-	public List<ModCandidateImpl> discoverMods(FabricLoaderImpl loader, Map<String, Set<ModCandidateImpl>> envDisabledModsOut) throws ModResolutionException {
+	public List<ModCandidateImpl> discoverMods(Map<String, Set<ModCandidateImpl>> envDisabledModsOut) throws ModResolutionException {
 		long startTime = System.nanoTime();
 		ForkJoinPool pool = new ForkJoinPool();
 		Set<Path> processedPaths = new HashSet<>(); // suppresses duplicate paths
@@ -114,12 +119,12 @@ public final class ModDiscoverer {
 		List<ModCandidateImpl> candidates = new ArrayList<>();
 
 		// add builtin mods
-		for (BuiltinMod mod : loader.getGameProvider().getBuiltinMods()) {
+		for (BuiltinMod mod : gameDefinition.getBuiltinMods()) {
 			if (!(mod.metadata.getVersion() instanceof SemanticVersion)) {
 				String error = String.format("%s uses the non-semantic version %s, which doesn't support range comparisons and may cause mod dependencies against it to fail unexpectedly. Consider updating Fabric Loader or explicitly specifying the game version with the fabric.gameVersion system property.",
 						mod.metadata.getId(), mod.metadata.getVersion());
 
-				if (loader.isDevelopmentEnvironment()) { // fail hard in-dev
+				if (isDevelopment) { // fail hard in-dev
 					throw new FormattedException("Invalid game version", error);
 				} else {
 					Log.warn(LogCategory.GENERAL, error);
@@ -127,11 +132,11 @@ public final class ModDiscoverer {
 			}
 
 			ModCandidateImpl candidate = ModCandidateImpl.createBuiltin(mod, versionOverrides, depOverrides);
-			candidates.add(MetadataVerifier.verifyIndev(candidate, loader.isDevelopmentEnvironment()));
+			candidates.add(MetadataVerifier.verifyIndev(candidate, isDevelopment));
 		}
 
 		// Add the current Java version
-		candidates.add(MetadataVerifier.verifyIndev(createJavaMod(), loader.isDevelopmentEnvironment()));
+		candidates.add(MetadataVerifier.verifyIndev(createJavaMod(), isDevelopment));
 
 		ModResolutionException exception = null;
 
@@ -372,7 +377,7 @@ public final class ModDiscoverer {
 						private ZipEntry currentEntry;
 					});
 
-					if (!nestedJarPaths.isEmpty() && FabricLoaderImpl.INSTANCE.isDevelopmentEnvironment()) {
+					if (!nestedJarPaths.isEmpty() && isDevelopment) {
 						Log.warn(LogCategory.METADATA, "Mod %s %s references missing nested jars: %s", metadata.getId(), metadata.getVersion(), nestedJarPaths);
 					}
 				}
@@ -450,7 +455,7 @@ public final class ModDiscoverer {
 					});
 				}
 
-				if (!nestedJarPaths.isEmpty() && FabricLoaderImpl.INSTANCE.isDevelopmentEnvironment()) {
+				if (!nestedJarPaths.isEmpty() && isDevelopment) {
 					Log.warn(LogCategory.METADATA, "Mod %s %s references missing nested jars: %s", metadata.getId(), metadata.getVersion(), nestedJarPaths);
 				}
 			}
@@ -507,7 +512,7 @@ public final class ModDiscoverer {
 		}
 
 		private LoaderModMetadata parseMetadata(InputStream is, String localPath) throws ParseMetadataException {
-			return ModMetadataParser.parseMetadata(is, localPath, parentPaths, versionOverrides, depOverrides, FabricLoaderImpl.INSTANCE.isDevelopmentEnvironment());
+			return ModMetadataParser.parseMetadata(is, localPath, parentPaths, versionOverrides, depOverrides, isDevelopment);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/game/GameDefinition.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameDefinition.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.game;
+
+import java.nio.file.Path;
+import java.util.Collection;
+
+import net.fabricmc.loader.impl.game.GameProvider.BuiltinMod;
+
+public interface GameDefinition {
+	String getGameId();
+	String getGameName();
+	String getRawGameVersion();
+	String getNormalizedGameVersion();
+	Collection<BuiltinMod> getBuiltinMods();
+	Path getLaunchDirectory();
+}
+

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -17,7 +17,6 @@
 package net.fabricmc.loader.impl.game;
 
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,15 +26,9 @@ import net.fabricmc.loader.impl.launch.FabricLauncher;
 import net.fabricmc.loader.impl.util.Arguments;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 
-public interface GameProvider { // name directly referenced in net.fabricmc.loader.impl.launch.knot.Knot.findEmbedddedGameProvider() and service loader records
-	String getGameId();
-	String getGameName();
-	String getRawGameVersion();
-	String getNormalizedGameVersion();
-	Collection<BuiltinMod> getBuiltinMods();
+public interface GameProvider extends GameDefinition { // name directly referenced in net.fabricmc.loader.impl.launch.knot.Knot.findEmbedddedGameProvider() and service loader records
 
 	String getEntrypoint();
-	Path getLaunchDirectory();
 	boolean isObfuscated();
 	boolean requiresUrlClassLoader();
 

--- a/src/test/java/net/fabricmc/loader/impl/discovery/GetNonFabricModsTest.java
+++ b/src/test/java/net/fabricmc/loader/impl/discovery/GetNonFabricModsTest.java
@@ -63,7 +63,7 @@ public class GetNonFabricModsTest {
 
 		loaderConstruction = Mockito.mockConstructionWithAnswer(FabricLoaderImpl.class, invocation -> loader);
 
-		discoverer = new ModDiscoverer(mock(), mock());
+		discoverer = new ModDiscoverer(provider, loader.isDevelopmentEnvironment(), loader.getEnvironmentType(), mock(), mock());
 		discoverer.addCandidateFinder(new MockCandidateFinder());
 	}
 
@@ -77,7 +77,7 @@ public class GetNonFabricModsTest {
 	 */
 	@Test
 	public void testGetNonFabricMods() throws ModResolutionException {
-		List<ModCandidateImpl> acceptedMods = discoverer.discoverMods(loader, new HashMap<String, Set<ModCandidateImpl>>());
+		List<ModCandidateImpl> acceptedMods = discoverer.discoverMods(new HashMap<String, Set<ModCandidateImpl>>());
 
 		boolean foundDummyFabricMod = false;
 


### PR DESCRIPTION
This PR enables tools such as custom game launchers to perform mod discovery and resolution without starting the game. This is useful for detecting mod compatibility issues pre-launch. I'd appreciate some feedback on this approach.

Note: This PR does not provide a builtin mechanism for discovering or resolving a minecraft game instance.
It only enables external tools to supply their own implementation. Such an implementation is out of scope for this PR, unless someone else wants to contribute it.

### Introduced `GameDefinition` interface
* Extracted the relevant methods from `GameProvider` into a new `GameDefinition` interface. This interface contains all functionality required to support mod discovery externally. `GameProvider` now implements `GameDefinition`, so there will be no API breakage here.
* I'm not satisfied with the name `GameDefinition`. Open to naming suggestions. The interface represents a game install on the user's filesystem.

### Removed dependency on `FabricLoaderImpl` from `ModDiscoverer`
* This decoupling makes `ModDiscoverer` usable by external tools. While technically a breaking change, it does not impact real-world usage. External programs could not use `ModDiscoverer` before due to its reliance on the internal loader instance.

### Tests
* Relevant tests were updated

## Example
![image](https://github.com/user-attachments/assets/38401992-2fdc-475d-be88-4c682c8b4c3a)
