### PR TITLE
Add fabric.defaultMixinRemapType

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
+++ b/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java
@@ -145,7 +145,7 @@ public final class RuntimeModRemapper {
 				InputTag tag = remapper.createInputTag();
 				info.tag = tag;
 
-				if (requiresMixinRemap(info.inputPath)) {
+				if (requiresMixinRemap(info.inputPath, config.getDefaultMixinRemapType())) {
 					remapMixins.add(tag);
 				}
 
@@ -254,13 +254,15 @@ public final class RuntimeModRemapper {
 	 *
 	 * <p>This is typically the case when a mod was built without the Mixin annotation processor generating refmaps.
 	 */
-	private static boolean requiresMixinRemap(Path inputPath) throws IOException, URISyntaxException {
+	private static boolean requiresMixinRemap(Path inputPath, String defaultMixinRemapType) throws IOException, URISyntaxException {
 		final Manifest manifest = ManifestUtil.readManifest(inputPath);
 		if (manifest == null) return false;
 
 		final Attributes mainAttributes = manifest.getMainAttributes();
 
-		return REMAP_TYPE_STATIC.equalsIgnoreCase(mainAttributes.getValue(REMAP_TYPE_MANIFEST_KEY));
+		String remapType = mainAttributes.getValue(REMAP_TYPE_MANIFEST_KEY);
+		if (remapType == null) remapType = defaultMixinRemapType;
+		return REMAP_TYPE_STATIC.equalsIgnoreCase(remapType);
 	}
 
 	private static class RemapInfo {

--- a/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
@@ -150,6 +150,10 @@ public final class MappingConfiguration {
 		return FabricLoaderImpl.INSTANCE.getGameProvider().getDefaultModDistributionNamespace(ret);
 	}
 
+	public String getDefaultMixinRemapType() {
+		return System.getProperty(SystemProperties.DEFAULT_MIXIN_REMAP_TYPE, "mixin");
+	}
+
 	public boolean requiresPackageAccessHack() {
 		// TODO
 		return FIX_PACKAGE_ACCESS || getRuntimeNamespace().equals(NAMED_NAMESPACE);

--- a/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/SystemProperties.java
@@ -30,6 +30,8 @@ public final class SystemProperties {
 	public static final String RUNTIME_MAPPING_NAMESPACE = "fabric.runtimeMappingNamespace";
 	// mapping namespace to assume mods are using when not explicitly stated, defaults to official if the runtime namespace is official or intermediary otherwise
 	public static final String DEFAULT_MOD_DISTRIBUTION_NAMESPACE = "fabric.defaultModDistributionNamespace";
+	// mixin remap type to assume mods are using when not explicit stated, defaults to mixin
+	public static final String DEFAULT_MIXIN_REMAP_TYPE = "fabric.defaultMixinRemapType";
 	// skips the embedded MC game provider, letting ServiceLoader-provided ones take over
 	public static final String SKIP_MC_PROVIDER = "fabric.skipMcProvider";
 	// game jar paths for common/client/server, replaces lookup from class path if present, env specific takes precedence


### PR DESCRIPTION
This PR adds `fabric.defaultMixinRemapType` system property to allow loom to specify whether mixins should be remapped by tiny-remapper. This is needed for dev-only remapping setups on unobfuscated versions. 

