### PR TITLE
Running game with custom mappings and namespace outside fabric-loom.

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -55,6 +55,8 @@ import net.fabricmc.tinyremapper.TinyRemapper;
 import net.fabricmc.tinyremapper.TinyUtils;
 
 public final class GameProviderHelper {
+	private static final boolean DEVELOPMENT_DEOBF_GAME_JAR = System.getProperty(SystemProperties.DEVELOPMENT_DEOBF_GAME_JAR) != null;
+
 	private GameProviderHelper() { }
 
 	public static Path getCommonGameJar() {
@@ -163,7 +165,7 @@ public final class GameProviderHelper {
 	public static Map<String, Path> deobfuscate(Map<String, Path> inputFileMap, String gameId, String gameVersion, Path gameDir, FabricLauncher launcher, String sourceNamespace) {
 		Log.debug(LogCategory.GAME_REMAP, "Requesting deobfuscation of %s", inputFileMap);
 
-		if (launcher.isDevelopment()) { // in-dev is already deobfuscated
+		if (launcher.isDevelopment() && !DEVELOPMENT_DEOBF_GAME_JAR) { // in-dev is already deobfuscated
 			return inputFileMap;
 		}
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
@@ -20,6 +20,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.List;
@@ -42,6 +44,8 @@ import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class MappingConfiguration {
+	private static final String MAPPINGS_PATH = System.getProperty(SystemProperties.MAPPINGS_PATH, null);
+	private static final String TARGET_NAMESPACE = System.getProperty(SystemProperties.TARGET_NAMESPACE, null);
 	private static final boolean FIX_PACKAGE_ACCESS = System.getProperty(SystemProperties.FIX_PACKAGE_ACCESS) != null;
 
 	private boolean initializedMetadata;
@@ -91,6 +95,10 @@ public final class MappingConfiguration {
 	}
 
 	public String getTargetNamespace() {
+		if (TARGET_NAMESPACE != null) {
+			return TARGET_NAMESPACE;
+		}
+
 		return FabricLauncherBase.getLauncher().isDevelopment() ? "named" : "intermediary";
 	}
 
@@ -178,7 +186,17 @@ public final class MappingConfiguration {
 
 	@Nullable
 	private URLConnection openMappings() {
-		URL url = MappingConfiguration.class.getClassLoader().getResource("mappings/mappings.tiny");
+		URL url;
+
+		if (MAPPINGS_PATH != null) {
+			try {
+				url = new URL(MAPPINGS_PATH);
+			} catch (MalformedURLException ex) {
+				url = null;
+			}
+		} else {
+			url = MappingConfiguration.class.getClassLoader().getResource("mappings/mappings.tiny");
+		}
 
 		if (url != null) {
 			try {

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -19,6 +19,8 @@ package net.fabricmc.loader.impl.util;
 public final class SystemProperties {
 	// whether fabric loader is running in a development environment / mode, affects class path mod discovery, remapping, logging, ...
 	public static final String DEVELOPMENT = "fabric.development";
+	// runtime deobf game jar although it is in development
+	public static final String DEVELOPMENT_DEOBF_GAME_JAR = "fabric.development.deobfGameJar";
 	public static final String SIDE = "fabric.side";
 	// skips the embedded MC game provider, letting ServiceLoader-provided ones take over
 	public static final String SKIP_MC_PROVIDER = "fabric.skipMcProvider";
@@ -42,6 +44,10 @@ public final class SystemProperties {
 	public static final String REMAP_CLASSPATH_FILE = "fabric.remapClasspathFile";
 	// class path groups to map multiple class path entries to a mod (paths separated by path separator, groups by double path separator)
 	public static final String PATH_GROUPS = "fabric.classPathGroups";
+	// direct use a tiny file as mappings for mapping configuration
+	public static final String MAPPINGS_PATH = "fabric.mappingsPath";
+	// define the target namespace for mapping configuration
+	public static final String TARGET_NAMESPACE = "fabric.targetNamespace";
 	// enable the fixing of package access errors in the game jar(s)
 	public static final String FIX_PACKAGE_ACCESS = "fabric.fixPackageAccess";
 	// system level libraries, matching code sources will not be assumed to be part of the game or mods and remain on the system class path (paths separated by path separator)


### PR DESCRIPTION
This is an enhancement. It added an easier way to run the game with any mapping file and target namespace without fabric-loom for debugging.  
I have some errors couldn't reproduce when starting with the IDE. So I want to launch the game with `named` namespace for clearly inspecting, instead of searching on linkie.  

It added some property:  
- `fabric.development.deobfGameJar` for deobf the game jar, although we're in development.  
- `fabric.mappingsPath` can load yarn mappings from an `URI` (we must use the resource named `mappings/mappings.tiny` in the classpath before).  
- `fabric.targetNamespace` can be set to something other which in the mappings, maybe even helps for versioning it?  

This PR won't break the existing behaviors, and passed the unit tests on my machine.