### PR TITLE
Fix signers not propagated to class if present

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -70,6 +70,8 @@ public final class SystemProperties {
 	public static final String DEBUG_LOG_TRANSFORM_ERRORS = "fabric.debug.logTransformErrors";
 	// disables system class path isolation, allowing bogus lib accesses (too early, transient jars)
 	public static final String DEBUG_DISABLE_CLASS_PATH_ISOLATION = "fabric.debug.disableClassPathIsolation";
+	// disables signers from being available in ProtectionDomain/Class#getSigners for signed JARs
+	public static final String DEBUG_DISABLE_JAR_SIGNERS = "fabric.debug.disableJarSigners";
 	// disables mod load order shuffling to be the same in-dev as in production
 	public static final String DEBUG_DISABLE_MOD_SHUFFLE = "fabric.debug.disableModShuffle";
 	// workaround for bad load order dependencies


### PR DESCRIPTION
Hi, this PR aim to fix signed jar class returning null signers for
`CodeSource.getCodeSigner/getCertificate` from `Class.getProtectionDomain` and `Class.getSigners`

The existing signer support is broken as currently in 0.17.3 (in the commented todo).
https://github.com/FabricMC/fabric-loader/blob/fd56b9bf67ac83af50d8d23cec539e06d972ff7e/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java#L391-L408


I have changed `Metadata` to show if the codeSource has signed manifest.
It is used to return early if not signed to avoid future processing.

If manifest is signed, it will get signer for the specified filename from `jar:` uri and create a signed CodeSource with it.
\- should not be cached since file will have different signer/no signer depending on the manifest. (ie, appended class file)

I also added a property flag to disables this if there is compatibility issue arise.

I have tested this using `-Djava.debug.security=scl` (valid before jdk24) with expected behavior when loading signed jars.