### PR TITLE
Clarify "matching version" wording in breaks.invalid message

### DIFF
--- a/src/main/resources/net/fabricmc/loader/Messages.properties
+++ b/src/main/resources/net/fabricmc/loader/Messages.properties
@@ -64,7 +64,7 @@ resolution.recommends.mismatch={0} {1} recommends {3} of {2}, but only the wrong
 resolution.recommends.invalid={0} {1} recommends {3} of {2}, which can''t be loaded due to other constraints!
 resolution.recommends.suggestion=You should install {3} of {2} for the optimal experience.
 
-resolution.breaks.invalid={0} {1} is incompatible with {3} of {2}, but{5, choice, 1# a|2#} matching version{5, choice, 1# is|2#s are} present: {4}!
+resolution.breaks.invalid={0} {1} is incompatible with {3} of {2}, but{5, choice, 1# a|2#} conflicting version{5, choice, 1# is|2#s are} present: {4}!
 resolution.breaks.suggestion=The developer(s) of {0} have found that this combination doesn''t work. You need to remove one of the mods or check for updates that resolve the issue.
 
 resolution.conflicts.invalid={0} {1} conflicts with {3} of {2}, which is present with the following version{5, choice, 2#s}: {4}!

--- a/src/main/resources/net/fabricmc/loader/Messages.properties
+++ b/src/main/resources/net/fabricmc/loader/Messages.properties
@@ -64,7 +64,7 @@ resolution.recommends.mismatch={0} {1} recommends {3} of {2}, but only the wrong
 resolution.recommends.invalid={0} {1} recommends {3} of {2}, which can''t be loaded due to other constraints!
 resolution.recommends.suggestion=You should install {3} of {2} for the optimal experience.
 
-resolution.breaks.invalid={0} {1} is incompatible with {3} of {2}, but{5, choice, 1# a|2#} conflicting version{5, choice, 1# is|2#s are} present: {4}!
+resolution.breaks.invalid={0} {1} is incompatible with {3} of {2}, yet{5, choice, 1# a|2#} conflicting version{5, choice, 1# is|2#s are} present: {4}!
 resolution.breaks.suggestion=The developer(s) of {0} have found that this combination doesn''t work. You need to remove one of the mods or check for updates that resolve the issue.
 
 resolution.conflicts.invalid={0} {1} conflicts with {3} of {2}, which is present with the following version{5, choice, 2#s}: {4}!


### PR DESCRIPTION
Fixes #1018.

The `resolution.breaks.invalid` message uses "matching version is present" in the context of an incompatibility declaration. "Matching" is ambiguous here: it describes the present version matching the `breaks` constraint, but reads to users as matching their requirements. Replacing it with "conflicting" removes the ambiguity without altering the message's structure or placeholders.

**Before:** `Mod X is incompatible with version Y of Z, but a matching version is present: W!`
**After:**  `Mod X is incompatible with version Y of Z, but a conflicting version is present: W!`