### PR TITLE
Allow game providers to use custom classloaders

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/net/fabricmc/loader/impl/game/GameProvider.java
@@ -26,6 +26,7 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.impl.game.patch.GameTransformer;
 import net.fabricmc.loader.impl.launch.FabricLauncher;
+import net.fabricmc.loader.impl.launch.knot.URLLoader;
 import net.fabricmc.loader.impl.util.Arguments;
 import net.fabricmc.loader.impl.util.LoaderUtil;
 import net.fabricmc.loader.impl.util.SystemProperties;
@@ -87,6 +88,10 @@ public interface GameProvider { // name directly referenced in net.fabricmc.load
 
 	default boolean hasAwtSupport() {
 		return LoaderUtil.hasAwtSupport();
+	}
+
+	default URLLoader getProviderCL() { //Cannot use intersecting types, see https://bugs.openjdk.org/browse/JDK-8380420
+		return null;
 	}
 
 	class BuiltinMod {

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -22,16 +22,19 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.CodeSource;
 import java.util.Enumeration;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.impl.game.GameProvider;
 import net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.ClassLoaderAccess;
 import net.fabricmc.loader.impl.mrj.AbstractSecureClassLoader;
+import net.fabricmc.loader.impl.util.log.Log;
+import net.fabricmc.loader.impl.util.log.LogCategory;
 
 // class name referenced by string constant in net.fabricmc.loader.impl.util.LoaderUtil.verifyNotInTargetCl
 final class KnotClassLoader extends AbstractSecureClassLoader implements ClassLoaderAccess {
-	private static final class DynamicURLClassLoader extends URLClassLoader {
+	private static final class DynamicURLClassLoader extends URLClassLoader implements URLLoader {
 		private DynamicURLClassLoader(URL[] urls) {
 			super(urls, new DummyClassLoader());
 		}
@@ -46,15 +49,19 @@ final class KnotClassLoader extends AbstractSecureClassLoader implements ClassLo
 		}
 	}
 
-	private final DynamicURLClassLoader urlLoader;
+	private final URLLoader urlLoader;
 	private final ClassLoader originalLoader;
 	private final KnotClassDelegate<KnotClassLoader> delegate;
 
 	KnotClassLoader(boolean isDevelopment, EnvType envType, GameProvider provider) {
-		super("knot", new DynamicURLClassLoader(new URL[0]));
+		super("knot", obtainClassloader(provider));
 		this.originalLoader = getClass().getClassLoader();
-		this.urlLoader = (DynamicURLClassLoader) getParent();
+		this.urlLoader = (URLLoader) getParent();
 		this.delegate = new KnotClassDelegate<>(isDevelopment, envType, this, originalLoader, provider);
+
+		if (!(urlLoader instanceof DynamicURLClassLoader)) {
+			Log.info(LogCategory.KNOT, "Found provider classloader: " + urlLoader.getClass().getCanonicalName());
+		}
 	}
 
 	KnotClassDelegate<?> getDelegate() {
@@ -105,13 +112,10 @@ final class KnotClassLoader extends AbstractSecureClassLoader implements ClassLo
 	public Enumeration<URL> getResources(String name) throws IOException {
 		Objects.requireNonNull(name);
 
-		final Enumeration<URL> resources = urlLoader.getResources(name);
-
-		if (!resources.hasMoreElements()) {
-			return originalLoader.getResources(name);
-		}
-
-		return resources;
+		return new MultiEnumeration<URL>(
+			urlLoader.getResources(name),
+			originalLoader.getResources(name)
+		);
 	}
 
 	@Override
@@ -170,7 +174,55 @@ final class KnotClassLoader extends AbstractSecureClassLoader implements ClassLo
 		super.resolveClass(cls);
 	}
 
+	private static ClassLoader obtainClassloader(GameProvider provider) { //cannot use intersecting return type: https://bugs.openjdk.org/browse/JDK-8380420
+		URLLoader ret = provider.getProviderCL();
+
+		if (ret == null) {
+			ret = new DynamicURLClassLoader(new URL[0]);
+		}
+
+		return (ClassLoader) ret;
+	}
+
 	static {
 		registerAsParallelCapable();
+	}
+
+	private static final class MultiEnumeration<T> implements Enumeration<T> {
+		private final Enumeration<T>[] enumerations;
+		private int index = 0;
+
+		@SafeVarargs
+		MultiEnumeration(Enumeration<T>... enumerations) {
+			this.enumerations = enumerations;
+			advance();
+		}
+
+		private void advance() {
+			while (index < enumerations.length && !enumerations[index].hasMoreElements()) {
+				index++;
+			}
+		}
+
+		@Override
+		public boolean hasMoreElements() {
+			return index < enumerations.length;
+		}
+
+		@Override
+		public T nextElement() {
+			if (!hasMoreElements()) {
+				throw new NoSuchElementException();
+			}
+
+			T element = enumerations[index].nextElement();
+
+			if (!enumerations[index].hasMoreElements()) {
+				index++;
+				advance();
+			}
+
+			return element;
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/launch/knot/URLLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/launch/knot/URLLoader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.loader.impl.launch.knot;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+
+public interface URLLoader {
+	void addURL(URL url);
+	URL getResource(String name);
+	Enumeration<URL> getResources(String name) throws IOException;
+	URL findResource(String name);
+	Enumeration<URL> findResources(String name) throws IOException;
+	InputStream getResourceAsStream(String name);
+	URL[] getURLs();
+}


### PR DESCRIPTION
Allows games to specify a custom classloader for knot to use.

URLClassLoader has undesired behavior for the game I'm modding. Specifically, `URLClassLoader` automatically adds everything under `Class-Path` in any jar's manifest to the classpath. I wrote a custom classloader which ignores the Class-Path entry in manifests, I just need a way to tell loader to use it (classloader implementation at https://github.com/WilderForge/WildermythGameProvider/tree/providerLoader/src/main/java/com/wildermods/provider/internal/classload).

I've tested this change on my fork of loader and everything seems to work fine. My custom classloader also correctly strips `Class-Path` entries.

Note: Provider classloaders must implement the `URLLoader` interface, but need not be instances of `URLClassLoader`.

DynamicURLClassLoader is still used by default.

Feedback would be appreciated. 

<img width="3840" height="2062" alt="image" src="https://github.com/user-attachments/assets/91a2aadd-8acc-4ebe-b4b5-4da1aaea6590" />
