### PR TITLE
Support `::<init>` in DefaultLanguageAdapter for interface entrypoints

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/DefaultLanguageAdapter.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/DefaultLanguageAdapter.java
@@ -118,6 +118,7 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 
 			if (targetExecutable instanceof Method) {
 				Method targetMethod = (Method) targetExecutable;
+
 				if ((targetMethod.getModifiers() & Modifier.STATIC) == 0) {
 					try {
 						object = c.getDeclaredConstructor().newInstance();

--- a/src/main/java/net/fabricmc/loader/impl/util/DefaultLanguageAdapter.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/DefaultLanguageAdapter.java
@@ -19,10 +19,13 @@ package net.fabricmc.loader.impl.util;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import net.fabricmc.loader.api.LanguageAdapter;
@@ -63,14 +66,18 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 				throw new LanguageAdapterException("Class " + c.getName() + " cannot be cast to " + type.getName() + "!");
 			}
 		} else /* length == 2 */ {
-			List<Method> methodList = new ArrayList<>();
+			List<Executable> executableList = new ArrayList<>();
 
 			for (Method m : c.getDeclaredMethods()) {
 				if (!(m.getName().equals(methodSplit[1]))) {
 					continue;
 				}
 
-				methodList.add(m);
+				executableList.add(m);
+			}
+
+			if (methodSplit[1].equals("<init>")) {
+				executableList.addAll(Arrays.asList(c.getDeclaredConstructors()));
 			}
 
 			try {
@@ -81,7 +88,7 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 					throw new LanguageAdapterException("Field " + value + " must be static!");
 				}
 
-				if (!methodList.isEmpty()) {
+				if (!executableList.isEmpty()) {
 					throw new LanguageAdapterException("Ambiguous " + value + " - refers to both field and method!");
 				}
 
@@ -100,28 +107,38 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 				throw new LanguageAdapterException("Cannot proxy method " + value + " to non-interface type " + type.getName() + "!");
 			}
 
-			if (methodList.isEmpty()) {
+			if (executableList.isEmpty()) {
 				throw new LanguageAdapterException("Could not find " + value + "!");
-			} else if (methodList.size() >= 2) {
+			} else if (executableList.size() >= 2) {
 				throw new LanguageAdapterException("Found multiple method entries of name " + value + "!");
 			}
 
-			final Method targetMethod = methodList.get(0);
+			final Executable targetExecutable = executableList.get(0);
 			Object object = null;
 
-			if ((targetMethod.getModifiers() & Modifier.STATIC) == 0) {
-				try {
-					object = c.getDeclaredConstructor().newInstance();
-				} catch (Exception e) {
-					throw new LanguageAdapterException(e);
+			if (targetExecutable instanceof Method) {
+				Method targetMethod = (Method) targetExecutable;
+				if ((targetMethod.getModifiers() & Modifier.STATIC) == 0) {
+					try {
+						object = c.getDeclaredConstructor().newInstance();
+					} catch (Exception e) {
+						throw new LanguageAdapterException(e);
+					}
 				}
 			}
 
 			MethodHandle handle;
 
 			try {
-				handle = MethodHandles.lookup()
-						.unreflect(targetMethod);
+				if (targetExecutable instanceof Method) {
+					Method targetMethod = (Method) targetExecutable;
+					handle = MethodHandles.lookup()
+							.unreflect(targetMethod);
+				} else {
+					Constructor<?> targetConstructor = (Constructor<?>) targetExecutable;
+					handle = MethodHandles.lookup()
+							.unreflectConstructor(targetConstructor);
+				}
 			} catch (Exception ex) {
 				throw new LanguageAdapterException(ex);
 			}

--- a/src/test/java/net/fabricmc/test/EntrypointTest.java
+++ b/src/test/java/net/fabricmc/test/EntrypointTest.java
@@ -37,4 +37,10 @@ public final class EntrypointTest {
 	public static String fieldEntry() {
 		return "field";
 	}
+
+	public static final class EntrypointCtorTest {
+		public EntrypointCtorTest() {
+			Log.info(LogCategory.TEST, "EntrypointCtorTest instance created! This runs at main");
+		}
+	}
 }

--- a/src/test/resources/fabric.mod.json
+++ b/src/test/resources/fabric.mod.json
@@ -9,7 +9,8 @@
       "net.fabricmc.test.TestMod"
     ],
     "main": [
-      "net.fabricmc.test.TestMod"
+      "net.fabricmc.test.TestMod",
+      "net.fabricmc.test.EntrypointTest$EntrypointCtorTest::<init>"
     ],
     "test:testing": [
       "net.fabricmc.test.EntrypointTest::instanceEntry",


### PR DESCRIPTION
Currently, the default language adapter supports field references (of an instance of the entrypoint callback), or method references (which are coerced to the relevant type). Supporting ctor references would also be nice, though obviously only makes sense for (interface) callbacks where the relevant types line up (initializers are an example of where they do, quite easily).

Why `::<init>` instead of the java-y `::new`? I figured the former made more sense given that the runtime (not source) names of classes are needed anyways, and using `::new` would be a breaking change but the other would not (since JVM methods can be named `new` without any issues, but cannot be named `<init>` without being constructors).