### PR TITLE
Implement on-demand native library extraction

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -17,6 +17,8 @@
 package net.fabricmc.loader.impl.launch.knot;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
@@ -27,19 +29,26 @@ import java.net.URLConnection;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.CodeSource;
 import java.security.cert.Certificate;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.Manifest;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
 
 import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.launch.FabricLauncherBase;
 import net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.ClassLoaderAccess;
@@ -86,6 +95,9 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 	private volatile Set<Path> validParentCodeSources = null; // null = disabled isolation, game provider has to set it to opt in
 	private final Map<Path, String[]> allowedPrefixes = new ConcurrentHashMap<>();
 	private final Set<String> parentSourcedClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+	private static final Collection<Path> JVM_NATIVE_DIRS = computeJvmNativeDirs();
+	private static final Map<String, String> PROCESSED_NATIVES = new HashMap<>();
 
 	KnotClassDelegate(boolean isDevelopment, EnvType envType, T classLoader, ClassLoader parentClassLoader, GameProvider provider) {
 		this.isDevelopment = isDevelopment;
@@ -539,5 +551,128 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 		Class<?> findLoadedClassFwd(String name);
 		Class<?> defineClassFwd(String name, byte[] b, int off, int len, CodeSource cs);
 		void resolveClassFwd(Class<?> cls);
+	}
+
+	private static Collection<Path> computeJvmNativeDirs() {
+		Set<Path> ret = new HashSet<>();
+		String[] libPathProperties = { "sun.boot.library.path", "java.library.path" };
+
+		for (String libPathProperty : libPathProperties) {
+			String value = System.getProperty(libPathProperty);
+			if (value == null || value.isEmpty()) continue;
+
+			for (String pathStr : value.split(File.pathSeparator)) {
+				Path path = Paths.get(pathStr);
+
+				if (Files.exists(path)) {
+					ret.add(path);
+				}
+			}
+		}
+
+		return ret;
+	}
+
+	/**
+	 * Implementation of {@link ClassLoader#findLibrary} that falls back to grabbing natives from the class path.
+	 *
+	 * @param libname Library name to find
+	 * @return Library path if available, null otherwise
+	 */
+	synchronized String findLibrary(String libname) {
+		String ret = PROCESSED_NATIVES.get(libname); // cache for repeat queries, avoids expensive validation
+		if (ret != null) return ret;
+
+		String fileName = System.mapLibraryName(libname);
+
+		// check if the jvm will provide the native after us
+
+		for (Path dir : JVM_NATIVE_DIRS) {
+			Path file = dir.resolve(fileName);
+
+			if (Files.exists(file)) return null;
+		}
+
+		// check if we can find the native on the knot class path
+
+		URL url = classLoader.getResource(fileName);
+		if (url == null) return null;
+
+		// grab native from class path, extracting it as needed
+
+		Path codeSource;
+
+		try {
+			codeSource = UrlUtil.getCodeSource(url, fileName);
+		} catch (UrlConversionException e) {
+			throw new RuntimeException(e);
+		}
+
+		Path libFile;
+
+		if (Files.isDirectory(codeSource)) { // cp entry is a folder, use library file directly
+			libFile = codeSource.resolve(fileName);
+		} else { // cp entry is a jar, extract library file
+			Path cacheDir = null;
+
+			try {
+				cacheDir = FabricLoaderImpl.INSTANCE.getGameDir().resolve(FabricLoaderImpl.CACHE_DIR_NAME).resolve("natives");
+				assert cacheDir.isAbsolute();
+				Files.createDirectories(cacheDir);
+			} catch (IllegalStateException e) { // too early access
+				return null;
+			} catch (IOException e) {
+				Log.warn(LogCategory.KNOT, "Error creating natives cache directory %s", cacheDir, e);
+				return null;
+			}
+
+			libFile = cacheDir.resolve(fileName);
+			Log.debug(LogCategory.KNOT, "Extracting native %s from class path %s to %s", libname, url, libFile);
+
+			try {
+				copyZipEntryIfDistinct(codeSource, fileName, libFile);
+			} catch (IOException e) {
+				Log.warn(LogCategory.KNOT, "Error extracting native %s to %s", url, cacheDir, e);
+				return null;
+			}
+		}
+
+		ret = libFile.toString();
+		PROCESSED_NATIVES.put(libname, ret);
+
+		Log.debug(LogCategory.KNOT, "Supplying native %s from class path (%s)", libname, ret);
+
+		return ret;
+	}
+
+	private static void copyZipEntryIfDistinct(Path zipFile, String fileName, Path output) throws IOException {
+		try (ZipFile zf = new ZipFile(zipFile.toFile())) {
+			ZipEntry entry = zf.getEntry(fileName);
+			if (entry == null) throw new FileNotFoundException(String.format("zip file %s doesn't contain %s", zipFile, fileName));
+
+			if (Files.exists(output)) { // extracted file exists, check size and crc
+				long expectedSize = entry.getSize();
+				long expectedCrc = entry.getCrc();
+
+				if (Files.size(output) == expectedSize) {
+					CRC32 crc = new CRC32();
+					byte[] buffer = new byte[0x4000];
+
+					try (InputStream is = Files.newInputStream(output)) {
+						int len;
+
+						while ((len = is.read(buffer)) >= 0) {
+							crc.update(buffer, 0, len);
+						}
+					}
+
+					if (crc.getValue() == expectedCrc) { // existing file has the same size and crc as the zip entry
+						return;
+					}
+				}
+			}
+
+			Files.copy(zf.getInputStream(entry), output, StandardCopyOption.REPLACE_EXISTING);
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -125,6 +125,11 @@ final class KnotClassLoader extends AbstractSecureClassLoader implements ClassLo
 	}
 
 	@Override
+	protected String findLibrary(String libname) {
+		return delegate.findLibrary(libname);
+	}
+
+	@Override
 	public void addUrlFwd(URL url) {
 		urlLoader.addURL(url);
 	}

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
@@ -47,6 +47,11 @@ class KnotCompatibilityClassLoader extends URLClassLoader implements ClassLoader
 	}
 
 	@Override
+	protected String findLibrary(String libname) {
+		return delegate.findLibrary(libname);
+	}
+
+	@Override
 	public void addUrlFwd(URL url) {
 		super.addURL(url);
 	}


### PR DESCRIPTION
This effectively adds a fallback to the JVM's native lookup procedure that searches and extracts natives from the class path if they'd otherwise fail to be discovered/loaded.

I mostly implemented this for my semi-in-dev testing, but it also makes launching games with natives much easier. LWJGL 3 implements a similar but less generic approach for its own native libraries.

At some point copyZipEntryIfDistinct might get generalized and merged with related handling for nested Jars to improve reliability there.