### PR TITLE
Fix remapped jar conflict

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProviderHelper.java
@@ -243,7 +243,7 @@ public final class GameProviderHelper {
 			return inputFileMap;
 		}
 
-		String mappingId = mappingConfig.getMappingId();
+		String mappingName = mappingConfig.getMappingName();
 		Path deobfJarDir = getDeobfJarDir(gameDir, gameId, gameVersion);
 		List<Path> inputFiles = new ArrayList<>(inputFileMap.size());
 		List<Path> outputFiles = new ArrayList<>(inputFileMap.size());
@@ -255,9 +255,9 @@ public final class GameProviderHelper {
 			String name = entry.getKey();
 			Path inputFile = entry.getValue();
 			// TODO: allow versioning mappings?
-			String deobfJarFilename = (mappingId == null)
+			String deobfJarFilename = (mappingName == null)
 					? String.format("%s-%s.jar", name, targetNamespace)
-					: String.format("%s-%s-%s.jar", name, targetNamespace, mappingId);
+					: String.format("%s-%s-%s.jar", name, targetNamespace, mappingName);
 			Path outputFile = deobfJarDir.resolve(deobfJarFilename);
 			Path tmpFile = deobfJarDir.resolve(deobfJarFilename + ".tmp");
 

--- a/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/MappingConfiguration.java
@@ -72,7 +72,7 @@ public final class MappingConfiguration {
 	@Nullable
 	private String gameVersion;
 	@Nullable
-	private String mappingId;
+	private String mappingName;
 	@Nullable
 	private List<String> namespaces;
 	@Nullable
@@ -93,10 +93,10 @@ public final class MappingConfiguration {
 	}
 
 	@Nullable
-	public String getMappingId() {
+	public String getMappingName() {
 		initializeMappings(true);
 
-		return mappingId;
+		return mappingName;
 	}
 
 	@Nullable
@@ -194,7 +194,7 @@ public final class MappingConfiguration {
 					if (manifest != null) {
 						gameId = ManifestUtil.getManifestValue(manifest, new Name("Game-Id"));
 						gameVersion = ManifestUtil.getManifestValue(manifest, new Name("Game-Version"));
-						mappingId = ManifestUtil.getManifestValue(manifest, new Name("Mapping-Id"));
+						mappingName = ManifestUtil.getManifestValue(manifest, new Name("Mapping-Name"));
 					}
 				}
 


### PR DESCRIPTION
Fixes #1117 by adding a "mapping id" to the remapped jar name. This mapping id is parsed from the `Mapping-Id` attribute from the mappings jar manifest.

This approach is backward compatible as Loader won't be expecting a different file names *unless* this specific manifest attribute is set in the mappings jar, so updating Loader won't result in unnecessarily remapping the game jar(s) again.

The downside is that this won't fix issues currently experienced with e.g. Legacy Fabric/Ornithe installations on the official launcher. Legacy Fabric and Ornithe would have to re-publish their intermediaries to add this manifest attribute.