### PR TITLE
Allow access wideners to modify any game or mod class, not only MC

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/transformer/FabricTransformer.java
+++ b/src/main/java/net/fabricmc/loader/impl/transformer/FabricTransformer.java
@@ -30,7 +30,7 @@ public final class FabricTransformer {
 		boolean isMinecraftClass = name.startsWith("net.minecraft.") || name.startsWith("com.mojang.blaze3d.") || name.indexOf('.') < 0;
 		boolean transformAccess = isMinecraftClass && FabricLauncherBase.getLauncher().getMappingConfiguration().requiresPackageAccessHack();
 		boolean environmentStrip = !isMinecraftClass || isDevelopment;
-		boolean applyAccessWidener = isMinecraftClass && FabricLoaderImpl.INSTANCE.getAccessWidener().getTargets().contains(name);
+		boolean applyAccessWidener = FabricLoaderImpl.INSTANCE.getAccessWidener().getTargets().contains(name);
 
 		if (!transformAccess && !environmentStrip && !applyAccessWidener) {
 			return bytes;


### PR DESCRIPTION
I don't think it's necessary to keep the restriction to Minecraft classes only. Fabric tends to be less restrictive and there are already ways to hack around it anyway.

Fixes part of #1049 and #1043 

Note this would come on top of https://github.com/FabricMC/fabric-loader/pull/1055 - making GameProvider.getBuiltinTransforms include `BuiltinTransform.CLASS_TWEAKS` in all cases. Other game provider can choose different behaviors.