### PR TITLE
Fix NPE with classloader debug logging

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -499,7 +499,7 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 			url = parentClassLoader.getResource(name);
 
 			if (!isValidParentUrl(url, name)) {
-				if (LOG_CLASS_LOAD) Log.info(LogCategory.KNOT, "refusing to load class %s at %s from parent class loader", name, getCodeSource(url, name));
+				if (LOG_CLASS_LOAD) Log.info(LogCategory.KNOT, "refusing to load class %s at %s from parent class loader", name, url != null ? getCodeSource(url, name) : "null");
 
 				return null;
 			}


### PR DESCRIPTION
When fabric.debug.logClassLoad is set to true, it is possible for an exception to be thrown during the logging which causes the game to crash and the log message to never be printed.

In KnotClassDelegate#getRawClassByteArray, ClassLoader#getResource is used to get a URL instance. ClassLoader#getResource is nullable, meaning it's possible for the url variable to be null.
It is expected that this can be null, thats why there is a check to the isValidParentUrl method. 

But if fabric.debug.logClassLoad is enabled, it attempts to log a message and passes the potentially null variable to the getCodeSource method, which throws an exception if url is null:
```
net.fabricmc.loader.impl.util.ExceptionUtil$WrappedException: net.fabricmc.loader.impl.util.UrlConversionException: java.lang.NullPointerException: Cannot invoke "java.net.URL.openConnection()" because "url" is null
	at net.fabricmc.loader.impl.util.ExceptionUtil.wrap(ExceptionUtil.java:51)
	at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getCodeSource(KnotClassDelegate.java:530)
	at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getRawClassByteArray(KnotClassDelegate.java:502)
```