### PR TITLE
add missing entrypoint for late pre-classic (rd-161348)

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/McLibrary.java
@@ -20,7 +20,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.LibClassifier.LibraryType;
 
 enum McLibrary implements LibraryType {
-	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class", "com/mojang/rubydung/RubyDung.class"),
+	MC_CLIENT(EnvType.CLIENT, "net/minecraft/client/main/Main.class", "net/minecraft/client/MinecraftApplet.class", "com/mojang/minecraft/MinecraftApplet.class", "com/mojang/minecraft/RubyDung.class", "com/mojang/rubydung/RubyDung.class"),
 	MC_SERVER(EnvType.SERVER, "net/minecraft/server/Main.class", "net/minecraft/server/MinecraftServer.class", "com/mojang/minecraft/server/MinecraftServer.class"),
 	MC_COMMON("net/minecraft/server/MinecraftServer.class"),
 	MC_ASSETS_ROOT("assets/.mcassetsroot"),


### PR DESCRIPTION
`rd-161348` from the launcher uses yet another different main class (it moved `RubyDung` from the `com/mojang/rubydung/` package to the `com/mojang/minecraft/` package). It also has a `MinecraftApplet` class but it's completely empty, so I reckon the `RubyDung` class should still be seen as the entrypoint for this version.