### PR TITLE
Run Mixin configuration explicitly at a better and well defined time

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -373,7 +373,7 @@ public class MinecraftGameProvider implements GameProvider {
 		if (!logJars.isEmpty() && !Boolean.getBoolean(SystemProperties.UNIT_TEST)) {
 			for (Path jar : logJars) {
 				if (gameJars.contains(jar)) {
-					launcher.addToClassPath(jar, ALLOWED_EARLY_CLASS_PREFIXES);
+					launcher.addToClassPathRestricted(jar, ALLOWED_EARLY_CLASS_PREFIXES);
 				} else {
 					launcher.addToClassPath(jar);
 				}
@@ -469,19 +469,30 @@ public class MinecraftGameProvider implements GameProvider {
 	}
 
 	@Override
-	public void unlockClassPath(FabricLauncher launcher) {
+	public void populateClassPath(FabricLauncher launcher) {
 		for (Path gameJar : gameJars) {
-			if (logJars.contains(gameJar)) {
-				launcher.setAllowedPrefixes(gameJar);
-			} else {
-				launcher.addToClassPath(gameJar);
+			if (!logJars.contains(gameJar)) {
+				launcher.addToClassPathRestricted(gameJar);
 			}
 		}
 
-		if (realmsJar != null) launcher.addToClassPath(realmsJar);
+		if (realmsJar != null) launcher.addToClassPathRestricted(realmsJar);
 
 		for (Path lib : miscGameLibraries) {
-			launcher.addToClassPath(lib);
+			launcher.addToClassPathRestricted(lib);
+		}
+	}
+
+	@Override
+	public void unlockClassPath(FabricLauncher launcher) {
+		for (Path gameJar : gameJars) {
+			launcher.setAllPrefixesAllowed(gameJar);
+		}
+
+		if (realmsJar != null) launcher.setAllPrefixesAllowed(realmsJar);
+
+		for (Path lib : miscGameLibraries) {
+			launcher.setAllPrefixesAllowed(lib);
 		}
 	}
 

--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/launchwrapper/FabricTweaker.java
@@ -34,7 +34,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
-import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.transformer.Proxy;
 
@@ -143,7 +142,6 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 		FabricLoaderImpl.INSTANCE.loadAccessWideners();
 
 		// Setup Mixin environment
-		MixinBootstrap.init();
 		FabricMixinBootstrap.init(getEnvironmentType(), FabricLoaderImpl.INSTANCE);
 		MixinEnvironment.getDefaultEnvironment().setSide(getEnvironmentType() == EnvType.CLIENT ? MixinEnvironment.Side.CLIENT : MixinEnvironment.Side.SERVER);
 
@@ -162,10 +160,9 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 	}
 
 	@Override
-	public void addToClassPath(Path path, String... allowedPrefixes) {
+	public void addToClassPath(Path path) {
 		try {
 			launchClassLoader.addURL(UrlUtil.asUrl(path));
-			// allowedPrefixes handling is not implemented (no-op)
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}
@@ -173,6 +170,11 @@ public abstract class FabricTweaker extends FabricLauncherBase implements ITweak
 
 	@Override
 	public void setAllowedPrefixes(Path path, String... prefixes) {
+		// not implemented (no-op)
+	}
+
+	@Override
+	public void setAllPrefixesAllowed(Path path) {
 		// not implemented (no-op)
 	}
 

--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -63,6 +63,7 @@ public interface GameProvider { // name directly referenced in net.fabricmc.load
 	boolean locateGame(FabricLauncher launcher, String[] args);
 	void initialize(FabricLauncher launcher);
 	GameTransformer getEntrypointTransformer();
+	void populateClassPath(FabricLauncher launcher);
 	void unlockClassPath(FabricLauncher launcher);
 	void launch(ClassLoader loader);
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncher.java
@@ -28,8 +28,15 @@ import net.fabricmc.api.EnvType;
 public interface FabricLauncher {
 	MappingConfiguration getMappingConfiguration();
 
-	void addToClassPath(Path path, String... allowedPrefixes);
+	void addToClassPath(Path path);
+
+	default void addToClassPathRestricted(Path path, String... allowedPrefixes) {
+		setAllowedPrefixes(path, allowedPrefixes);
+		addToClassPath(path);
+	}
+
 	void setAllowedPrefixes(Path path, String... prefixes);
+	void setAllPrefixesAllowed(Path path);
 	void setValidParentClassPath(Collection<Path> paths);
 
 	EnvType getEnvironmentType();

--- a/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/FabricLauncherBase.java
@@ -19,11 +19,9 @@ package net.fabricmc.loader.impl.launch;
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
-import java.lang.reflect.Method;
 import java.util.Map;
 
 import org.jetbrains.annotations.VisibleForTesting;
-import org.spongepowered.asm.mixin.MixinEnvironment;
 
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.FormattedException;
@@ -36,7 +34,6 @@ import net.fabricmc.loader.impl.util.log.LogCategory;
 public abstract class FabricLauncherBase implements FabricLauncher {
 	protected static final boolean IS_DEVELOPMENT = SystemProperties.isSet(SystemProperties.DEVELOPMENT);
 
-	private static boolean mixinReady;
 	private static Map<String, Object> properties;
 	private static FabricLauncher launcher;
 	private static MappingConfiguration mappingConfiguration = new MappingConfiguration();
@@ -139,26 +136,5 @@ public abstract class FabricLauncherBase implements FabricLauncher {
 				}
 			}
 		});
-	}
-
-	protected static void finishMixinBootstrapping() {
-		if (mixinReady) {
-			throw new RuntimeException("Must not call FabricLauncherBase.finishMixinBootstrapping() twice!");
-		}
-
-		try {
-			Method m = MixinEnvironment.class.getDeclaredMethod("gotoPhase", MixinEnvironment.Phase.class);
-			m.setAccessible(true);
-			m.invoke(null, MixinEnvironment.Phase.INIT);
-			m.invoke(null, MixinEnvironment.Phase.DEFAULT);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-
-		mixinReady = true;
-	}
-
-	public static boolean isMixinReady() {
-		return mixinReady;
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -156,11 +156,13 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 	public void setAllowedPrefixes(Path codeSource, String... prefixes) {
 		codeSource = LoaderUtil.normalizeExistingPath(codeSource);
 
-		if (prefixes.length == 0) {
-			allowedPrefixes.remove(codeSource);
-		} else {
-			allowedPrefixes.put(codeSource, prefixes);
-		}
+		allowedPrefixes.put(codeSource, prefixes);
+	}
+
+	@Override
+	public void setAllPrefixesAllowed(Path codeSource) {
+		codeSource = LoaderUtil.normalizeExistingPath(codeSource);
+		allowedPrefixes.remove(codeSource);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -40,6 +40,7 @@ interface KnotClassLoaderInterface {
 
 	void addCodeSource(Path path);
 	void setAllowedPrefixes(Path codeSource, String... prefixes);
+	void setAllPrefixesAllowed(Path codeSource);
 	void setValidParentClassPath(Collection<Path> codeSources);
 
 	Manifest getManifest(Path codeSource);


### PR DESCRIPTION
This PR shows how we can directly invoke Mixin's configuration phase that goes through all the configs and potentially plugins. Normally this runs a bit later, when the first class gets loaded, but at that point we lost control over the class path restrictions and conflate any errors with other activity.

Resolves issues like https://github.com/FabricMC/fabric-loader/issues/998 or when Mixin plugins end up loading MC classes before they should.