### PR TITLE
Add Jar ManifestCallback

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -389,7 +389,7 @@ final class KnotClassDelegate<T extends ClassLoader & ClassLoaderAccess> impleme
 					URLConnection connection = new URL("jar:" + path.toUri().toString() + "!/").openConnection();
 
 					if (connection instanceof JarURLConnection) {
-						manifest = ((JarURLConnection) connection).getManifest();
+						manifest = ManifestUtil.processCallback(((JarURLConnection) connection).getManifest(), path);
 						certificates = ((JarURLConnection) connection).getCertificates();
 					}
 

--- a/src/main/java/net/fabricmc/loader/impl/util/ManifestUtil.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/ManifestUtil.java
@@ -83,14 +83,16 @@ public final class ManifestUtil {
 		if (!Files.exists(path)) return null;
 
 		try (InputStream stream = Files.newInputStream(path)) {
-			Manifest manifest = new Manifest(stream);
-
-			for (BiConsumer<Manifest, Path> callback : callbacks) {
-				callback.accept(manifest, path);
-			}
-
-			return manifest;
+			return processCallback(new Manifest(stream), path);
 		}
+	}
+
+	public static Manifest processCallback(Manifest manifest, Path path) {
+		for (BiConsumer<Manifest, Path> callback : callbacks) {
+			callback.accept(manifest, path);
+		}
+
+		return manifest;
 	}
 
 	public static String getManifestValue(Manifest manifest, Name name) {


### PR DESCRIPTION
This PR adds a callback mechanism to `ManifestUtil` that allows consumers to intercept and modify a manifest immediately after it is read, but before it is processed by the classloader.

Specifically, this is intended to allow the modification or removal of the `Class-Path` attribute prior to the classloader adding those entries to the classpath. It also allows you to other things like change the main class without modifying the jar, however that is not the purpose of this PR.

## The Problem
Some games (Ex: Wildermyth) ship with a `MANIFEST.MF` containing a large amount of `Class-Path` entries. These entries are added to the classpath automatically when `FabricLauncher.addToClassPath(jar)` is called on the parent jar.

This causes two issues:

1. Implicit dependency injection
    * All jars in `Class-Path` are automatically added to Knot's runtime classpath
    * **This happens even if the IDE or build system does not include (or specifically wants to exclude) those jars**
2. Lack of control in game providers
    * A custom game provider may want to control classpath construction explicitly (Ex: via `unlockClasspath()`)
    * However, manifest based `Class-Path` expansion happens independently and silently re-injects dependencies

Currently, there is no supported way to:
* Remove the `Class-Path` attribute
* Rewrite its entries
* Filter specific entries
* Or disable manifest based classpath expansion entirely

## Usage

### Disabling classpath expansion entirely
A callback can be registered via `ManifestUtil.addCallback()`.
The callback is invoked immediately after a manifest is read and before any classpath entries are resolved. Below is a basic example that prevents all manifest declared dependencies from being automatically added to the runtime classpath.

```java
ManifestUtil.addCallback((manifest, path) -> {
    manifest.getMainAttributes().remove(Name.CLASS_PATH);
});
```

After creating this callback, classpath construction can then be handled entirely by the game provider.


### Rewriting classpath entries
```java
ManifestUtil.addCallback((manifest, path) -> {
    String cp = manifest.getMainAttributes().getValue(Name.CLASS_PATH);
    if (cp != null) {
        cp = cp.replace("./lib/", "./someOtherDir/");
        manifest.getMainAttributes().put(Name.CLASS_PATH, cp);
    }
});
```

This allows relocation of dependencies without modifying the original JAR.