### PR TITLE
Add fabric.gameLibraries to explicitly specify game libraries instead of using the class path

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/game/LibClassifier.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/LibClassifier.java
@@ -16,12 +16,10 @@
 
 package net.fabricmc.loader.impl.game;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -74,21 +72,14 @@ public final class LibClassifier<L extends Enum<L> & LibraryType> {
 		// system libs configured through system property
 
 		StringBuilder sb = DEBUG ? new StringBuilder() : null;
-		String systemLibProp = System.getProperty(SystemProperties.SYSTEM_LIBRARIES);
+		List<Path> systemLibs = GameProviderHelper.getLibraries(SystemProperties.SYSTEM_LIBRARIES);
 
-		if (systemLibProp != null) {
-			for (String lib : systemLibProp.split(File.pathSeparator)) {
-				Path path = Paths.get(lib);
+		if (systemLibs != null) {
+			for (Path lib : systemLibs) {
+				assert lib.equals(LoaderUtil.normalizeExistingPath(lib));
 
-				if (!Files.exists(path)) {
-					Log.info(LogCategory.LIB_CLASSIFICATION, "Skipping missing system library entry %s", path);
-					continue;
-				}
-
-				path = LoaderUtil.normalizeExistingPath(path);
-
-				if (systemLibraries.add(path)) {
-					if (DEBUG) sb.append(String.format("🇸 %s%n", path));
+				if (systemLibraries.add(lib)) {
+					if (DEBUG) sb.append(String.format("🇸 %s%n", lib));
 				}
 			}
 		}
@@ -125,6 +116,14 @@ public final class LibClassifier<L extends Enum<L> & LibraryType> {
 		}
 
 		if (DEBUG) Log.info(LogCategory.LIB_CLASSIFICATION, "Loader/system libraries:%n%s", sb);
+
+		// game libraries
+
+		List<Path> gameLibs = GameProviderHelper.getLibraries(SystemProperties.GAME_LIBRARIES);
+
+		if (gameLibs != null) {
+			process(gameLibs);
+		}
 
 		// process indirectly referenced libs
 

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -34,6 +34,9 @@ public final class SystemProperties {
 	public static final String GAME_JAR_PATH = "fabric.gameJarPath";
 	public static final String GAME_JAR_PATH_CLIENT = "fabric.gameJarPath.client";
 	public static final String GAME_JAR_PATH_SERVER = "fabric.gameJarPath.server";
+	// game library paths, replaces lookup from class path if present
+	// paths separated by path separator, @ prefix for meta-file with each line referencing an actual file)
+	public static final String GAME_LIBRARIES = "fabric.gameLibraries";
 	// set the game version for the builtin game mod/dependencies, bypassing auto-detection
 	public static final String GAME_VERSION = "fabric.gameVersion";
 	// fallback log file for the builtin log handler (dumped on exit if not replaced with another handler)
@@ -52,7 +55,8 @@ public final class SystemProperties {
 	public static final String PATH_GROUPS = "fabric.classPathGroups";
 	// enable the fixing of package access errors in the game jar(s)
 	public static final String FIX_PACKAGE_ACCESS = "fabric.fixPackageAccess";
-	// system level libraries, matching code sources will not be assumed to be part of the game or mods and remain on the system class path (paths separated by path separator)
+	// system level libraries, matching code sources will not be assumed to be part of the game or mods and remain on the system class path
+	// paths separated by path separator, @ prefix for meta-file with each line referencing an actual file)
 	public static final String SYSTEM_LIBRARIES = "fabric.systemLibraries";
 	// throw exceptions from entrypoints, discovery etc. directly instead of gathering and attaching as suppressed
 	public static final String DEBUG_THROW_DIRECTLY = "fabric.debug.throwDirectly";


### PR DESCRIPTION
This should allow for much shorter command lines, especially in-dev, when using `@listFilePath` as the value. The arg is otherwise very similar to fabric.addMods.

Another benefit is avoiding pollution of the system class path with a lot of the libraries that should only be on Knot CL.