### PR TITLE
Fix .x version predicates for more than 3 components

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/util/version/VersionPredicateParser.java
+++ b/src/main/java/net/fabricmc/loader/impl/util/version/VersionPredicateParser.java
@@ -35,7 +35,13 @@ import net.fabricmc.loader.api.metadata.version.VersionPredicate.PredicateTerm;
 public final class VersionPredicateParser {
 	private static final VersionComparisonOperator[] OPERATORS = VersionComparisonOperator.values();
 
+	public static VersionPredicate any() {
+		return AnyVersionPredicate.INSTANCE;
+	}
+
 	public static VersionPredicate parse(String predicate) throws VersionParsingException {
+		if (predicate.isEmpty() || predicate.equals("*")) return AnyVersionPredicate.INSTANCE;
+
 		List<SingleVersionPredicate> predicateList = new ArrayList<>();
 
 		for (String s : predicate.split(" ")) {
@@ -67,11 +73,6 @@ public final class VersionPredicateParser {
 
 					assert !semVer.getPrereleaseKey().isPresent();
 
-					int compCount = semVer.getVersionComponentCount();
-					assert compCount == 2 || compCount == 3;
-
-					operator = compCount == 2 ? VersionComparisonOperator.SAME_TO_NEXT_MAJOR : VersionComparisonOperator.SAME_TO_NEXT_MINOR;
-
 					int[] newComponents = new int[semVer.getVersionComponentCount() - 1];
 
 					for (int i = 0; i < semVer.getVersionComponentCount() - 1; i++) {
@@ -79,6 +80,24 @@ public final class VersionPredicateParser {
 					}
 
 					version = new SemanticVersionImpl(newComponents, "", semVer.getBuildKey().orElse(null));
+
+					int compCount = semVer.getVersionComponentCount();
+
+					if (compCount <= 1) {
+						throw new IllegalStateException("invalid component count "+compCount+" for version "+semVer);
+					} else if (compCount <= 3) { // 2, 3 -> represent a.x as ^a-, a.b.x as ~a.b-
+						operator = compCount == 2 ? VersionComparisonOperator.SAME_TO_NEXT_MAJOR : VersionComparisonOperator.SAME_TO_NEXT_MINOR;
+					} else { // > 3 -> represent a.b.c.x as >=a.b.c- <a.b.(c+1)-
+						// generate two predicates for the bounds by adding the first to the list in this block
+						predicateList.add(new SingleVersionPredicate(VersionComparisonOperator.GREATER_EQUAL, version));
+
+						newComponents = newComponents.clone();
+						newComponents[newComponents.length - 1]++;
+						version = new SemanticVersionImpl(newComponents, "", null);
+						operator = VersionComparisonOperator.LESS;
+					}
+
+					// version, operator are being used later
 				}
 			} else if (!operator.isMinInclusive() && !operator.isMaxInclusive()) { // non-semver without inclusive bound
 				throw new VersionParsingException("Invalid predicate: "+predicate+", version ranges need to be semantic version compatible to use operators that exclude the bound!");

--- a/src/test/java/net/fabricmc/test/VersionParsingTests.java
+++ b/src/test/java/net/fabricmc/test/VersionParsingTests.java
@@ -318,5 +318,20 @@ public class VersionParsingTests {
 			testFalse(predicate.test(new SemanticVersionImpl("2.0.0", false)));
 			testFalse(predicate.test(new SemanticVersionImpl("2.0.0-beta.2", false)));
 		}
+
+		{
+			Predicate<Version> predicate = VersionPredicateParser.parse("1.2.3.x");
+			testFalse(predicate.test(new SemanticVersionImpl("1.2.2", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("1.2.3", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("1.2.3-", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("1.2.3.4", false)));
+			testTrue(predicate.test(new SemanticVersionImpl("1.2.3.4.5", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("1.2.4", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("1.2.4-", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("1.2", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("1.3", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("1", false)));
+			testFalse(predicate.test(new SemanticVersionImpl("2", false)));
+		}
 	}
 }


### PR DESCRIPTION
This supports `1.2.3.x` and similar, which was previously handled incorrectly.

Fixes #1156 