### PR TITLE
Suppress remap warning when namespaces match, fixes #1122

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -245,7 +245,11 @@ public final class FabricLoaderImpl extends net.fabricmc.loader.FabricLoader {
 
 		if (remapRegularMods) {
 			if (System.getProperty(SystemProperties.REMAP_CLASSPATH_FILE) == null) {
-				Log.warn(LogCategory.MOD_REMAP, "Runtime mod remapping disabled due to no fabric.remapClasspathFile being specified. You may need to update loom.");
+				MappingConfiguration config = FabricLauncherBase.getLauncher().getMappingConfiguration();
+
+				if (!config.getRuntimeNamespace().equals(config.getDefaultModDistributionNamespace())) {
+					Log.warn(LogCategory.MOD_REMAP, "Runtime mod remapping disabled due to no fabric.remapClasspathFile being specified. You may need to update loom.");
+				}
 			} else {
 				RuntimeModRemapper.remap(modCandidates, cacheDir.resolve(TMP_DIR_NAME), outputdir);
 			}


### PR DESCRIPTION
Fixes #1122

Adds a namespace check before the `remapClasspathFile` warning in
`FabricLoaderImpl.setup()`. The warning is now only logged when
`getRuntimeNamespace()` differs from `getDefaultModDistributionNamespace()`,
meaning remapping was actually needed. When namespaces match the warning is silently skipped.

Tested locally against Minecraft 26.1.2.