### PR TITLE
Use correct repository in mod metadata

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,8 +8,8 @@
   "contact": {
     "homepage": "https://fabricmc.net",
     "irc": "ircs://irc.esper.net:6697/fabric",
-    "issues": "https://github.com/FabricMC/fabric/issues",
-    "sources": "https://github.com/FabricMC/fabric"
+    "issues": "https://github.com/FabricMC/fabric-loader/issues",
+    "sources": "https://github.com/FabricMC/fabric-loader"
   },
   "license": "Apache-2.0",
   "icon": "assets/fabricloader/icon.png",


### PR DESCRIPTION
`fabric.mod.json` uses the wrong repository for `issues` and `sources`, causing downstream components to route to the incorrect location.